### PR TITLE
Include content formula in `formulasInComponent`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,11 +14,11 @@
   "scripts": {
     "build": "tsc",
     "publish": "bun publish --access public",
-    "typecheck": "tsc --noEmit --project tsconfig.json",
-    "typecheck:watch": "tsc --noEmit -w --project tsconfig.json",
     "test": "bun test",
     "test:watch": "bun test --watch",
-    "test:debug": "bun test --watch --inspect-wait=localhost:6499/toddle"
+    "test:debug": "bun test --watch --inspect-wait=localhost:6499/toddle",
+    "typecheck": "tsc --noEmit",
+    "watch": "tsc -w"
   },
   "files": [
     "dist"

--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -199,6 +199,13 @@ export class ToddleComponent {
     for (const [metaKey, meta] of Object.entries(
       this.route?.info?.meta ?? {},
     )) {
+      yield* getFormulasInFormula(meta.content, [
+        'route',
+        'info',
+        'meta',
+        metaKey,
+        'content',
+      ])
       for (const [attrKey, a] of Object.entries(meta.attrs)) {
         yield* getFormulasInFormula(a, [
           'route',

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -8,8 +8,8 @@
     "build": "tsc",
     "publish": "bun publish --access public",
     "test": "bun test",
-    "typecheck": "tsc --noEmit --project tsconfig.json",
-    "typecheck:watch": "tsc --noEmit -w --project tsconfig.json"
+    "typecheck": "tsc --noEmit",
+    "watch": "tsc --noEmit -w"
   },
   "files": [
     "dist"


### PR DESCRIPTION
The `content` formula was not visited in the `formulasInComponent` function in the `ToddleComponent` class. This meant that formulas were reported as unused, even when they were used. See reported issue here https://discord.com/channels/972416966683926538/1311015179798184021/1311015179798184021