### PR TITLE
Visit onMessage event for formula/action lookup

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/core",
-  "version": "0.0.2-alpha.9",
+  "version": "0.0.2-alpha.10",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",

--- a/packages/core/src/api/ToddleApiV2.ts
+++ b/packages/core/src/api/ToddleApiV2.ts
@@ -254,7 +254,7 @@ export class ToddleApiV2<Handler> implements ApiRequest {
       yield* getFormulasInAction({
         action,
         globalFormulas: this.globalFormulas,
-        path: ['apis', apiKey, 'client', 'onData', 'actions', actionKey],
+        path: ['apis', apiKey, 'client', 'onMessage', 'actions', actionKey],
       })
     }
     for (const [rule, value] of Object.entries(api.redirectRules ?? {})) {

--- a/packages/core/src/component/actionUtils.ts
+++ b/packages/core/src/component/actionUtils.ts
@@ -23,6 +23,9 @@ export function* getActionsInAction(
       for (const [key, a] of Object.entries(action.onError?.actions ?? {})) {
         yield* getActionsInAction(a, [...path, 'onError', 'actions', key])
       }
+      for (const [key, a] of Object.entries(action.onMessage?.actions ?? {})) {
+        yield* getActionsInAction(a, [...path, 'onMessage', 'actions', key])
+      }
       break
     case 'Custom':
     case undefined:

--- a/packages/core/src/formula/formulaUtils.ts
+++ b/packages/core/src/formula/formulaUtils.ts
@@ -190,6 +190,14 @@ export function* getFormulasInAction<Handler>({
           visitedFormulas,
         })
       }
+      for (const [key, a] of Object.entries(action.onMessage?.actions ?? {})) {
+        yield* getFormulasInAction({
+          action: a,
+          globalFormulas,
+          path: [...path, 'onMessage', 'actions', key],
+          visitedFormulas,
+        })
+      }
       break
     case 'Custom':
     case undefined:

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -536,7 +536,7 @@ export function createAPI(
     } = {
       chunks: [],
       currentChunk: '',
-      // Function to add a chunk to the chunks array and emits the data to the onData event
+      // Function to add a chunk to the chunks array and emits the data to the onMessage event
       add(chunk: string | Uint8Array) {
         const parsedChunk = parseChunk(chunk)
         this.chunks.push(parsedChunk)


### PR DESCRIPTION
We were not visiting formulas/actions correctly in `onMessage` events, which meant that custom formulas/actions would not be included if they were only referenced from an `onMessage` event.