### PR TITLE
Use a BatchQueue for the component lifecycle callback

### DIFF
--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -14,6 +14,7 @@ import {
   LocationSignal,
   PreviewShowSignal,
 } from '../types'
+import { BatchQueue } from '../utils/BatchQueue'
 import { createNode } from './createNode'
 
 interface RenderComponentProps {
@@ -42,6 +43,8 @@ interface RenderComponentProps {
   toddle: Toddle<LocationSignal, PreviewShowSignal>
   env: ToddleEnv
 }
+
+const BATCH_QUEUE = new BatchQueue()
 
 export function renderComponent({
   component,
@@ -87,8 +90,7 @@ export function renderComponent({
     parentElement,
     instance,
   })
-
-  requestAnimationFrame(() => {
+  BATCH_QUEUE.add(() => {
     let prev: Record<string, any> | undefined
     if (
       component.onAttributeChange?.actions &&

--- a/packages/runtime/src/utils/BatchQueue.ts
+++ b/packages/runtime/src/utils/BatchQueue.ts
@@ -1,0 +1,25 @@
+/**
+ * A helper class to batch multiple callbacks and process them in a single tick.
+ * This is more efficient than processing each callback in a separate tick, as creating a new tick is expensive.
+ * It also allows batching DOM updates, which can help to reduce layout thrashing.
+ */
+export class BatchQueue {
+  private batchQueue = new Set<() => void>()
+  private isProcessing = false
+
+  private processBatch() {
+    if (this.isProcessing) return
+    this.isProcessing = true
+
+    setTimeout(() => {
+      this.batchQueue.forEach((callback) => callback())
+      this.batchQueue.clear()
+      this.isProcessing = false
+    })
+  }
+
+  public add(callback: () => void) {
+    this.batchQueue.add(callback)
+    this.processBatch()
+  }
+}


### PR DESCRIPTION
I looked into Spark and the Editor for some performance improvements. Simply registering the ticks via. multiple (481 on spark) took 41ms, and then running each update in a different tick added an additional ~100ms.

On the toddle editor this change seems to reduce startup scripting time from 1653ms -> 1258ms (24% improvement) and should also benefit show/hide and dynamic repeats.

This is not enough on its own to get Spark a green lighthouse score, but it should help a bit.

Pretty average snapshot of render flamegraph. Each of the yellow fields was the allocation (not actually running the callback) to requestAnimationFrame. This is essentially 0ms after this update.

![CleanShot 2025-01-17 at 14 04 06@2x](https://github.com/user-attachments/assets/df15b6a8-1a39-455c-9787-6b81865c860d)

83 microseconds called 418 times is ~40ms