### PR TITLE
Use canvas highlight instead of custom container outline

### DIFF
--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -841,6 +841,12 @@ export const createRoot = (
               }
               break
           }
+          if (message.data.canceled) {
+            dragState?.initialContainer.insertBefore(
+              dragState?.element,
+              dragState?.initialNextSibling,
+            )
+          }
           dragEnded(dragState)
           window.parent?.postMessage(
             {

--- a/packages/runtime/src/editor/drag-drop/dragEnded.ts
+++ b/packages/runtime/src/editor/drag-drop/dragEnded.ts
@@ -7,17 +7,9 @@ export function dragEnded(dragState: DragState | null) {
   dragState?.element.classList.remove(DRAG_REORDER_CLASSNAME)
   dragState?.element.classList.remove(DRAG_MOVE_CLASSNAME)
   dragState?.element.style.removeProperty('translate')
-  dragState?.initialContainer.classList.remove('__drag-container')
   dragState?.copy?.remove()
-  dragState?.initialContainer.insertBefore(
-    dragState?.element,
-    dragState?.initialNextSibling,
-  )
   dragState?.repeatedNodes.toReversed().forEach((node) => {
     dragState?.element.insertAdjacentElement('afterend', node)
   })
   removeDropHighlight()
-  document
-    .querySelectorAll('.__drag-container')
-    .forEach((c) => c.classList.remove('__drag-container'))
 }

--- a/packages/runtime/src/editor/drag-drop/dragMove.ts
+++ b/packages/runtime/src/editor/drag-drop/dragMove.ts
@@ -72,10 +72,13 @@ export function dragMove(dragState: DragState | null, exclude: HTMLElement[]) {
   if (insertArea) {
     dragState.selectedInsertAreaIndex =
       dragState.insertAreas?.indexOf(insertArea)
-    document
-      .querySelectorAll('.__drag-container')
-      .forEach((c) => c.classList.remove('__drag-container'))
-    insertArea.parent.classList.add('__drag-container')
+    window.parent?.postMessage(
+      {
+        type: 'highlight',
+        highlightedNodeId: insertArea.parent.getAttribute('data-id'),
+      },
+      '*',
+    )
     setExternalDropHighlight({
       layout: insertArea.layout,
       center: insertArea.center,

--- a/packages/runtime/src/editor/drag-drop/dragReorder.ts
+++ b/packages/runtime/src/editor/drag-drop/dragReorder.ts
@@ -26,10 +26,13 @@ export function dragReorder(dragState: DragState | null) {
     const nextRect = dragState.element.getBoundingClientRect()
     dragState.offset.x += nextRect.left - prevRect.left
     dragState.offset.y += nextRect.top - prevRect.top
-    document
-      .querySelectorAll('.__drag-container')
-      .forEach((c) => c.classList.remove('__drag-container'))
-    dragState.initialContainer.classList.add('__drag-container')
+    window.parent?.postMessage(
+      {
+        type: 'highlight',
+        highlightedNodeId: dragState.initialContainer.getAttribute('data-id'),
+      },
+      '*',
+    )
     setDropHighlight(
       dragState.element,
       dragState.initialContainer,

--- a/packages/runtime/src/editor/drag-drop/dragStarted.ts
+++ b/packages/runtime/src/editor/drag-drop/dragStarted.ts
@@ -80,7 +80,14 @@ export function dragStarted({
 
   // Highlight container
   element.classList.add(DRAG_REORDER_CLASSNAME)
-  dragState.initialContainer.classList.add('__drag-container')
+  window.parent?.postMessage(
+    {
+      type: 'highlight',
+      highlightedNodeId: dragState.initialContainer.getAttribute('data-id'),
+    },
+    '*',
+  )
+
   setDropHighlight(
     dragState.element,
     dragState.initialContainer,


### PR DESCRIPTION
Andreas suggested using the canvas element hover instead of a custom outline—this way the drop-target is also highlighted in the tree view.