### PR TITLE
Allow toddle scope override away from window

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toddledev/runtime",
-  "version": "0.0.1-alpha.10",
+  "version": "0.0.1-alpha.11",
   "license": "Apache-2.0",
   "homepage": "https://github.com/toddledev/toddle",
   "dependencies": {

--- a/packages/runtime/src/custom-element.main.ts.ts
+++ b/packages/runtime/src/custom-element.main.ts.ts
@@ -3,12 +3,12 @@ import * as libFormulas from '@toddledev/std-lib/dist/formulas'
 import fastDeepEqual from 'fast-deep-equal'
 import { defineComponents } from './custom-element/defineComponents'
 
-const loadCorePlugins = () => {
-  window.toddle.isEqual = fastDeepEqual
+const loadCorePlugins = (toddle = window.toddle) => {
+  toddle.isEqual = fastDeepEqual
 
   // load default formulas and actions
   Object.entries(libFormulas).forEach(([name, module]) =>
-    window.toddle.registerFormula(
+    toddle.registerFormula(
       '@toddle/' + name,
       module.default as any,
       'getArgumentInputData' in module
@@ -17,7 +17,7 @@ const loadCorePlugins = () => {
     ),
   )
   Object.entries(libActions).forEach(([name, module]) =>
-    window.toddle.registerAction('@toddle/' + name, module.default),
+    toddle.registerAction('@toddle/' + name, module.default),
   )
 }
 


### PR DESCRIPTION
This will allow us to decide which toddle object we want to populate with lib formulas/actions. I will add a PR for toddle-internal to instead use a locally scoped object rather than `window.toddle`