### PR TITLE
Require toddle object on FormulaContext

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,14 +17,14 @@
     },
     "packages/core": {
       "name": "@toddledev/core",
-      "version": "0.0.2-alpha.14",
+      "version": "0.0.2-alpha.15",
       "dependencies": {
         "@types/react": "18.3.10",
       },
     },
     "packages/lib": {
       "name": "@toddledev/std-lib",
-      "version": "0.0.1-alpha.5",
+      "version": "0.0.1-alpha.6",
       "dependencies": {
         "@toddledev/core": "packages/core",
         "fast-deep-equal": "3.1.3",
@@ -37,7 +37,7 @@
     },
     "packages/runtime": {
       "name": "@toddledev/runtime",
-      "version": "0.0.1-alpha.9",
+      "version": "0.0.1-alpha.10",
       "dependencies": {
         "@toddledev/core": "packages/core",
         "fast-deep-equal": "3.1.3",
@@ -49,14 +49,14 @@
     },
     "packages/search": {
       "name": "@toddledev/search",
-      "version": "0.0.1-alpha.11",
+      "version": "0.0.1-alpha.12",
       "dependencies": {
         "@toddledev/ssr": "packages/ssr",
       },
     },
     "packages/ssr": {
       "name": "@toddledev/ssr",
-      "version": "0.0.2-alpha.14",
+      "version": "0.0.2-alpha.15",
       "dependencies": {
         "@toddledev/core": "packages/core",
         "cookie": "1.0.2",
@@ -325,7 +325,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "browserslist": ["browserslist@4.24.3", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA=="],
+    "browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
 
     "bs-logger": ["bs-logger@0.2.6", "", { "dependencies": { "fast-json-stable-stringify": "2.x" } }, "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog=="],
 
@@ -337,7 +337,7 @@
 
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001690", "", {}, "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001692", "", {}, "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -401,7 +401,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.75", "", {}, "sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.79", "", {}, "sha512-nYOxJNxQ9Om4EC88BE4pPoNI8xwSFf8pU/BAeOl4Hh/b/i6V4biTAzwV7pXi3ARKeoYO5JZKMIXTryXSVer5RA=="],
 
     "emittery": ["emittery@0.13.1", "", {}, "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="],
 
@@ -445,13 +445,13 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-glob": ["fast-glob@3.3.2", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow=="],
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fastq": ["fastq@1.17.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w=="],
+    "fastq": ["fastq@1.18.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw=="],
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
 
@@ -527,7 +527,7 @@
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
-    "is-core-module": ["is-core-module@2.16.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g=="],
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -825,7 +825,7 @@
 
     "universalify": ["universalify@0.2.0", "", {}, "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="],
 
-    "update-browserslist-db": ["update-browserslist-db@1.1.1", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.0" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A=="],
+    "update-browserslist-db": ["update-browserslist-db@1.1.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 

--- a/examples/projects/medium.json
+++ b/examples/projects/medium.json
@@ -1,1 +1,670 @@
-{"id":"7546cf70-4b38-48be-bcd3-a3dfb35b939f","name":"medium","project":{"id":"2961e2d1-3c63-4d98-bd3b-302fbd35972b","short_id":"brown_sebulba_agreed_baboon","emoji":"🙌","name":"Untitled","description":null,"custom_domains":false,"type":"app","published_at":null,"thumbnail":null,"accounts":{"name":"erik-test-org","account_plans":{"plans":{"custom_domains":false}}}},"commit":"1cff2386d655c158f237e299079ebfb64154608c","files":{"components":{"HomePage":{"apis":{"WOW API":{"version":2,"name":"WOW API","type":"http","autoFetch":{"type":"value","value":true},"url":{"type":"value","value":"https://owen-wilson-wow-api.onrender.com"},"path":{"IbdbGqON7MJvvmNOO1TAg":{"index":0,"formula":{"type":"value","value":"wows"}},"8dyQhOhHDyfv-BskOoSks":{"index":1,"formula":{"type":"value","value":"random"}}},"headers":{},"method":"GET","inputs":{},"queryParams":{},"server":{"ssr":{"enabled":{"formula":{"type":"value","value":true}}},"proxy":{"enabled":{"formula":{"type":"value","value":false}}}},"client":{},"redirectRules":{},"isError":{},"timeout":{}}},"name":"HomePage","nodes":{"root":{"tag":"div","type":"element","attrs":{},"style":{"min-height":"100%","align-items":"center","justify-content":"center","background-color":"var(--grey-900)","color":"var(--grey-200, #E5E5E5)","gap":"8px"},"events":{},"classes":{},"children":["p44ree-FsxJKSeiWKWQpa","pK1rq0usjmjwt2RZhiTFV","9cdB1ieO8k-D0guvB5q6d","co7vEt15EK6qGAVA2PGaM"],"styleVariables":{}},"c8DBGzXyJIHSfoguEo7OL":{"type":"text","value":{"type":"value","value":"Hello world"}},"p44ree-FsxJKSeiWKWQpa":{"tag":"h1","type":"element","attrs":{},"style":{"color":"var(--grey-200, #E5E5E5)","font-size":"2.25rem","font-weight":"var(--font-weight-bold)"},"events":{},"classes":{},"children":["c8DBGzXyJIHSfoguEo7OL"],"styleVariables":{}},"pK1rq0usjmjwt2RZhiTFV":{"tag":"p","type":"element","attrs":{},"style":{"color":"inherit","display":"inline-block"},"events":{},"classes":{},"children":["vnERXXaHU1zd6Jz79Ry5I"],"styleVariables":{}},"vnERXXaHU1zd6Jz79Ry5I":{"type":"text","value":{"type":"path","path":["URL parameters","q"]}},"9cdB1ieO8k-D0guvB5q6d":{"tag":"button","type":"element","attrs":{},"style":{"color":"var(--grey-200, #E5E5E5)","border-radius":"6px","background-color":"var(--blue-600, #2563EB)","padding-left":"8px","padding-right":"8px","padding-top":"8px","padding-bottom":"8px","width":"fit-content","cursor":"pointer"},"events":{},"classes":{},"children":["RGFpys0-7b_IQ8SYApMAL"],"variants":[{"hover":true,"style":{"background-color":"var(--blue-500, #3B82F6)"}}],"styleVariables":{},"condition":{"type":"function","name":"@toddle/equals","arguments":[{"name":"First","formula":{"type":"path","path":["URL parameters","test"],"label":null},"type":{"type":"Any"}},{"name":"Second","formula":{"type":"value","value":null},"type":{"type":"Any"}}],"display_name":"Equals","label":null}},"RGFpys0-7b_IQ8SYApMAL":{"type":"text","value":{"type":"value","value":"Conditional element"}},"co7vEt15EK6qGAVA2PGaM":{"tag":"p","type":"element","attrs":{},"style":{"color":"inherit","display":"inline-block"},"events":{},"classes":{},"children":["EEfz_0R8BhOvKve4YgCi6"],"styleVariables":{}},"EEfz_0R8BhOvKve4YgCi6":{"type":"text","value":{"type":"function","name":"@toddle/concatenate","arguments":[{"name":"0","formula":{"type":"value","value":"Wow API: "},"type":{"type":"Union","types":[{"type":"String"},{"type":"Array","ofType":{"type":"Any"}}]}},{"name":"0","formula":{"type":"path","path":["Apis","WOW API","data","0","movie"]},"type":{"type":"Union","types":[{"type":"String"},{"type":"Array","ofType":{"type":"Any"}}]}}],"variableArguments":true,"display_name":"Concatenate"}}},"route":{"info":{"title":{"formula":{"type":"value","value":"Toddle template"}},"description":{"formula":{"type":"value","value":"A blank template from toddle"}}},"path":[],"query":{"test":{"name":"test","testValue":"test"},"q":{"name":"q","testValue":"search"}}},"events":[],"onLoad":{"actions":[],"trigger":"load"},"functions":{},"variables":{},"attributes":{}}},"actions":{},"formulas":{},"config":{},"packages":{},"themes":{"Default":{"color":[{"name":"grey","tokens":[{"name":"grey-50","type":"value","value":"#FAFAFA"},{"name":"grey-100","type":"value","value":"#F5F5F5"},{"name":"grey-200","type":"value","value":"#E5E5E5"},{"name":"grey-300","type":"value","value":"#D4D4D4"},{"name":"grey-400","type":"value","value":"#A3A3A3"},{"name":"grey-500","type":"value","value":"#737373"},{"name":"grey-600","type":"value","value":"#525252"},{"name":"grey-700","type":"value","value":"#404040"},{"name":"grey-800","type":"value","value":"#262626"},{"name":"grey-900","type":"value","value":"#171717"}]},{"name":"red","tokens":[{"name":"red-50","type":"value","value":"#FEF2F2"},{"name":"red-100","type":"value","value":"#FEE2E2"},{"name":"red-200","type":"value","value":"#FECACA"},{"name":"red-300","type":"value","value":"#FCA5A5"},{"name":"red-400","type":"value","value":"#F87171"},{"name":"red-500","type":"value","value":"#EF4444"},{"name":"red-600","type":"value","value":"#DC2626"},{"name":"red-700","type":"value","value":"#B91C1C"},{"name":"red-800","type":"value","value":"#991B1B"},{"name":"red-900","type":"value","value":"#7F1D1D"}]},{"name":"blue","tokens":[{"name":"blue-50","type":"value","value":"#EFF6FF"},{"name":"blue-100","type":"value","value":"#DBEAFE"},{"name":"blue-200","type":"value","value":"#BFDBFE"},{"name":"blue-300","type":"value","value":"#93C5FD"},{"name":"blue-400","type":"value","value":"#60A5FA"},{"name":"blue-500","type":"value","value":"#3B82F6"},{"name":"blue-600","type":"value","value":"#2563EB"},{"name":"blue-700","type":"value","value":"#1D4ED8"},{"name":"blue-800","type":"value","value":"#1E40AF"},{"name":"blue-900","type":"value","value":"#1E3A8A"}]},{"name":"lime","tokens":[{"name":"lime-50","type":"value","value":"#F7FEE7"},{"name":"lime-100","type":"value","value":"#ECFCCB"},{"name":"lime-200","type":"value","value":"#D9F99D"},{"name":"lime-300","type":"value","value":"#BEF264"},{"name":"lime-400","type":"value","value":"#A3E635"},{"name":"lime-500","type":"value","value":"#84CC16"},{"name":"lime-600","type":"value","value":"#65A30D"},{"name":"lime-700","type":"value","value":"#4D7C0F"},{"name":"lime-800","type":"value","value":"#3F6212"},{"name":"lime-900","type":"value","value":"#365314"}]},{"name":"pink","tokens":[{"name":"pink-50","type":"value","value":"#FDF2F8"},{"name":"pink-100","type":"value","value":"#FCE7F3"},{"name":"pink-200","type":"value","value":"#FBCFE8"},{"name":"pink-300","type":"value","value":"#F9A8D4"},{"name":"pink-400","type":"value","value":"#F472B6"},{"name":"pink-500","type":"value","value":"#EC4899"},{"name":"pink-600","type":"value","value":"#DB2777"},{"name":"pink-700","type":"value","value":"#BE185D"},{"name":"pink-800","type":"value","value":"#9D174D"},{"name":"pink-900","type":"value","value":"#831843"}]},{"name":"teal","tokens":[{"name":"teal-50","type":"value","value":"#F0FDFA"},{"name":"teal-100","type":"value","value":"#CCFBF1"},{"name":"teal-200","type":"value","value":"#99F6E4"},{"name":"teal-300","type":"value","value":"#5EEAD4"},{"name":"teal-400","type":"value","value":"#2DD4BF"},{"name":"teal-500","type":"value","value":"#14B8A6"},{"name":"teal-600","type":"value","value":"#0D9488"},{"name":"teal-700","type":"value","value":"#0F766E"},{"name":"teal-800","type":"value","value":"#115E59"},{"name":"teal-900","type":"value","value":"#134E4A"}]},{"name":"green","tokens":[{"name":"green-50","type":"value","value":"#ECFDF5"},{"name":"green-100","type":"value","value":"#D1FAE5"},{"name":"green-200","type":"value","value":"#A7F3D0"},{"name":"green-300","type":"value","value":"#6EE7B7"},{"name":"green-400","type":"value","value":"#34D399"},{"name":"green-500","type":"value","value":"#10B981"},{"name":"green-600","type":"value","value":"#059669"},{"name":"green-700","type":"value","value":"#047857"},{"name":"green-800","type":"value","value":"#065F46"},{"name":"green-900","type":"value","value":"#064E3B"}]},{"name":"purple","tokens":[{"name":"purple-50","type":"value","value":"#F5F3FF"},{"name":"purple-100","type":"value","value":"#EDE9FE"},{"name":"purple-200","type":"value","value":"#DDD6FE"},{"name":"purple-300","type":"value","value":"#C4B5FD"},{"name":"purple-400","type":"value","value":"#A78BFA"},{"name":"purple-500","type":"value","value":"#8B5CF6"},{"name":"purple-600","type":"value","value":"#7C3AED"},{"name":"purple-700","type":"value","value":"#6D28D9"},{"name":"purple-800","type":"value","value":"#5B21B6"},{"name":"purple-900","type":"value","value":"#4C1D95"}]},{"name":"yellow","tokens":[{"name":"yellow-50","type":"value","value":"#FFFBEB"},{"name":"yellow-100","type":"value","value":"#FEF3C7"},{"name":"yellow-200","type":"value","value":"#FDE68A"},{"name":"yellow-300","type":"value","value":"#FCD34D"},{"name":"yellow-400","type":"value","value":"#FBBF24"},{"name":"yellow-500","type":"value","value":"#F59E0B"},{"name":"yellow-600","type":"value","value":"#D97706"},{"name":"yellow-700","type":"value","value":"#B45309"},{"name":"yellow-800","type":"value","value":"#92400E"},{"name":"yellow-900","type":"value","value":"#78350F"}]}],"fonts":[{"name":"sans","type":"sans-serif","family":"Inter","provider":"google","variants":[{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyeMZ1rib2Bg-4.woff2","name":"100","italic":false,"weight":"100"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyfMZ1rib2Bg-4.woff2","name":"200","italic":false,"weight":"200"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuOKfMZ1rib2Bg-4.woff2","name":"300","italic":false,"weight":"300"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfMZ1rib2Bg-4.woff2","name":"regular","italic":false,"weight":"400"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fMZ1rib2Bg-4.woff2","name":"500","italic":false,"weight":"500"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuGKYMZ1rib2Bg-4.woff2","name":"600","italic":false,"weight":"600"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuFuYMZ1rib2Bg-4.woff2","name":"700","italic":false,"weight":"700"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyYMZ1rib2Bg-4.woff2","name":"800","italic":false,"weight":"800"},{"url":"https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuBWYMZ1rib2Bg-4.woff2","name":"900","italic":false,"weight":"900"}]}],"scheme":"dark","shadow":[{"name":"Default","tokens":[{"name":"shadow-sm","type":"value","value":" 0 1px 2px 0 rgba(0, 0, 0, 0.25)"},{"name":"shadow-base","type":"value","value":" 0 1px 3px 0 rgba(0, 0, 0, 0.25), 0 1px 2px 0 rgba(0, 0, 0, 0.25)"},{"name":"shadow-md","type":"value","value":" 0 4px 6px -1px rgba(0, 0, 0, 0.25), 0 2px 4px -1px rgba(0, 0, 0, 0.25)"},{"name":"shadow-lg","type":"value","value":" 0 10px 15px -3px rgba(0, 0, 0, 0.25), 0 4px 6px -2px rgba(0, 0, 0, 0.25)"},{"name":"shadow-xl","type":"value","value":"0 20px 25px -5px rgba(0, 0, 0, 0.25), 0 10px 10px -5px rgba(0, 0, 0, 0.25)"},{"name":"shadow-2xl","type":"value","value":" 0 25px 50px -12px rgba(0, 0, 0, 0.25)"}]}],"spacing":[],"z-index":[],"font-size":[{"name":"Default","tokens":[{"name":"font-size-xxs","type":"value","value":"0.625rem"},{"name":"font-size-xs","type":"value","value":"0.75rem"},{"name":"font-size-sm","type":"value","value":"0.875rem"},{"name":"font-size-base","type":"value","value":"1rem"},{"name":"font-size-lg","type":"value","value":"1.125rem"},{"name":"font-size-xl","type":"value","value":"1.25rem"},{"name":"font-size-2xl","type":"value","value":"1.5rem"},{"name":"font-size-3xl","type":"value","value":"1.875rem"},{"name":"font-size-4xl","type":"value","value":"2.25rem"},{"name":"font-size-5xl","type":"value","value":"3rem"}]}],"font-weight":[{"name":"Default","tokens":[{"name":"font-weight-thin","type":"value","value":"100"},{"name":"font-weight-lighter","type":"value","value":"200"},{"name":"font-weight-light","type":"value","value":"300"},{"name":"font-weight-regular","type":"value","value":"400"},{"name":"font-weight-normal","type":"value","value":"500"},{"name":"font-weight-bold","type":"value","value":"700"},{"name":"font-weight-semi-bold","type":"value","value":"600"},{"name":"font-weight-bolder","type":"value","value":"800"},{"name":"font-weight-black","type":"value","value":"900"}]}],"border-radius":[]}}}}
+{
+  "id": "7546cf70-4b38-48be-bcd3-a3dfb35b939f",
+  "name": "medium",
+  "project": {
+    "id": "2961e2d1-3c63-4d98-bd3b-302fbd35972b",
+    "short_id": "brown_sebulba_agreed_baboon",
+    "emoji": "🙌",
+    "name": "Untitled",
+    "description": null,
+    "custom_domains": false,
+    "type": "app",
+    "published_at": null,
+    "thumbnail": null,
+    "accounts": {
+      "id": "f9e6ee17-c6b2-4cf5-9d67-0e3cba39d2a3",
+      "name": "erik-test-org",
+      "account_plans": { "plans": { "custom_domains": false } }
+    }
+  },
+  "commit": "9e43025ae4602ebb344862502220b8fc4e0d2bde",
+  "files": {
+    "components": {
+      "HomePage": {
+        "apis": {
+          "WOW API": {
+            "url": {
+              "type": "value",
+              "value": "https://owen-wilson-wow-api.onrender.com"
+            },
+            "name": "WOW API",
+            "path": {
+              "8dyQhOhHDyfv-BskOoSks": {
+                "index": 1,
+                "formula": { "type": "value", "value": "random" }
+              },
+              "IbdbGqON7MJvvmNOO1TAg": {
+                "index": 0,
+                "formula": { "type": "value", "value": "wows" }
+              }
+            },
+            "type": "http",
+            "client": {},
+            "inputs": {},
+            "method": "GET",
+            "server": {
+              "ssr": {
+                "enabled": { "formula": { "type": "value", "value": true } }
+              },
+              "proxy": {
+                "enabled": { "formula": { "type": "value", "value": false } }
+              }
+            },
+            "headers": {},
+            "isError": {},
+            "timeout": {},
+            "version": 2,
+            "autoFetch": { "type": "value", "value": true },
+            "queryParams": {},
+            "redirectRules": {}
+          }
+        },
+        "name": "HomePage",
+        "nodes": {
+          "root": {
+            "tag": "div",
+            "type": "element",
+            "attrs": {},
+            "style": {
+              "gap": "8px",
+              "color": "var(--grey-200, #E5E5E5)",
+              "min-height": "100%",
+              "align-items": "center",
+              "justify-content": "center",
+              "background-color": "var(--grey-900)"
+            },
+            "events": {},
+            "classes": {},
+            "children": [
+              "p44ree-FsxJKSeiWKWQpa",
+              "D3FDz9GhM-ZyJChwJhxzK",
+              "pK1rq0usjmjwt2RZhiTFV",
+              "9cdB1ieO8k-D0guvB5q6d",
+              "co7vEt15EK6qGAVA2PGaM"
+            ],
+            "styleVariables": {}
+          },
+          "9cdB1ieO8k-D0guvB5q6d": {
+            "tag": "button",
+            "type": "element",
+            "attrs": {},
+            "style": {
+              "color": "var(--grey-200, #E5E5E5)",
+              "width": "fit-content",
+              "cursor": "pointer",
+              "padding-top": "8px",
+              "padding-left": "8px",
+              "border-radius": "6px",
+              "padding-right": "8px",
+              "padding-bottom": "8px",
+              "background-color": "var(--blue-600, #2563EB)"
+            },
+            "events": {},
+            "classes": {},
+            "children": ["RGFpys0-7b_IQ8SYApMAL"],
+            "variants": [
+              {
+                "hover": true,
+                "style": { "background-color": "var(--blue-500, #3B82F6)" }
+              }
+            ],
+            "condition": {
+              "name": "@toddle/equals",
+              "type": "function",
+              "label": null,
+              "arguments": [
+                {
+                  "name": "First",
+                  "type": { "type": "Any" },
+                  "formula": {
+                    "path": ["URL parameters", "test"],
+                    "type": "path",
+                    "label": null
+                  }
+                },
+                {
+                  "name": "Second",
+                  "type": { "type": "Any" },
+                  "formula": { "type": "value", "value": null }
+                }
+              ],
+              "display_name": "Equals"
+            },
+            "styleVariables": {}
+          },
+          "EEfz_0R8BhOvKve4YgCi6": {
+            "type": "text",
+            "value": {
+              "name": "@toddle/concatenate",
+              "type": "function",
+              "arguments": [
+                {
+                  "name": "0",
+                  "type": {
+                    "type": "Union",
+                    "types": [
+                      { "type": "String" },
+                      { "type": "Array", "ofType": { "type": "Any" } }
+                    ]
+                  },
+                  "formula": { "type": "value", "value": "Wow API: " }
+                },
+                {
+                  "name": "0",
+                  "type": {
+                    "type": "Union",
+                    "types": [
+                      { "type": "String" },
+                      { "type": "Array", "ofType": { "type": "Any" } }
+                    ]
+                  },
+                  "formula": {
+                    "path": ["Apis", "WOW API", "data", "0", "movie"],
+                    "type": "path"
+                  }
+                }
+              ],
+              "display_name": "Concatenate",
+              "variableArguments": true
+            }
+          },
+          "RGFpys0-7b_IQ8SYApMAL": {
+            "type": "text",
+            "value": {
+              "type": "value",
+              "value": "Element which is only visible when \"test\" query parameter doesn't have a value"
+            }
+          },
+          "c8DBGzXyJIHSfoguEo7OL": {
+            "type": "text",
+            "value": { "type": "value", "value": "Hello world" }
+          },
+          "co7vEt15EK6qGAVA2PGaM": {
+            "tag": "p",
+            "type": "element",
+            "attrs": {},
+            "style": { "color": "inherit", "display": "inline-block" },
+            "events": {},
+            "classes": {},
+            "children": ["EEfz_0R8BhOvKve4YgCi6"],
+            "styleVariables": {}
+          },
+          "p44ree-FsxJKSeiWKWQpa": {
+            "tag": "h1",
+            "type": "element",
+            "attrs": {},
+            "style": {
+              "color": "var(--grey-200, #E5E5E5)",
+              "font-size": "2.25rem",
+              "font-weight": "var(--font-weight-bold)"
+            },
+            "events": {},
+            "classes": {},
+            "children": ["c8DBGzXyJIHSfoguEo7OL"],
+            "styleVariables": {}
+          },
+          "pK1rq0usjmjwt2RZhiTFV": {
+            "tag": "p",
+            "type": "element",
+            "attrs": {},
+            "style": { "color": "inherit", "display": "inline-block" },
+            "events": {},
+            "classes": {},
+            "children": ["vnERXXaHU1zd6Jz79Ry5I"],
+            "styleVariables": {}
+          },
+          "vnERXXaHU1zd6Jz79Ry5I": {
+            "type": "text",
+            "value": { "path": ["URL parameters", "q"], "type": "path" }
+          },
+          "D3FDz9GhM-ZyJChwJhxzK": {
+            "tag": "p",
+            "type": "element",
+            "attrs": {},
+            "style": { "color": "inherit", "display": "inline-block" },
+            "events": {},
+            "classes": {},
+            "children": ["z5I8Rnxfdy2McmsNLlMhD"],
+            "styleVariables": {}
+          },
+          "z5I8Rnxfdy2McmsNLlMhD": {
+            "type": "text",
+            "value": {
+              "type": "function",
+              "name": "@toddle/concatenate",
+              "arguments": [
+                {
+                  "name": "0",
+                  "formula": { "type": "value", "value": "Calculated value: " },
+                  "type": {
+                    "type": "Union",
+                    "types": [
+                      { "type": "String" },
+                      { "type": "Array", "ofType": { "type": "Any" } }
+                    ]
+                  }
+                },
+                {
+                  "name": "0",
+                  "formula": {
+                    "type": "function",
+                    "name": "@toddle/formatDate",
+                    "arguments": [
+                      {
+                        "name": "Date",
+                        "formula": {
+                          "type": "function",
+                          "name": "@toddle/now",
+                          "arguments": [],
+                          "display_name": "Now"
+                        },
+                        "type": { "type": "Date" }
+                      },
+                      {
+                        "name": "Locale(s)",
+                        "formula": { "type": "value", "value": null },
+                        "type": { "type": "String | Array" }
+                      },
+                      {
+                        "name": "Options",
+                        "formula": {
+                          "type": "object",
+                          "arguments": [
+                            {
+                              "Name": 0,
+                              "formula": { "type": "value", "value": "short" },
+                              "name": "timeFormat"
+                            },
+                            {
+                              "Name": 0,
+                              "formula": { "type": "value", "value": "short" },
+                              "name": "dateFormat"
+                            }
+                          ]
+                        },
+                        "type": { "type": "Object" }
+                      }
+                    ],
+                    "display_name": "Format Date"
+                  },
+                  "type": {
+                    "type": "Union",
+                    "types": [
+                      { "type": "String" },
+                      { "type": "Array", "ofType": { "type": "Any" } }
+                    ]
+                  }
+                },
+                {
+                  "name": "0",
+                  "formula": { "type": "value", "value": " and 4 + 9 is: " },
+                  "type": {
+                    "type": "Union",
+                    "types": [
+                      { "type": "String" },
+                      { "type": "Array", "ofType": { "type": "Any" } }
+                    ]
+                  }
+                },
+                {
+                  "name": "0",
+                  "formula": {
+                    "type": "function",
+                    "name": "@toddle/sum",
+                    "arguments": [
+                      {
+                        "name": "Array",
+                        "formula": {
+                          "type": "array",
+                          "arguments": [
+                            {
+                              "Name": 0,
+                              "formula": { "type": "value", "value": 4 }
+                            },
+                            {
+                              "Name": 0,
+                              "formula": { "type": "value", "value": 9 }
+                            }
+                          ]
+                        },
+                        "type": { "type": "Array" }
+                      }
+                    ],
+                    "display_name": "Sum"
+                  },
+                  "type": {
+                    "type": "Union",
+                    "types": [
+                      { "type": "String" },
+                      { "type": "Array", "ofType": { "type": "Any" } }
+                    ]
+                  }
+                }
+              ],
+              "variableArguments": true,
+              "display_name": "Concatenate"
+            }
+          }
+        },
+        "route": {
+          "info": {
+            "title": {
+              "formula": { "type": "value", "value": "Toddle template" }
+            },
+            "description": {
+              "formula": {
+                "type": "value",
+                "value": "A blank template from toddle"
+              }
+            }
+          },
+          "path": [],
+          "query": {
+            "q": { "name": "q", "testValue": "search" },
+            "test": { "name": "test", "testValue": "test" }
+          }
+        },
+        "events": [],
+        "onLoad": { "actions": [], "trigger": "load" },
+        "functions": {},
+        "variables": {},
+        "attributes": {}
+      }
+    },
+    "actions": {},
+    "formulas": {},
+    "config": {},
+    "packages": {},
+    "themes": {
+      "Default": {
+        "color": [
+          {
+            "name": "grey",
+            "tokens": [
+              { "name": "grey-50", "type": "value", "value": "#FAFAFA" },
+              { "name": "grey-100", "type": "value", "value": "#F5F5F5" },
+              { "name": "grey-200", "type": "value", "value": "#E5E5E5" },
+              { "name": "grey-300", "type": "value", "value": "#D4D4D4" },
+              { "name": "grey-400", "type": "value", "value": "#A3A3A3" },
+              { "name": "grey-500", "type": "value", "value": "#737373" },
+              { "name": "grey-600", "type": "value", "value": "#525252" },
+              { "name": "grey-700", "type": "value", "value": "#404040" },
+              { "name": "grey-800", "type": "value", "value": "#262626" },
+              { "name": "grey-900", "type": "value", "value": "#171717" }
+            ]
+          },
+          {
+            "name": "red",
+            "tokens": [
+              { "name": "red-50", "type": "value", "value": "#FEF2F2" },
+              { "name": "red-100", "type": "value", "value": "#FEE2E2" },
+              { "name": "red-200", "type": "value", "value": "#FECACA" },
+              { "name": "red-300", "type": "value", "value": "#FCA5A5" },
+              { "name": "red-400", "type": "value", "value": "#F87171" },
+              { "name": "red-500", "type": "value", "value": "#EF4444" },
+              { "name": "red-600", "type": "value", "value": "#DC2626" },
+              { "name": "red-700", "type": "value", "value": "#B91C1C" },
+              { "name": "red-800", "type": "value", "value": "#991B1B" },
+              { "name": "red-900", "type": "value", "value": "#7F1D1D" }
+            ]
+          },
+          {
+            "name": "blue",
+            "tokens": [
+              { "name": "blue-50", "type": "value", "value": "#EFF6FF" },
+              { "name": "blue-100", "type": "value", "value": "#DBEAFE" },
+              { "name": "blue-200", "type": "value", "value": "#BFDBFE" },
+              { "name": "blue-300", "type": "value", "value": "#93C5FD" },
+              { "name": "blue-400", "type": "value", "value": "#60A5FA" },
+              { "name": "blue-500", "type": "value", "value": "#3B82F6" },
+              { "name": "blue-600", "type": "value", "value": "#2563EB" },
+              { "name": "blue-700", "type": "value", "value": "#1D4ED8" },
+              { "name": "blue-800", "type": "value", "value": "#1E40AF" },
+              { "name": "blue-900", "type": "value", "value": "#1E3A8A" }
+            ]
+          },
+          {
+            "name": "lime",
+            "tokens": [
+              { "name": "lime-50", "type": "value", "value": "#F7FEE7" },
+              { "name": "lime-100", "type": "value", "value": "#ECFCCB" },
+              { "name": "lime-200", "type": "value", "value": "#D9F99D" },
+              { "name": "lime-300", "type": "value", "value": "#BEF264" },
+              { "name": "lime-400", "type": "value", "value": "#A3E635" },
+              { "name": "lime-500", "type": "value", "value": "#84CC16" },
+              { "name": "lime-600", "type": "value", "value": "#65A30D" },
+              { "name": "lime-700", "type": "value", "value": "#4D7C0F" },
+              { "name": "lime-800", "type": "value", "value": "#3F6212" },
+              { "name": "lime-900", "type": "value", "value": "#365314" }
+            ]
+          },
+          {
+            "name": "pink",
+            "tokens": [
+              { "name": "pink-50", "type": "value", "value": "#FDF2F8" },
+              { "name": "pink-100", "type": "value", "value": "#FCE7F3" },
+              { "name": "pink-200", "type": "value", "value": "#FBCFE8" },
+              { "name": "pink-300", "type": "value", "value": "#F9A8D4" },
+              { "name": "pink-400", "type": "value", "value": "#F472B6" },
+              { "name": "pink-500", "type": "value", "value": "#EC4899" },
+              { "name": "pink-600", "type": "value", "value": "#DB2777" },
+              { "name": "pink-700", "type": "value", "value": "#BE185D" },
+              { "name": "pink-800", "type": "value", "value": "#9D174D" },
+              { "name": "pink-900", "type": "value", "value": "#831843" }
+            ]
+          },
+          {
+            "name": "teal",
+            "tokens": [
+              { "name": "teal-50", "type": "value", "value": "#F0FDFA" },
+              { "name": "teal-100", "type": "value", "value": "#CCFBF1" },
+              { "name": "teal-200", "type": "value", "value": "#99F6E4" },
+              { "name": "teal-300", "type": "value", "value": "#5EEAD4" },
+              { "name": "teal-400", "type": "value", "value": "#2DD4BF" },
+              { "name": "teal-500", "type": "value", "value": "#14B8A6" },
+              { "name": "teal-600", "type": "value", "value": "#0D9488" },
+              { "name": "teal-700", "type": "value", "value": "#0F766E" },
+              { "name": "teal-800", "type": "value", "value": "#115E59" },
+              { "name": "teal-900", "type": "value", "value": "#134E4A" }
+            ]
+          },
+          {
+            "name": "green",
+            "tokens": [
+              { "name": "green-50", "type": "value", "value": "#ECFDF5" },
+              { "name": "green-100", "type": "value", "value": "#D1FAE5" },
+              { "name": "green-200", "type": "value", "value": "#A7F3D0" },
+              { "name": "green-300", "type": "value", "value": "#6EE7B7" },
+              { "name": "green-400", "type": "value", "value": "#34D399" },
+              { "name": "green-500", "type": "value", "value": "#10B981" },
+              { "name": "green-600", "type": "value", "value": "#059669" },
+              { "name": "green-700", "type": "value", "value": "#047857" },
+              { "name": "green-800", "type": "value", "value": "#065F46" },
+              { "name": "green-900", "type": "value", "value": "#064E3B" }
+            ]
+          },
+          {
+            "name": "purple",
+            "tokens": [
+              { "name": "purple-50", "type": "value", "value": "#F5F3FF" },
+              { "name": "purple-100", "type": "value", "value": "#EDE9FE" },
+              { "name": "purple-200", "type": "value", "value": "#DDD6FE" },
+              { "name": "purple-300", "type": "value", "value": "#C4B5FD" },
+              { "name": "purple-400", "type": "value", "value": "#A78BFA" },
+              { "name": "purple-500", "type": "value", "value": "#8B5CF6" },
+              { "name": "purple-600", "type": "value", "value": "#7C3AED" },
+              { "name": "purple-700", "type": "value", "value": "#6D28D9" },
+              { "name": "purple-800", "type": "value", "value": "#5B21B6" },
+              { "name": "purple-900", "type": "value", "value": "#4C1D95" }
+            ]
+          },
+          {
+            "name": "yellow",
+            "tokens": [
+              { "name": "yellow-50", "type": "value", "value": "#FFFBEB" },
+              { "name": "yellow-100", "type": "value", "value": "#FEF3C7" },
+              { "name": "yellow-200", "type": "value", "value": "#FDE68A" },
+              { "name": "yellow-300", "type": "value", "value": "#FCD34D" },
+              { "name": "yellow-400", "type": "value", "value": "#FBBF24" },
+              { "name": "yellow-500", "type": "value", "value": "#F59E0B" },
+              { "name": "yellow-600", "type": "value", "value": "#D97706" },
+              { "name": "yellow-700", "type": "value", "value": "#B45309" },
+              { "name": "yellow-800", "type": "value", "value": "#92400E" },
+              { "name": "yellow-900", "type": "value", "value": "#78350F" }
+            ]
+          }
+        ],
+        "fonts": [
+          {
+            "name": "sans",
+            "type": "sans-serif",
+            "family": "Inter",
+            "provider": "google",
+            "variants": [
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyeMZ1rib2Bg-4.woff2",
+                "name": "100",
+                "italic": false,
+                "weight": "100"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyfMZ1rib2Bg-4.woff2",
+                "name": "200",
+                "italic": false,
+                "weight": "200"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuOKfMZ1rib2Bg-4.woff2",
+                "name": "300",
+                "italic": false,
+                "weight": "300"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfMZ1rib2Bg-4.woff2",
+                "name": "regular",
+                "italic": false,
+                "weight": "400"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuI6fMZ1rib2Bg-4.woff2",
+                "name": "500",
+                "italic": false,
+                "weight": "500"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuGKYMZ1rib2Bg-4.woff2",
+                "name": "600",
+                "italic": false,
+                "weight": "600"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuFuYMZ1rib2Bg-4.woff2",
+                "name": "700",
+                "italic": false,
+                "weight": "700"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyYMZ1rib2Bg-4.woff2",
+                "name": "800",
+                "italic": false,
+                "weight": "800"
+              },
+              {
+                "url": "https://fonts.gstatic.com/s/inter/v12/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuBWYMZ1rib2Bg-4.woff2",
+                "name": "900",
+                "italic": false,
+                "weight": "900"
+              }
+            ]
+          }
+        ],
+        "scheme": "dark",
+        "shadow": [
+          {
+            "name": "Default",
+            "tokens": [
+              {
+                "name": "shadow-sm",
+                "type": "value",
+                "value": " 0 1px 2px 0 rgba(0, 0, 0, 0.25)"
+              },
+              {
+                "name": "shadow-base",
+                "type": "value",
+                "value": " 0 1px 3px 0 rgba(0, 0, 0, 0.25), 0 1px 2px 0 rgba(0, 0, 0, 0.25)"
+              },
+              {
+                "name": "shadow-md",
+                "type": "value",
+                "value": " 0 4px 6px -1px rgba(0, 0, 0, 0.25), 0 2px 4px -1px rgba(0, 0, 0, 0.25)"
+              },
+              {
+                "name": "shadow-lg",
+                "type": "value",
+                "value": " 0 10px 15px -3px rgba(0, 0, 0, 0.25), 0 4px 6px -2px rgba(0, 0, 0, 0.25)"
+              },
+              {
+                "name": "shadow-xl",
+                "type": "value",
+                "value": "0 20px 25px -5px rgba(0, 0, 0, 0.25), 0 10px 10px -5px rgba(0, 0, 0, 0.25)"
+              },
+              {
+                "name": "shadow-2xl",
+                "type": "value",
+                "value": " 0 25px 50px -12px rgba(0, 0, 0, 0.25)"
+              }
+            ]
+          }
+        ],
+        "spacing": [],
+        "z-index": [],
+        "font-size": [
+          {
+            "name": "Default",
+            "tokens": [
+              { "name": "font-size-xxs", "type": "value", "value": "0.625rem" },
+              { "name": "font-size-xs", "type": "value", "value": "0.75rem" },
+              { "name": "font-size-sm", "type": "value", "value": "0.875rem" },
+              { "name": "font-size-base", "type": "value", "value": "1rem" },
+              { "name": "font-size-lg", "type": "value", "value": "1.125rem" },
+              { "name": "font-size-xl", "type": "value", "value": "1.25rem" },
+              { "name": "font-size-2xl", "type": "value", "value": "1.5rem" },
+              { "name": "font-size-3xl", "type": "value", "value": "1.875rem" },
+              { "name": "font-size-4xl", "type": "value", "value": "2.25rem" },
+              { "name": "font-size-5xl", "type": "value", "value": "3rem" }
+            ]
+          }
+        ],
+        "font-weight": [
+          {
+            "name": "Default",
+            "tokens": [
+              { "name": "font-weight-thin", "type": "value", "value": "100" },
+              {
+                "name": "font-weight-lighter",
+                "type": "value",
+                "value": "200"
+              },
+              { "name": "font-weight-light", "type": "value", "value": "300" },
+              {
+                "name": "font-weight-regular",
+                "type": "value",
+                "value": "400"
+              },
+              { "name": "font-weight-normal", "type": "value", "value": "500" },
+              { "name": "font-weight-bold", "type": "value", "value": "700" },
+              {
+                "name": "font-weight-semi-bold",
+                "type": "value",
+                "value": "600"
+              },
+              { "name": "font-weight-bolder", "type": "value", "value": "800" },
+              { "name": "font-weight-black", "type": "value", "value": "900" }
+            ]
+          }
+        ],
+        "border-radius": []
+      }
+    }
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/core",
-  "version": "0.0.2-alpha.14",
+  "version": "0.0.2-alpha.15",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "dependencies": {

--- a/packages/core/src/formula/formula.ts
+++ b/packages/core/src/formula/formula.ts
@@ -103,7 +103,7 @@ export type FormulaContext = {
   data: ComponentData
   root?: Document | ShadowRoot | null
   package: string | undefined
-  toddle?: {
+  toddle: {
     getFormula: FormulaLookup
     getCustomFormula: CustomFormulaHandler
   }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/std-lib",
-  "version": "0.0.1-alpha.5",
+  "version": "0.0.1-alpha.6",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "dependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/runtime",
-  "version": "0.0.1-alpha.9",
+  "version": "0.0.1-alpha.10",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "dependencies": {

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toddledev/search",
   "description": "Used for searching and reporting linting problems in toddle projects.",
-  "version": "0.0.1-alpha.11",
+  "version": "0.0.1-alpha.12",
   "license": "Apache-2.0",
   "dependencies": {
     "@toddledev/ssr": "workspace:*"

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/ssr",
-  "version": "0.0.2-alpha.14",
+  "version": "0.0.2-alpha.15",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "scripts": {

--- a/packages/ssr/src/rendering/attributes.ts
+++ b/packages/ssr/src/rendering/attributes.ts
@@ -3,7 +3,11 @@ import type {
   ComponentData,
   ElementNodeModel,
 } from '@toddledev/core/dist/component/component.types'
-import { applyFormula, ToddleEnv } from '@toddledev/core/dist/formula/formula'
+import {
+  applyFormula,
+  FormulaContext,
+  ToddleEnv,
+} from '@toddledev/core/dist/formula/formula'
 import { isDefined, toBoolean } from '@toddledev/core/dist/utils/util'
 
 const REGEXP_QUOTE = /"/g
@@ -46,12 +50,14 @@ export function getNodeAttrs({
   component,
   packageName,
   env,
+  toddle,
 }: {
   node: Pick<ElementNodeModel, 'attrs' | 'style-variables'>
   data: ComponentData
   component: Component
   packageName: string | undefined
   env: ToddleEnv
+  toddle: FormulaContext['toddle']
 }) {
   const { style, ...restAttrs } = node.attrs
   const nodeAttrs = Object.entries(restAttrs).reduce<string[]>(
@@ -61,6 +67,7 @@ export function getNodeAttrs({
         component,
         package: packageName,
         env,
+        toddle,
       })
       if (toBoolean(value)) {
         appliedAttributes.push(`${name}="${escapeAttrValue(value)}"`)
@@ -78,6 +85,7 @@ export function getNodeAttrs({
             component,
             package: packageName,
             env,
+            toddle,
           }),
         ) + (unit ?? '')
       }`,
@@ -92,6 +100,7 @@ export function getNodeAttrs({
             component,
             package: packageName,
             env,
+            toddle,
           }),
         ]
       : []),

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -30,6 +30,7 @@ const renderComponent = async ({
   env,
   evaluateComponentApis,
   files,
+  toddle,
   includedComponents,
   instance,
   packageName,
@@ -44,6 +45,7 @@ const renderComponent = async ({
   env: ToddleServerEnv
   evaluateComponentApis: ApiEvaluator
   files: ProjectFiles
+  toddle: FormulaContext['toddle']
   includedComponents: Component[]
   instance: Record<string, string>
   packageName: string | undefined
@@ -72,6 +74,7 @@ const renderComponent = async ({
       component,
       package: packageName,
       env,
+      toddle,
     }
     if (node.repeat) {
       const items = applyFormula(node.repeat, formulaContext)
@@ -138,6 +141,7 @@ const renderComponent = async ({
           component,
           packageName,
           env,
+          toddle,
         })
         const classHash = getClassName([node.style, node.variants])
         let classList = Object.entries(node.classes)
@@ -277,6 +281,7 @@ const renderComponent = async ({
             package:
               node.package ?? (isLocalComponent ? undefined : packageName),
             env,
+            toddle,
           },
           req,
           apiCache,
@@ -318,6 +323,7 @@ const renderComponent = async ({
                                       component,
                                       package: _packageName,
                                       env,
+                                      toddle,
                                     }),
                                   ]),
                               ),
@@ -334,11 +340,13 @@ const renderComponent = async ({
                                   component,
                                   package: _packageName,
                                   env,
+                                  toddle,
                                 })
                               },
                             ),
                           },
                           env,
+                          toddle,
                         }),
                       ]),
                   ),
@@ -460,19 +468,20 @@ const createComponent = async ({
   }
 
   return renderComponent({
+    apiCache,
+    children,
     component,
     data,
-    children,
-    packageName,
-    instance,
     env,
-    includedComponents,
-    apiCache,
-    updateApiCache,
-    files,
-    projectId,
     evaluateComponentApis,
+    files,
+    includedComponents,
+    instance,
+    packageName,
+    projectId,
     req,
+    toddle: formulaContext.toddle,
+    updateApiCache,
   })
 }
 
@@ -511,18 +520,19 @@ export const renderPageBody = async ({
   formulaContext.data.Apis = apis
 
   const html = await renderComponent({
+    apiCache,
     component,
     data: formulaContext.data,
-    packageName: undefined,
-    instance: {},
     env,
+    evaluateComponentApis,
     files,
     includedComponents,
-    req,
-    apiCache,
-    updateApiCache,
-    evaluateComponentApis,
+    instance: {},
+    packageName: undefined,
     projectId,
+    req,
+    toddle: formulaContext.toddle,
+    updateApiCache,
   })
   return { html, apiCache }
 }


### PR DESCRIPTION
This fixes an issue where global formulas were missing during SSR since the `toddle` object was not available on the `FormulaContext` object.