### PR TITLE
Fix an issue where instance styling would not work in the editor

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/runtime",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "dependencies": {

--- a/packages/runtime/src/styles/style.ts
+++ b/packages/runtime/src/styles/style.ts
@@ -73,11 +73,9 @@ export const insertStyles = (
     ])
 
     const styleElem = document.createElement('style')
-
     styleElem.setAttribute('data-hash', classHash)
     styleElem.appendChild(
       document.createTextNode(`
-
     ${renderVariant('.' + classHash, style)}
 
 ${
@@ -140,7 +138,7 @@ ${
         )
         if (childComponent) {
           insertComponentStyles(childComponent, node.package ?? package_name) // write the dependant CSS first.
-          parent.querySelector(`[data-hash$="${id}"]`)?.remove() //  remove the old styles
+          parent.querySelector(`[data-hash="${id}"]`)?.remove() //  remove the old styles
           parent.appendChild(
             getNodeStyles(
               node,


### PR DESCRIPTION
The selector used an `ends-with`, which caused the class `root` to select the last instance with a root component to be selected instead.