### PR TITLE
Only stop following global formula refs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/core",
-  "version": "0.0.2-alpha.7",
+  "version": "0.0.2-alpha.8",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",

--- a/packages/core/src/formula/formulaUtils.ts
+++ b/packages/core/src/formula/formulaUtils.ts
@@ -75,8 +75,6 @@ export function* getFormulasInFormula<Handler>({
           break
         }
         visitedFormulas.add(formulaKey)
-
-        console.log('Formula', formulaKey)
       }
 
       for (const [key, arg] of (
@@ -116,11 +114,6 @@ export function* getFormulasInFormula<Handler>({
       }
       break
     case 'apply':
-      if (visitedFormulas.has(formula.name)) {
-        // Prevent infinite loops when visiting other component formulas
-        break
-      }
-      visitedFormulas.add(formula.name)
       for (const [key, arg] of (
         (formula.arguments as typeof formula.arguments | undefined) ?? []
       ).entries()) {


### PR DESCRIPTION
The previous solution would sometimes also stop following formula references that were not global.