### PR TITLE
Fix node path to events to be index based

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toddledev/search",
   "description": "Used for searching and reporting linting problems in toddle projects.",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "license": "Apache-2.0",
   "devDependencies": {
     "ts-jest": "29.2.5"

--- a/packages/search/src/rules/noReferenceEventRule.test.ts
+++ b/packages/search/src/rules/noReferenceEventRule.test.ts
@@ -54,12 +54,7 @@ describe('noReferenceEventRule', () => {
 
     expect(problems).toHaveLength(1)
     expect(problems[0].code).toBe('no-reference event')
-    expect(problems[0].path).toEqual([
-      'components',
-      'test',
-      'events',
-      'unused-event',
-    ])
+    expect(problems[0].path).toEqual(['components', 'test', 'events', 0])
   })
 
   test('should not detect events with references', () => {

--- a/packages/search/src/searchProject.ts
+++ b/packages/search/src/searchProject.ts
@@ -262,19 +262,22 @@ function* visitNode(
         )
       }
 
-      for (const event of value.events ?? []) {
-        yield* visitNode(
-          {
-            nodeType: 'component-event',
-            path: [...path, 'events', event.name],
-            rules,
-            files,
-            pathsToVisit,
-            memo,
-            value: { component, event },
-          },
-          state,
-        )
+      for (let i = 0; i < (value.events ?? []).length; i++) {
+        const event = value.events?.[i]
+        if (event) {
+          yield* visitNode(
+            {
+              nodeType: 'component-event',
+              path: [...path, 'events', i],
+              rules,
+              files,
+              pathsToVisit,
+              memo,
+              value: { component, event },
+            },
+            state,
+          )
+        }
       }
 
       for (const key in value.contexts) {


### PR DESCRIPTION
The node path should be index based, not name based when events is an array