### PR TITLE
Only pass numbers to value property of <progress>

### DIFF
--- a/packages/runtime/src/utils/setAttribute.ts
+++ b/packages/runtime/src/utils/setAttribute.ts
@@ -1,4 +1,4 @@
-import { toBoolean } from '@toddledev/core/dist/utils/util'
+import { isDefined, toBoolean } from '@toddledev/core/dist/utils/util'
 
 /**
  * Some attributes need special handling.
@@ -18,9 +18,16 @@ export function setAttribute(
       }
       break
     case 'value':
-    case 'type':
-      ;(elem as any)[attr] = toBoolean(value) ? String(value) : undefined
+    case 'type': {
+      let val = value
+      if (elem instanceof HTMLProgressElement) {
+        if (!isDefined(value) || !Number.isFinite(Number(value))) {
+          val = 0
+        }
+      }
+      ;(elem as any)[attr] = toBoolean(val) ? String(val) : undefined
       break
+    }
     case 'muted':
     case 'autoplay':
       if (elem instanceof HTMLMediaElement) {


### PR DESCRIPTION
Tom reported an issue, where an `HTMLProgressElement` would fail to render + break other elements, if the passed value attribute was not a finite number (or a string that can be casted into a finite number).