### PR TITLE
Ensure global formula arguments are always visited

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/core": {
       "name": "@toddledev/core",
-      "version": "0.0.2-alpha.12",
+      "version": "0.0.2-alpha.13",
       "dependencies": {
         "@types/react": "18.3.10",
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/core",
-  "version": "0.0.2-alpha.12",
+  "version": "0.0.2-alpha.13",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "dependencies": {


### PR DESCRIPTION
We were returning early if a global formula had already been visited, but while we shouldn't visit the same global toddle formula multiple times, we should always visit all arguments for a formula (regadless of whether it's a custom or toddle formula).

This fixes an issue where a formula in the toddle project was incorrectly reported as unused.