### PR TITLE
Update the unknown cookie rule

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,7 +49,7 @@
     },
     "packages/search": {
       "name": "@toddledev/search",
-      "version": "0.0.1-alpha.9",
+      "version": "0.0.1-alpha.10",
       "dependencies": {
         "@toddledev/ssr": "packages/ssr",
       },

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toddledev/search",
   "description": "Used for searching and reporting linting problems in toddle projects.",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "license": "Apache-2.0",
   "dependencies": {
     "@toddledev/ssr": "workspace:*"

--- a/packages/search/src/rules/unknownCookieRule.ts
+++ b/packages/search/src/rules/unknownCookieRule.ts
@@ -13,7 +13,8 @@ export const unknownCookieRule: Rule<{
       value.type !== 'function' ||
       value.name !== '@toddle/getHttpOnlyCookie' ||
       value.arguments.length !== 1 ||
-      !state
+      !state ||
+      state.isBrowserExtensionAvailable !== true
     ) {
       return
     }


### PR DESCRIPTION
The unknown cookie rule should only be shown when the extension is installed.