### PR TITLE
Adjust logic for when we refetch APIs

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/runtime",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "dependencies": {


### PR DESCRIPTION
- Include the `autoFetch` and `proxy` values in the payload signal when comparing if an API should be re-evaluated for fetching
- Allow refetching an API if redirectRules definitions change
