### PR TITLE
Update types for ToddleComponent and ToddleFormula

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,70 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": "always"
+  },
+  "cSpell.words": [
+    "classname",
+    "codegen",
+    "crossorigin",
+    "ctx",
+    "datasignal",
+    "dryrun",
+    "fastly",
+    "fetchpriority",
+    "Fira",
+    "fkey",
+    "happydom",
+    "hono",
+    "imagedelivery",
+    "importmap",
+    "isnt",
+    "livemode",
+    "LOCALHOSTS",
+    "MAILERSEND",
+    "maxage",
+    "pako",
+    "plpgsql",
+    "postgrest",
+    "POSTHOG",
+    "predev",
+    "proxied",
+    "proxying",
+    "rebeccapurple",
+    "registrator",
+    "ROWTYPE",
+    "serviceworker",
+    "signup",
+    "signups",
+    "speculationrules",
+    "supabase",
+    "tilecolor",
+    "toddle",
+    "tsndr",
+    "ttl",
+    "typecheck",
+    "typeof",
+    "urlset",
+    "valibot"
+  ],
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/*.js.map": true,
+    ".vscode/*": true
+  },
+  "prettier.configPath": "./.prettierrc",
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/.git/subtree-cache/**": true,
+    "**/.hg/store/**": true,
+    "**/node_modules/**": true
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "typescript.preferences.autoImportSpecifierExcludeRegexes": ["^lodash$"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/core",
-  "version": "0.0.2-alpha.5",
+  "version": "0.0.2-alpha.6",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",

--- a/packages/core/src/api/LegacyToddleApi.ts
+++ b/packages/core/src/api/LegacyToddleApi.ts
@@ -1,4 +1,5 @@
 import { isFormula, type Formula } from '../formula/formula'
+import { GlobalFormulas } from '../formula/formulaTypes'
 import {
   getFormulasInAction,
   getFormulasInFormula,
@@ -6,14 +7,20 @@ import {
 import { isDefined } from '../utils/util'
 import { type LegacyComponentAPI } from './apiTypes'
 
-export class LegacyToddleApi {
+export class LegacyToddleApi<Handler> {
   private api: LegacyComponentAPI
   private key: string
+  private globalFormulas: GlobalFormulas<Handler>
   private _apiReferences?: Set<string>
 
-  constructor(api: LegacyComponentAPI, key: string) {
+  constructor(
+    api: LegacyComponentAPI,
+    key: string,
+    globalFormulas: GlobalFormulas<Handler>,
+  ) {
     this.api = api
     this.key = key
+    this.globalFormulas = globalFormulas
   }
 
   get apiReferences(): Set<string> {
@@ -127,10 +134,18 @@ export class LegacyToddleApi {
   *formulasInApi(): Generator<[(string | number)[], Formula]> {
     const api = this.api
     const apiKey = this.key
-    yield* getFormulasInFormula(api.autoFetch, ['apis', apiKey, 'autoFetch'])
-    yield* getFormulasInFormula(api.url, ['apis', apiKey, 'url'])
+    yield* getFormulasInFormula(api.autoFetch, this.globalFormulas, [
+      'apis',
+      apiKey,
+      'autoFetch',
+    ])
+    yield* getFormulasInFormula(api.url, this.globalFormulas, [
+      'apis',
+      apiKey,
+      'url',
+    ])
     for (const [pathKey, path] of Object.entries(api.path ?? {})) {
-      yield* getFormulasInFormula(path.formula, [
+      yield* getFormulasInFormula(path.formula, this.globalFormulas, [
         'apis',
         apiKey,
         'path',
@@ -141,7 +156,7 @@ export class LegacyToddleApi {
     for (const [queryParamKey, queryParam] of Object.entries(
       api.queryParams ?? {},
     )) {
-      yield* getFormulasInFormula(queryParam.formula, [
+      yield* getFormulasInFormula(queryParam.formula, this.globalFormulas, [
         'apis',
         apiKey,
         'queryParams',
@@ -152,10 +167,14 @@ export class LegacyToddleApi {
 
     // this is supporting a few legacy cases where the whole header object was set as a formula. This is no longer possible
     if (isFormula(api.headers)) {
-      yield* getFormulasInFormula(api.headers, ['apis', apiKey, 'headers'])
+      yield* getFormulasInFormula(api.headers, this.globalFormulas, [
+        'apis',
+        apiKey,
+        'headers',
+      ])
     } else {
       for (const [headerKey, header] of Object.entries(api.headers ?? {})) {
-        yield* getFormulasInFormula(header, [
+        yield* getFormulasInFormula(header, this.globalFormulas, [
           'apis',
           apiKey,
           'headers',
@@ -164,11 +183,15 @@ export class LegacyToddleApi {
       }
     }
 
-    yield* getFormulasInFormula(api.body, ['apis', apiKey, 'body'])
+    yield* getFormulasInFormula(api.body, this.globalFormulas, [
+      'apis',
+      apiKey,
+      'body',
+    ])
     for (const [actionKey, action] of Object.entries(
       api.onCompleted?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, [
+      yield* getFormulasInAction(action, this.globalFormulas, [
         'apis',
         apiKey,
         'onCompleted',
@@ -179,7 +202,7 @@ export class LegacyToddleApi {
     for (const [actionKey, action] of Object.entries(
       api.onFailed?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, [
+      yield* getFormulasInAction(action, this.globalFormulas, [
         'apis',
         apiKey,
         'onFailed',

--- a/packages/core/src/api/LegacyToddleApi.ts
+++ b/packages/core/src/api/LegacyToddleApi.ts
@@ -134,81 +134,72 @@ export class LegacyToddleApi<Handler> {
   *formulasInApi(): Generator<[(string | number)[], Formula]> {
     const api = this.api
     const apiKey = this.key
-    yield* getFormulasInFormula(api.autoFetch, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'autoFetch',
-    ])
-    yield* getFormulasInFormula(api.url, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'url',
-    ])
+    yield* getFormulasInFormula({
+      formula: api.autoFetch,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'autoFetch'],
+    })
+    yield* getFormulasInFormula({
+      formula: api.url,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'url'],
+    })
     for (const [pathKey, path] of Object.entries(api.path ?? {})) {
-      yield* getFormulasInFormula(path.formula, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'path',
-        pathKey,
-        'formula',
-      ])
+      yield* getFormulasInFormula({
+        formula: path.formula,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'path', pathKey, 'formula'],
+      })
     }
     for (const [queryParamKey, queryParam] of Object.entries(
       api.queryParams ?? {},
     )) {
-      yield* getFormulasInFormula(queryParam.formula, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'queryParams',
-        queryParamKey,
-        'formula',
-      ])
+      yield* getFormulasInFormula({
+        formula: queryParam.formula,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'queryParams', queryParamKey, 'formula'],
+      })
     }
 
     // this is supporting a few legacy cases where the whole header object was set as a formula. This is no longer possible
     if (isFormula(api.headers)) {
-      yield* getFormulasInFormula(api.headers, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'headers',
-      ])
+      yield* getFormulasInFormula({
+        formula: api.headers,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'headers'],
+      })
     } else {
       for (const [headerKey, header] of Object.entries(api.headers ?? {})) {
-        yield* getFormulasInFormula(header, this.globalFormulas, [
-          'apis',
-          apiKey,
-          'headers',
-          headerKey,
-        ])
+        yield* getFormulasInFormula({
+          formula: header,
+          globalFormulas: this.globalFormulas,
+          path: ['apis', apiKey, 'headers', headerKey],
+        })
       }
     }
 
-    yield* getFormulasInFormula(api.body, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'body',
-    ])
+    yield* getFormulasInFormula({
+      formula: api.body,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'body'],
+    })
     for (const [actionKey, action] of Object.entries(
       api.onCompleted?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'onCompleted',
-        'actions',
-        actionKey,
-      ])
+      yield* getFormulasInAction({
+        action,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'onCompleted', 'actions', actionKey],
+      })
     }
     for (const [actionKey, action] of Object.entries(
       api.onFailed?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'onFailed',
-        'actions',
-        actionKey,
-      ])
+      yield* getFormulasInAction({
+        action,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'onFailed', 'actions', actionKey],
+      })
     }
   }
 }

--- a/packages/core/src/api/ToddleApiV2.ts
+++ b/packages/core/src/api/ToddleApiV2.ts
@@ -169,146 +169,121 @@ export class ToddleApiV2<Handler> implements ApiRequest {
     const api = this.api
     const apiKey = this.key
     for (const [input, value] of Object.entries(this.api.inputs)) {
-      yield* getFormulasInFormula(value.formula, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'inputs',
-        input,
-        'formula',
-      ])
+      yield* getFormulasInFormula({
+        formula: value.formula,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'inputs', input, 'formula'],
+      })
     }
-    yield* getFormulasInFormula(api.autoFetch, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'autoFetch',
-    ])
-    yield* getFormulasInFormula(api.url, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'url',
-    ])
+    yield* getFormulasInFormula({
+      formula: api.autoFetch,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'autoFetch'],
+    })
+    yield* getFormulasInFormula({
+      formula: api.url,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'url'],
+    })
     for (const [pathKey, path] of Object.entries(api.path ?? {})) {
-      yield* getFormulasInFormula(path.formula, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'path',
-        pathKey,
-        'formula',
-      ])
+      yield* getFormulasInFormula({
+        formula: path.formula,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'path', pathKey, 'formula'],
+      })
     }
     for (const [queryParamKey, queryParam] of Object.entries(
       api.queryParams ?? {},
     )) {
-      yield* getFormulasInFormula(queryParam.formula, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'queryParams',
-        queryParamKey,
-        'formula',
-      ])
-      yield* getFormulasInFormula(queryParam.enabled, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'queryParams',
-        queryParamKey,
-        'enabled',
-      ])
+      yield* getFormulasInFormula({
+        formula: queryParam.formula,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'queryParams', queryParamKey, 'formula'],
+      })
+      yield* getFormulasInFormula({
+        formula: queryParam.enabled,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'queryParams', queryParamKey, 'enabled'],
+      })
     }
 
     for (const [headerKey, header] of Object.entries(api.headers ?? {})) {
-      yield* getFormulasInFormula(header.formula, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'headers',
-        headerKey,
-        'formula',
-      ])
-      yield* getFormulasInFormula(header.enabled, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'headers',
-        headerKey,
-        'enabled',
-      ])
+      yield* getFormulasInFormula({
+        formula: header.formula,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'headers', headerKey, 'formula'],
+      })
+      yield* getFormulasInFormula({
+        formula: header.enabled,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'headers', headerKey, 'enabled'],
+      })
     }
 
-    yield* getFormulasInFormula(api.body, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'body',
-    ])
+    yield* getFormulasInFormula({
+      formula: api.body,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'body'],
+    })
     for (const [actionKey, action] of Object.entries(
       api.client?.onCompleted?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'client',
-        'onCompleted',
-        'actions',
-        actionKey,
-      ])
+      yield* getFormulasInAction({
+        action,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'client', 'onCompleted', 'actions', actionKey],
+      })
     }
     for (const [actionKey, action] of Object.entries(
       api.client?.onFailed?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'client',
-        'onFailed',
-        'actions',
-        actionKey,
-      ])
+      yield* getFormulasInAction({
+        action,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'client', 'onFailed', 'actions', actionKey],
+      })
     }
-    yield* getFormulasInFormula(
-      api.client?.debounce?.formula,
-      this.globalFormulas,
-      ['apis', apiKey, 'client', 'debounce', 'formula'],
-    )
+    yield* getFormulasInFormula({
+      formula: api.client?.debounce?.formula,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'client', 'debounce', 'formula'],
+    })
     for (const [actionKey, action] of Object.entries(
       api.client?.onMessage?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'client',
-        'onData',
-        'actions',
-        actionKey,
-      ])
+      yield* getFormulasInAction({
+        action,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'client', 'onData', 'actions', actionKey],
+      })
     }
     for (const [rule, value] of Object.entries(api.redirectRules ?? {})) {
-      yield* getFormulasInFormula(value.formula, this.globalFormulas, [
-        'apis',
-        apiKey,
-        'redirectRules',
-        rule,
-        'formula',
-      ])
+      yield* getFormulasInFormula({
+        formula: value.formula,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'redirectRules', rule, 'formula'],
+      })
     }
-    yield* getFormulasInFormula(api.isError?.formula, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'isError',
-      'formula',
-    ])
-    yield* getFormulasInFormula(api.timeout?.formula, this.globalFormulas, [
-      'apis',
-      apiKey,
-      'timeout',
-      'formula',
-    ])
-    yield* getFormulasInFormula(
-      api.server?.proxy?.enabled.formula,
-      this.globalFormulas,
-      ['apis', apiKey, 'server', 'proxy', 'enabled', 'formula'],
-    )
-    yield* getFormulasInFormula(
-      api.server?.ssr?.enabled?.formula,
-      this.globalFormulas,
-      ['apis', apiKey, 'server', 'ssr', 'enabled', 'formula'],
-    )
+    yield* getFormulasInFormula({
+      formula: api.isError?.formula,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'isError', 'formula'],
+    })
+    yield* getFormulasInFormula({
+      formula: api.timeout?.formula,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'timeout', 'formula'],
+    })
+    yield* getFormulasInFormula({
+      formula: api.server?.proxy?.enabled.formula,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'server', 'proxy', 'enabled', 'formula'],
+    })
+    yield* getFormulasInFormula({
+      formula: api.server?.ssr?.enabled?.formula,
+      globalFormulas: this.globalFormulas,
+      path: ['apis', apiKey, 'server', 'ssr', 'enabled', 'formula'],
+    })
   }
 
   *actionModelsInApi(): Generator<[(string | number)[], ActionModel]> {

--- a/packages/core/src/component/ToddleComponent.formulasInComponent.test.ts
+++ b/packages/core/src/component/ToddleComponent.formulasInComponent.test.ts
@@ -34,6 +34,7 @@ describe('ToddleComponent.formulasInComponent', () => {
       },
       getComponent: () => undefined,
       packageName: 'demo',
+      globalFormulas: { formulas: {}, packages: {} },
     })
     const formulas = Array.from(demo.formulasInComponent()).map(
       ([, formula]) => formula,
@@ -86,6 +87,7 @@ describe('ToddleComponent.formulasInComponent', () => {
       },
       getComponent: () => undefined,
       packageName: undefined,
+      globalFormulas: { formulas: {}, packages: {} },
     })
     const formulas = Array.from(demo.formulasInComponent()).map(
       ([, formula]) => formula,

--- a/packages/core/src/component/ToddleComponent.formulasInComponent.test.ts
+++ b/packages/core/src/component/ToddleComponent.formulasInComponent.test.ts
@@ -1,4 +1,4 @@
-import { valueFormula } from '../formula/formulaUtils'
+import { functionFormula, valueFormula } from '../formula/formulaUtils'
 import { ToddleComponent } from './ToddleComponent'
 
 describe('ToddleComponent.formulasInComponent', () => {
@@ -45,7 +45,7 @@ describe('ToddleComponent.formulasInComponent', () => {
       arguments: [],
     })
   })
-  test('it return formulas used in APIs', () => {
+  test('it returns formulas used in APIs', () => {
     const demo = new ToddleComponent({
       component: {
         name: 'demo',
@@ -99,6 +99,134 @@ describe('ToddleComponent.formulasInComponent', () => {
     })
     expect(formulas).toContainEqual({
       name: 'otherFunction',
+      type: 'function',
+      arguments: [],
+    })
+  })
+  test('it returns global formulas', () => {
+    const demo = new ToddleComponent({
+      component: {
+        name: 'demo',
+        apis: {},
+        attributes: {},
+        nodes: {},
+        variables: {
+          x: {
+            initialValue: functionFormula('globalFunction'),
+          },
+        },
+        workflows: {},
+      },
+      getComponent: () => undefined,
+      packageName: undefined,
+      globalFormulas: {
+        formulas: {
+          globalFunction: {
+            name: 'globalFunction',
+            arguments: [],
+            formula: valueFormula(4),
+          },
+        },
+        packages: {},
+      },
+    })
+    const formulas = Array.from(demo.formulasInComponent()).map(
+      ([, formula]) => formula,
+    )
+    expect(formulas).toContainEqual({
+      name: 'globalFunction',
+      type: 'function',
+      arguments: [],
+    })
+  })
+  test('it returns global formulas that are referenced through global formulas', () => {
+    const demo = new ToddleComponent({
+      component: {
+        name: 'demo',
+        apis: {},
+        attributes: {},
+        nodes: {},
+        variables: {
+          x: {
+            initialValue: functionFormula('globalFunction'),
+          },
+        },
+        workflows: {},
+      },
+      getComponent: () => undefined,
+      packageName: undefined,
+      globalFormulas: {
+        formulas: {
+          globalFunction: {
+            name: 'globalFunction',
+            arguments: [],
+            formula: functionFormula('otherGlobalFunction'),
+          },
+          otherGlobalFunction: {
+            name: 'otherGlobalFunction',
+            arguments: [],
+            formula: valueFormula(4),
+          },
+        },
+        packages: {},
+      },
+    })
+    const formulas = Array.from(demo.formulasInComponent()).map(
+      ([, formula]) => formula,
+    )
+    expect(formulas).toContainEqual({
+      name: 'globalFunction',
+      type: 'function',
+      arguments: [],
+    })
+    expect(formulas).toContainEqual({
+      name: 'otherGlobalFunction',
+      type: 'function',
+      arguments: [],
+    })
+  })
+  test("it stops following function refs after they've been visited once (no infinite loops)", () => {
+    const demo = new ToddleComponent({
+      component: {
+        name: 'demo',
+        apis: {},
+        attributes: {},
+        nodes: {},
+        variables: {
+          x: {
+            initialValue: functionFormula('globalFunction'),
+          },
+        },
+        workflows: {},
+      },
+      getComponent: () => undefined,
+      packageName: undefined,
+      globalFormulas: {
+        formulas: {
+          globalFunction: {
+            name: 'globalFunction',
+            arguments: [],
+            formula: functionFormula('otherGlobalFunction'),
+          },
+          otherGlobalFunction: {
+            name: 'otherGlobalFunction',
+            arguments: [],
+            formula: functionFormula('globalFunction'),
+          },
+        },
+        packages: {},
+      },
+    })
+    const formulas = Array.from(demo.formulasInComponent()).map(
+      ([, formula]) => formula,
+    )
+    expect(formulas).toContainEqual({
+      name: 'globalFunction',
+      type: 'function',
+      arguments: [],
+    })
+    expect(formulas).toContainEqual({
+      name: 'otherGlobalFunction',
       type: 'function',
       arguments: [],
     })

--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -103,189 +103,188 @@ export class ToddleComponent<Handler> {
     ): Generator<[(string | number)[], Formula]> {
       switch (node.type) {
         case 'text':
-          yield* getFormulasInFormula(node.condition, globalFormulas, [
-            ...path,
-            'condition',
-          ])
-          yield* getFormulasInFormula(node.repeat, globalFormulas, [
-            ...path,
-            'repeat',
-          ])
-          yield* getFormulasInFormula(node.repeatKey, globalFormulas, [
-            ...path,
-            'repeatKey',
-          ])
-          yield* getFormulasInFormula(node.value, globalFormulas, [
-            ...path,
-            'value',
-          ])
+          yield* getFormulasInFormula({
+            formula: node.condition,
+            globalFormulas,
+            path: [...path, 'condition'],
+          })
+          yield* getFormulasInFormula({
+            formula: node.repeat,
+            globalFormulas,
+            path: [...path, 'repeat'],
+          })
+          yield* getFormulasInFormula({
+            formula: node.repeatKey,
+            globalFormulas,
+            path: [...path, 'repeatKey'],
+          })
+          yield* getFormulasInFormula({
+            formula: node.value,
+            globalFormulas,
+            path: [...path, 'value'],
+          })
           break
         case 'slot':
-          yield* getFormulasInFormula(node.condition, globalFormulas, [
-            ...path,
-            'condition',
-          ])
+          yield* getFormulasInFormula({
+            formula: node.condition,
+            globalFormulas,
+            path: [...path, 'condition'],
+          })
           break
         case 'component':
-          yield* getFormulasInFormula(node.condition, globalFormulas, [
-            ...path,
-            'condition',
-          ])
-          yield* getFormulasInFormula(node.repeat, globalFormulas, [
-            ...path,
-            'repeat',
-          ])
-          yield* getFormulasInFormula(node.repeatKey, globalFormulas, [
-            ...path,
-            'repeatKey',
-          ])
+          yield* getFormulasInFormula({
+            formula: node.condition,
+            globalFormulas,
+            path: [...path, 'condition'],
+          })
+          yield* getFormulasInFormula({
+            formula: node.repeat,
+            globalFormulas,
+            path: [...path, 'repeat'],
+          })
+          yield* getFormulasInFormula({
+            formula: node.repeatKey,
+            globalFormulas,
+            path: [...path, 'repeatKey'],
+          })
           for (const [attrKey, attr] of Object.entries(node.attrs ?? {})) {
-            yield* getFormulasInFormula(attr, globalFormulas, [
-              ...path,
-              'attrs',
-              attrKey,
-            ])
+            yield* getFormulasInFormula({
+              formula: attr,
+              globalFormulas,
+              path: [...path, 'attrs', attrKey],
+            })
           }
           for (const [eventKey, event] of Object.entries(node.events ?? {})) {
             for (const [actionKey, action] of Object.entries(
               event?.actions ?? {},
             )) {
-              yield* getFormulasInAction(action, globalFormulas, [
-                ...path,
-                'events',
-                eventKey,
-                'actions',
-                actionKey,
-              ])
+              yield* getFormulasInAction({
+                action,
+                globalFormulas,
+                path: [...path, 'events', eventKey, 'actions', actionKey],
+              })
             }
           }
           break
         case 'element':
-          yield* getFormulasInFormula(node.condition, globalFormulas, [
-            ...path,
-            'condition',
-          ])
-          yield* getFormulasInFormula(node.repeat, globalFormulas, [
-            ...path,
-            'repeat',
-          ])
-          yield* getFormulasInFormula(node.repeatKey, globalFormulas, [
-            ...path,
-            'repeatKey',
-          ])
+          yield* getFormulasInFormula({
+            formula: node.condition,
+            globalFormulas,
+            path: [...path, 'condition'],
+          })
+          yield* getFormulasInFormula({
+            formula: node.repeat,
+            globalFormulas,
+            path: [...path, 'repeat'],
+          })
+          yield* getFormulasInFormula({
+            formula: node.repeatKey,
+            globalFormulas,
+            path: [...path, 'repeatKey'],
+          })
           for (const [attrKey, attr] of Object.entries(node.attrs ?? {})) {
-            yield* getFormulasInFormula(attr, globalFormulas, [
-              ...path,
-              'attrs',
-              attrKey,
-            ])
+            yield* getFormulasInFormula({
+              formula: attr,
+              globalFormulas,
+              path: [...path, 'attrs', attrKey],
+            })
           }
           for (const [eventKey, event] of Object.entries(node.events ?? {})) {
             for (const [actionKey, a] of Object.entries(event?.actions ?? {})) {
-              yield* getFormulasInAction(a, globalFormulas, [
-                ...path,
-                'events',
-                eventKey,
-                'actions',
-                actionKey,
-              ])
+              yield* getFormulasInAction({
+                action: a,
+                globalFormulas,
+                path: [...path, 'events', eventKey, 'actions', actionKey],
+              })
             }
           }
           for (const [classKey, c] of Object.entries(node.classes ?? {})) {
-            yield* getFormulasInFormula(c.formula, globalFormulas, [
-              ...path,
-              'classes',
-              classKey,
-              'formula',
-            ])
+            yield* getFormulasInFormula({
+              formula: c.formula,
+              globalFormulas,
+              path: [...path, 'classes', classKey, 'formula'],
+            })
           }
 
           for (const [styleVariableKey, styleVariable] of Object.entries(
             node['style-variables'] ?? {},
           )) {
-            yield* getFormulasInFormula(styleVariable.formula, globalFormulas, [
-              ...path,
-              'style-variables',
-              styleVariableKey,
-              'formula',
-            ])
+            yield* getFormulasInFormula({
+              formula: styleVariable.formula,
+              globalFormulas,
+              path: [...path, 'style-variables', styleVariableKey, 'formula'],
+            })
           }
           break
       }
     }
 
-    yield* getFormulasInFormula(
-      this.route?.info?.language?.formula,
+    yield* getFormulasInFormula({
+      formula: this.route?.info?.language?.formula,
       globalFormulas,
-      ['route', 'info', 'language', 'formula'],
-    )
-    yield* getFormulasInFormula(
-      this.route?.info?.title?.formula,
+      path: ['route', 'info', 'language', 'formula'],
+    })
+    yield* getFormulasInFormula({
+      formula: this.route?.info?.title?.formula,
       globalFormulas,
-      ['route', 'info', 'title', 'formula'],
-    )
-    yield* getFormulasInFormula(
-      this.route?.info?.description?.formula,
+      path: ['route', 'info', 'title', 'formula'],
+    })
+    yield* getFormulasInFormula({
+      formula: this.route?.info?.description?.formula,
       globalFormulas,
-      ['route', 'info', 'description', 'formula'],
-    )
-    yield* getFormulasInFormula(
-      this.route?.info?.icon?.formula,
+      path: ['route', 'info', 'description', 'formula'],
+    })
+    yield* getFormulasInFormula({
+      formula: this.route?.info?.icon?.formula,
       globalFormulas,
-      ['route', 'info', 'icon', 'formula'],
-    )
-    yield* getFormulasInFormula(
-      this.route?.info?.charset?.formula,
+      path: ['route', 'info', 'icon', 'formula'],
+    })
+    yield* getFormulasInFormula({
+      formula: this.route?.info?.charset?.formula,
       globalFormulas,
-      ['route', 'info', 'charset', 'formula'],
-    )
+      path: ['route', 'info', 'charset', 'formula'],
+    })
     for (const [metaKey, meta] of Object.entries(
       this.route?.info?.meta ?? {},
     )) {
-      yield* getFormulasInFormula(meta.content, globalFormulas, [
-        'route',
-        'info',
-        'meta',
-        metaKey,
-        'content',
-      ])
+      yield* getFormulasInFormula({
+        formula: meta.content,
+        globalFormulas,
+        path: ['route', 'info', 'meta', metaKey, 'content'],
+      })
       for (const [attrKey, a] of Object.entries(meta.attrs)) {
-        yield* getFormulasInFormula(a, globalFormulas, [
-          'route',
-          'info',
-          'meta',
-          metaKey,
-          'attrs',
-          attrKey,
-        ])
+        yield* getFormulasInFormula({
+          formula: a,
+          globalFormulas,
+          path: ['route', 'info', 'meta', metaKey, 'attrs', attrKey],
+        })
       }
     }
     for (const [formulaKey, formula] of Object.entries(this.formulas ?? {})) {
-      yield* getFormulasInFormula(formula.formula, globalFormulas, [
-        'formulas',
-        formulaKey,
-        'formula',
-      ])
+      yield* getFormulasInFormula({
+        formula: formula.formula,
+        globalFormulas,
+        path: ['formulas', formulaKey, 'formula'],
+      })
     }
     for (const [variableKey, variable] of Object.entries(
       this.variables ?? {},
     )) {
-      yield* getFormulasInFormula(variable.initialValue, globalFormulas, [
-        'variables',
-        variableKey,
-        'initialValue',
-      ])
+      yield* getFormulasInFormula({
+        formula: variable.initialValue,
+        globalFormulas,
+        path: ['variables', variableKey, 'initialValue'],
+      })
     }
     for (const [workflowKey, workflow] of Object.entries(
       this.workflows ?? {},
     )) {
       for (const [actionKey, action] of workflow.actions.entries()) {
-        yield* getFormulasInAction(action, globalFormulas, [
-          'workflows',
-          workflowKey,
-          'actions',
-          actionKey,
-        ])
+        yield* getFormulasInAction({
+          action,
+          globalFormulas,
+          path: ['workflows', workflowKey, 'actions', actionKey],
+        })
       }
     }
     for (const [, api] of Object.entries(this.apis)) {
@@ -294,30 +293,30 @@ export class ToddleComponent<Handler> {
     for (const [actionKey, action] of Object.entries(
       this.component.onLoad?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, globalFormulas, [
-        'onLoad',
-        'actions',
-        actionKey,
-      ])
+      yield* getFormulasInAction({
+        action,
+        globalFormulas,
+        path: ['onLoad', 'actions', actionKey],
+      })
     }
     for (const [actionKey, action] of Object.entries(
       this.component.onAttributeChange?.actions ?? {},
     )) {
-      yield* getFormulasInAction(action, globalFormulas, [
-        'onAttributeChange',
-        'actions',
-        actionKey,
-      ])
+      yield* getFormulasInAction({
+        action,
+        globalFormulas,
+        path: ['onAttributeChange', 'actions', actionKey],
+      })
     }
     // Visit all component formulas in case they reference other formulas
     for (const [key, componentFormula] of Object.entries(
       this.component.formulas ?? {},
     )) {
-      yield* getFormulasInFormula(componentFormula.formula, globalFormulas, [
-        'formulas',
-        key,
-        'formula',
-      ])
+      yield* getFormulasInFormula({
+        formula: componentFormula.formula,
+        globalFormulas,
+        path: ['formulas', key, 'formula'],
+      })
     }
     for (const [nodeKey, node] of Object.entries(this.nodes ?? {})) {
       yield* visitNode(node, ['nodes', nodeKey])

--- a/packages/core/src/formula/ToddleFormula.ts
+++ b/packages/core/src/formula/ToddleFormula.ts
@@ -1,11 +1,20 @@
 import { Formula } from './formula'
+import { GlobalFormulas } from './formulaTypes'
 import { getFormulasInFormula } from './formulaUtils'
 
-export class ToddleFormula {
+export class ToddleFormula<Handler> {
   private formula: Formula
+  private globalFormulas: GlobalFormulas<Handler>
 
-  constructor({ formula }: { formula: Formula }) {
+  constructor({
+    formula,
+    globalFormulas,
+  }: {
+    formula: Formula
+    globalFormulas: GlobalFormulas<Handler>
+  }) {
     this.formula = formula
+    this.globalFormulas = globalFormulas
   }
 
   /**
@@ -13,6 +22,6 @@ export class ToddleFormula {
    * @returns An iterable that yields the path and formula.
    */
   *formulasInFormula(): Generator<[(string | number)[], Formula]> {
-    yield* getFormulasInFormula(this.formula)
+    yield* getFormulasInFormula(this.formula, this.globalFormulas)
   }
 }

--- a/packages/core/src/formula/ToddleFormula.ts
+++ b/packages/core/src/formula/ToddleFormula.ts
@@ -22,6 +22,9 @@ export class ToddleFormula<Handler> {
    * @returns An iterable that yields the path and formula.
    */
   *formulasInFormula(): Generator<[(string | number)[], Formula]> {
-    yield* getFormulasInFormula(this.formula, this.globalFormulas)
+    yield* getFormulasInFormula({
+      formula: this.formula,
+      globalFormulas: this.globalFormulas,
+    })
   }
 }

--- a/packages/core/src/formula/formulaTypes.ts
+++ b/packages/core/src/formula/formulaTypes.ts
@@ -19,13 +19,26 @@ export interface ToddleFormula extends BaseFormula {
 /**
  * The Handler generic is a string server side, but a function client side
  */
-export interface CodeFormula<Handler> extends BaseFormula {
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export interface CodeFormula<Handler = string | Function> extends BaseFormula {
   version?: 2 | never
   handler: Handler
 }
 
-export type PluginFormula<Handler> = ToddleFormula | CodeFormula<Handler>
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export type PluginFormula<Handler = string | Function> =
+  | ToddleFormula
+  | CodeFormula<Handler>
 
 export const isToddleFormula = <Handler>(
   formula: PluginFormula<Handler>,
 ): formula is ToddleFormula => Object.hasOwn(formula, 'formula')
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export interface GlobalFormulas<Handler = string | Function> {
+  formulas?: Record<string, PluginFormula<Handler>>
+  packages?: Record<
+    string,
+    { formulas?: Record<string, PluginFormula<Handler>> }
+  >
+}

--- a/packages/core/src/formula/formulaUtils.ts
+++ b/packages/core/src/formula/formulaUtils.ts
@@ -7,7 +7,7 @@ import {
   PathOperation,
   ValueOperation,
 } from './formula'
-import { GlobalFormulas, isToddleFormula, PluginFormula } from './formulaTypes'
+import { GlobalFormulas, isToddleFormula } from './formulaTypes'
 
 export const valueFormula = (
   value: string | number | boolean | null | object,
@@ -32,11 +32,17 @@ export const functionFormula = (
   variableArguments: formula?.variableArguments,
 })
 
-export function* getFormulasInFormula<Handler>(
-  formula: Formula | undefined | null,
-  globalFormulas: GlobalFormulas<Handler>,
-  path: (string | number)[] = [],
-): Generator<[(string | number)[], Formula]> {
+export function* getFormulasInFormula<Handler>({
+  formula,
+  globalFormulas,
+  path = [],
+  visitedFormulas = new Set<string>(),
+}: {
+  formula: Formula | undefined | null
+  globalFormulas: GlobalFormulas<Handler>
+  path?: (string | number)[]
+  visitedFormulas?: Set<string>
+}): Generator<[(string | number)[], Formula]> {
   if (!isDefined(formula)) {
     return
   }
@@ -48,84 +54,114 @@ export function* getFormulasInFormula<Handler>(
       break
     case 'record':
       for (const [key, entry] of formula.entries.entries()) {
-        yield* getFormulasInFormula(entry.formula, globalFormulas, [
-          ...path,
-          'entries',
-          key,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: entry.formula,
+          globalFormulas,
+          path: [...path, 'entries', key, 'formula'],
+          visitedFormulas,
+        })
       }
       break
     case 'function': {
+      const formulaKey = [formula.package, formula.name]
+        .filter(isDefined)
+        .join('/')
+      if (visitedFormulas.has(formulaKey)) {
+        // Prevent infinite loops when visiting global formulas (potentially in a package)
+        break
+      }
+      visitedFormulas.add(formulaKey)
       for (const [key, arg] of (
         (formula.arguments as typeof formula.arguments | undefined) ?? []
       ).entries()) {
-        yield* getFormulasInFormula(arg.formula, globalFormulas, [
-          ...path,
-          'arguments',
-          key,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: arg.formula,
+          globalFormulas,
+          path: [...path, 'arguments', key, 'formula'],
+          visitedFormulas,
+        })
       }
       // Lookup the actual function and traverse its potential formula references
-      let globalFormula: PluginFormula<Handler> | undefined
-      if (formula.package) {
-        globalFormula =
-          globalFormulas.packages?.[formula.package]?.formulas?.[formula.name]
-      } else {
-        globalFormula = globalFormulas.formulas?.[formula.name]
-      }
+      const globalFormula = formula.package
+        ? globalFormulas.packages?.[formula.package]?.formulas?.[formula.name]
+        : globalFormulas.formulas?.[formula.name]
       if (globalFormula && isToddleFormula(globalFormula)) {
-        yield* getFormulasInFormula(globalFormula.formula, globalFormulas, [
-          ...path,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: globalFormula.formula,
+          globalFormulas,
+          path: [...path, 'formula'],
+          visitedFormulas,
+        })
       }
       break
     }
     case 'array':
     case 'or':
     case 'and':
-    case 'apply':
     case 'object':
       for (const [key, arg] of (
         (formula.arguments as typeof formula.arguments | undefined) ?? []
       ).entries()) {
-        yield* getFormulasInFormula(arg.formula, globalFormulas, [
-          ...path,
-          'arguments',
-          key,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: arg.formula,
+          globalFormulas,
+          path: [...path, 'arguments', key, 'formula'],
+          visitedFormulas,
+        })
+      }
+      break
+    case 'apply':
+      if (visitedFormulas.has(formula.name)) {
+        // Prevent infinite loops when visiting other component formulas
+        break
+      }
+      visitedFormulas.add(formula.name)
+      for (const [key, arg] of (
+        (formula.arguments as typeof formula.arguments | undefined) ?? []
+      ).entries()) {
+        yield* getFormulasInFormula({
+          formula: arg.formula,
+          globalFormulas,
+          path: [...path, 'arguments', key, 'formula'],
+          visitedFormulas,
+        })
       }
       break
     case 'switch':
       for (const [key, c] of formula.cases.entries()) {
-        yield* getFormulasInFormula(c.condition, globalFormulas, [
-          ...path,
-          'cases',
-          key,
-          'condition',
-        ])
-        yield* getFormulasInFormula(c.formula, globalFormulas, [
-          ...path,
-          'cases',
-          key,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: c.condition,
+          globalFormulas,
+          path: [...path, 'cases', key, 'condition'],
+          visitedFormulas,
+        })
+        yield* getFormulasInFormula({
+          formula: c.formula,
+          globalFormulas,
+          path: [...path, 'cases', key, 'formula'],
+          visitedFormulas,
+        })
       }
-      yield* getFormulasInFormula(formula.default, globalFormulas, [
-        ...path,
-        'default',
-      ])
+      yield* getFormulasInFormula({
+        formula: formula.default,
+        globalFormulas,
+        path: [...path, 'default'],
+        visitedFormulas,
+      })
       break
   }
 }
-export function* getFormulasInAction<Handler>(
-  action: ActionModel | null,
-  globalFormulas: GlobalFormulas<Handler>,
-  path: (string | number)[] = [],
-): Generator<[(string | number)[], Formula]> {
+export function* getFormulasInAction<Handler>({
+  action,
+  globalFormulas,
+  path = [],
+  visitedFormulas = new Set<string>(),
+}: {
+  action: ActionModel | null
+  globalFormulas: GlobalFormulas<Handler>
+  path?: (string | number)[]
+  visitedFormulas?: Set<string>
+}): Generator<[(string | number)[], Formula]> {
   if (!isDefined(action)) {
     return
   }
@@ -133,108 +169,112 @@ export function* getFormulasInAction<Handler>(
   switch (action.type) {
     case 'Fetch':
       for (const [inputKey, input] of Object.entries(action.inputs ?? {})) {
-        yield* getFormulasInFormula(input.formula, globalFormulas, [
-          ...path,
-          'input',
-          inputKey,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: input.formula,
+          globalFormulas,
+          path: [...path, 'input', inputKey, 'formula'],
+          visitedFormulas,
+        })
       }
       for (const [key, a] of Object.entries(action.onSuccess?.actions ?? {})) {
-        yield* getFormulasInAction(a, globalFormulas, [
-          ...path,
-          'onSuccess',
-          'actions',
-          key,
-        ])
+        yield* getFormulasInAction({
+          action: a,
+          globalFormulas,
+          path: [...path, 'onSuccess', 'actions', key],
+          visitedFormulas,
+        })
       }
       for (const [key, a] of Object.entries(action.onError?.actions ?? {})) {
-        yield* getFormulasInAction(a, globalFormulas, [
-          ...path,
-          'onError',
-          'actions',
-          key,
-        ])
+        yield* getFormulasInAction({
+          action: a,
+          globalFormulas,
+          path: [...path, 'onError', 'actions', key],
+          visitedFormulas,
+        })
       }
       break
     case 'Custom':
     case undefined:
       if (isFormula(action.data)) {
-        yield* getFormulasInFormula(action.data, globalFormulas, [
-          ...path,
-          'data',
-        ])
+        yield* getFormulasInFormula({
+          formula: action.data,
+          globalFormulas,
+          path: [...path, 'data'],
+          visitedFormulas,
+        })
       }
       for (const [key, a] of Object.entries(action.arguments ?? {})) {
-        yield* getFormulasInFormula(a.formula, globalFormulas, [
-          ...path,
-          'arguments',
-          key,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: a.formula,
+          globalFormulas,
+          path: [...path, 'arguments', key, 'formula'],
+          visitedFormulas,
+        })
       }
 
       for (const [eventKey, event] of Object.entries(action.events ?? {})) {
         for (const [key, a] of Object.entries(event.actions ?? {})) {
-          yield* getFormulasInAction(a, globalFormulas, [
-            ...path,
-            'events',
-            eventKey,
-            'actions',
-            key,
-          ])
+          yield* getFormulasInAction({
+            action: a,
+            globalFormulas,
+            path: [...path, 'events', eventKey, 'actions', key],
+            visitedFormulas,
+          })
         }
       }
       break
     case 'SetVariable':
     case 'SetURLParameter':
     case 'TriggerEvent':
-      yield* getFormulasInFormula(action.data, globalFormulas, [
-        ...path,
-        'data',
-      ])
+      yield* getFormulasInFormula({
+        formula: action.data,
+        globalFormulas,
+        path: [...path, 'data'],
+        visitedFormulas,
+      })
       break
     case 'TriggerWorkflow':
       for (const [key, a] of Object.entries(action.parameters ?? {})) {
-        yield* getFormulasInFormula(a.formula, globalFormulas, [
-          ...path,
-          'parameters',
-          key,
-          'formula',
-        ])
+        yield* getFormulasInFormula({
+          formula: a.formula,
+          globalFormulas,
+          path: [...path, 'parameters', key, 'formula'],
+          visitedFormulas,
+        })
       }
       break
     case 'Switch':
       if (isDefined(action.data) && isFormula(action.data)) {
-        yield* getFormulasInFormula(action.data, globalFormulas, [
-          ...path,
-          'data',
-        ])
+        yield* getFormulasInFormula({
+          formula: action.data,
+          globalFormulas,
+          path: [...path, 'data'],
+          visitedFormulas,
+        })
       }
       for (const [key, c] of action.cases.entries()) {
-        yield* getFormulasInFormula(c.condition, globalFormulas, [
-          ...path,
-          'cases',
-          key,
-          'condition',
-        ])
+        yield* getFormulasInFormula({
+          formula: c.condition,
+          globalFormulas,
+          path: [...path, 'cases', key, 'condition'],
+          visitedFormulas,
+        })
         for (const [actionKey, a] of Object.entries(c.actions)) {
-          yield* getFormulasInAction(a, globalFormulas, [
-            ...path,
-            'cases',
-            key,
-            'actions',
-            actionKey,
-          ])
+          yield* getFormulasInAction({
+            action: a,
+            globalFormulas,
+            path: [...path, 'cases', key, 'actions', actionKey],
+            visitedFormulas,
+          })
         }
       }
       for (const [actionKey, a] of Object.entries(action.default.actions)) {
-        yield* getFormulasInAction(a, globalFormulas, [
-          ...path,
-          'default',
-          'actions',
-          actionKey,
-        ])
+        yield* getFormulasInAction({
+          action: a,
+          globalFormulas,
+          path: [...path, 'default', 'actions', actionKey],
+          visitedFormulas,
+        })
       }
       break
   }


### PR DESCRIPTION
We were not visiting global formulas when we were looking for formula references. This fixes that by adding new parameters where necessary to allow the different classes/functions to visit global formulas.

Please see reported issue here: https://discord.com/channels/972416966683926538/1310985625205473421/1310985625205473421
and the test project here: https://toddle.dev/projects/broken_global_formulas_project/branches/main/components/HomePage?leftpanel=design&canvas-width=800&canvas-height=925&rightpanel=attributes&selection=nodes.Uh8K4O215YFRyrAjH6eKN