### PR TITLE
Limit function parameters to 3

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,7 @@ export default [
 
     rules: {
       'no-return-await': 'off',
+      'max-params': ['error', 3],
       '@typescript-eslint/no-unsafe-function-type': 'off',
       '@typescript-eslint/return-await': 'warn',
       '@typescript-eslint/await-thenable': 'error',

--- a/packages/core/src/styling/style.css.ts
+++ b/packages/core/src/styling/style.css.ts
@@ -71,6 +71,7 @@ export const createStylesheet = (
   components: Component[],
   theme: Theme | OldTheme,
   options: ThemeOptions,
+  // eslint-disable-next-line max-params
 ) => {
   const hashes = new Set<string>()
 

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -183,6 +183,7 @@ export const initGlobalObject = ({
           toddle.formulas[window.__toddle.project]?.[name]
         )
       },
+      // eslint-disable-next-line max-params
       getArgumentInputData: (formulaName, args, argIndex, data) =>
         argumentInputDataList[formulaName]?.(args, argIndex, data) || data,
       data: {},

--- a/packages/runtime/src/editor/drag-drop/dragMove.ts
+++ b/packages/runtime/src/editor/drag-drop/dragMove.ts
@@ -76,13 +76,13 @@ export function dragMove(dragState: DragState | null, exclude: HTMLElement[]) {
       .querySelectorAll('.__drag-container')
       .forEach((c) => c.classList.remove('__drag-container'))
     insertArea.parent.classList.add('__drag-container')
-    setExternalDropHighlight(
-      insertArea.layout,
-      insertArea.center,
-      insertArea.size,
-      dragState.elementType === 'component' ? 'D946EF' : '2563EB',
+    setExternalDropHighlight({
+      layout: insertArea.layout,
+      center: insertArea.center,
+      length: insertArea.size,
+      color: dragState.elementType === 'component' ? 'D946EF' : '2563EB',
       projectionPoint,
-    )
+    })
   } else {
     removeDropHighlight()
   }

--- a/packages/runtime/src/editor/drag-drop/dropHighlight.ts
+++ b/packages/runtime/src/editor/drag-drop/dropHighlight.ts
@@ -33,13 +33,19 @@ export function setDropHighlight(
 /**
  * Visual representation of where a dragged node will be dropped outside of its own container.
  */
-export function setExternalDropHighlight(
-  layout: 'block' | 'inline',
-  center: Point,
-  length: number,
-  color: string,
-  projectionPoint: number,
-) {
+export function setExternalDropHighlight({
+  layout,
+  center,
+  length,
+  color,
+  projectionPoint,
+}: {
+  layout: 'block' | 'inline'
+  center: Point
+  length: number
+  color: string
+  projectionPoint: number
+}) {
   highlight?.remove()
   highlight = document.createElement('div')
   highlight.classList.add('__drop-area-line')

--- a/packages/runtime/src/events/handleAction.ts
+++ b/packages/runtime/src/events/handleAction.ts
@@ -5,6 +5,7 @@ import { mapValues, omitKeys } from '@toddledev/core/dist/utils/collections'
 import { isDefined, toBoolean } from '@toddledev/core/dist/utils/util'
 import { ComponentContext } from '../types'
 
+// eslint-disable-next-line max-params
 export function handleAction(
   action: ActionModel,
   data: ComponentData,

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -87,6 +87,7 @@ export const initGlobalObject = (code?: {
           toddle.formulas[window.__toddle.project]?.[name]
         )
       },
+      // eslint-disable-next-line max-params
       getArgumentInputData: (formulaName, args, argIndex, data) =>
         argumentInputDataList[formulaName]?.(args, argIndex, data) || data,
       data: {},

--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -61,7 +61,7 @@ export type Options = {
 }
 
 const RULES = [
-  createActionNameRule('@toddle/logToConsole', 'no-console'),
+  createActionNameRule({ name: '@toddle/logToConsole', code: 'no-console' }),
   createRequiredElementAttributeRule('a', 'href'),
   createRequiredElementAttributeRule('img', 'alt'),
   createRequiredElementAttributeRule('img', 'src'),

--- a/packages/search/src/rules/createActionNameRule.test.ts
+++ b/packages/search/src/rules/createActionNameRule.test.ts
@@ -84,7 +84,12 @@ describe('createActionNameRule', () => {
             },
           },
         },
-        rules: [createActionNameRule('@toddle/logToConsole', 'no-console')],
+        rules: [
+          createActionNameRule({
+            name: '@toddle/logToConsole',
+            code: 'no-console',
+          }),
+        ],
       }),
     )
 

--- a/packages/search/src/rules/createActionNameRule.ts
+++ b/packages/search/src/rules/createActionNameRule.ts
@@ -6,12 +6,17 @@ import { Category, Code, Level, Rule } from '../types'
  * @example
  * myRule = () => createActionNameRule('myAction', myRule.code)
  */
-export function createActionNameRule(
-  name: string,
-  code: Code,
-  category: Category = 'Other',
-  level: Level = 'info',
-): Rule<{
+export function createActionNameRule({
+  name,
+  code,
+  category = 'Other',
+  level = 'info',
+}: {
+  name: string
+  code: Code
+  category?: Category
+  level?: Level
+}): Rule<{
   name: string
 }> {
   return {


### PR DESCRIPTION
Let's help ourselves by limiting the number of parameters to 3. This will make our functions easier to understand and maintain.