### PR TITLE
Remove more uses of global toddle object

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.5",
+  "version": "0.0.3-alpha.6",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/api/createAPI.ts
+++ b/packages/runtime/src/api/createAPI.ts
@@ -320,7 +320,7 @@ export function createLegacyAPI(
         // we don't fetch data for component APIs during SSR
         if (firstRun && ctx.isRootComponent) {
           firstRun = false
-          const cached = window.toddle?.pageState?.Apis?.[api.name]
+          const cached = ctx.toddle?.pageState?.Apis?.[api.name]
           if (cached && cached.data) {
             if (typeof cached.data === 'string') {
               // Mimic the behavior from getBody and parse

--- a/packages/runtime/src/api/createAPIv2.ts
+++ b/packages/runtime/src/api/createAPIv2.ts
@@ -741,7 +741,7 @@ export function createAPI(
       if ((window?.__toddle?.isPageLoaded ?? false) === false) {
         const { url, requestSettings } = constructRequest(api)
         const cacheKey = requestHash(url, requestSettings)
-        const cacheMatch = window.toddle.pageState.Apis?.[cacheKey] as ApiStatus
+        const cacheMatch = ctx.toddle.pageState.Apis?.[cacheKey] as ApiStatus
         if (cacheMatch) {
           if (cacheMatch.error) {
             apiError(

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -96,9 +96,9 @@ export function createElement({
     if (
       attr === 'autofocus' &&
       ctx.env.runtime === 'preview' &&
-      window.toddle._preview
+      ctx.toddle._preview
     ) {
-      window.toddle._preview.showSignal.subscribe(({ testMode }) => {
+      ctx.toddle._preview.showSignal.subscribe(({ testMode }) => {
         if (testMode) {
           setupAttribute()
         } else {

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -143,8 +143,8 @@ export function createNode({
         childDataSignal?.destroy()
       },
     })
-    if (ctx.env.runtime === 'preview' && window.toddle._preview) {
-      window.toddle._preview.showSignal.subscribe(
+    if (ctx.env.runtime === 'preview' && ctx.toddle._preview) {
+      ctx.toddle._preview.showSignal.subscribe(
         ({ displayedNodes, testMode }) => {
           if (displayedNodes.includes(path) && !testMode) {
             // only override the default show if we are in design mode (not test mode)

--- a/packages/runtime/src/context/subscribeToContext.ts
+++ b/packages/runtime/src/context/subscribeToContext.ts
@@ -53,7 +53,7 @@ export function subscribeToContext(
       else if (
         !provider &&
         ctx.env.runtime === 'preview' &&
-        window.toddle._preview
+        ctx.toddle._preview
       ) {
         const testProvider = ctx.components?.find(
           (comp) =>

--- a/packages/runtime/src/events/handleAction.ts
+++ b/packages/runtime/src/events/handleAction.ts
@@ -79,7 +79,7 @@ export function handleAction(
         break
       }
       case 'SetURLParameter': {
-        window.toddle.locationSignal.update((current) => {
+        ctx.toddle.locationSignal.update((current) => {
           const value = applyFormula(action.data, {
             data,
             component: ctx.component,
@@ -253,7 +253,7 @@ export function handleAction(
           }
           const newAction =
             action.version === 2
-              ? (ctx.toddle.getCustomAction ?? window.toddle.getCustomAction)(
+              ? (ctx.toddle.getCustomAction ?? ctx.toddle.getCustomAction)(
                   action.name,
                   action.package ?? ctx.package,
                 )
@@ -310,7 +310,7 @@ export function handleAction(
 
             return result
           } else {
-            const legacyHandler = window.toddle.getAction(action.name)
+            const legacyHandler = ctx.toddle.getAction(action.name)
             if (!legacyHandler) {
               console.error('Missing custom action', action.name)
               return

--- a/packages/runtime/src/utils/getElementTagName.ts
+++ b/packages/runtime/src/utils/getElementTagName.ts
@@ -7,7 +7,7 @@ export function getElementTagName(
   id: string,
 ) {
   if (ctx.component.version === 2 && id === 'root') {
-    return `${ctx.package ?? window.toddle.project}-${node.tag}`
+    return `${ctx.package ?? ctx.toddle.project}-${node.tag}`
   }
 
   return node.tag


### PR DESCRIPTION
This should fix an issue with custom elements trying to access `window.toddle`