### PR TITLE
Add rule for dl->dd|dt|script|template relation

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toddledev/search",
   "description": "Used for searching and reporting linting problems in toddle projects.",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "license": "Apache-2.0",
   "devDependencies": {
     "ts-jest": "29.2.5"

--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -89,6 +89,8 @@ const RULES = [
   createRequiredDirectChildRule(['optgroup'], ['option']),
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend#technical_summary
   createRequiredDirectParentRule(['fieldset'], ['legend']),
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl#technical_summary
+  createRequiredDirectChildRule(['dl'], ['dd', 'dt', 'script', 'template']),
   imageWithoutDimensionRule,
   duplicateEventTriggerRule,
   duplicateUrlParameterRule,


### PR DESCRIPTION
I found another element where the direct child rule is relevant (although I've never heard of the `dl`, `dt` or `dd` element 😂 )