### PR TITLE
Adjust destination types to mimic API definitions

### DIFF
--- a/examples/projects/route.json
+++ b/examples/projects/route.json
@@ -84,14 +84,31 @@
     "config": {},
     "packages": {},
     "routes": {
-      "a": {
+      "myRoute": {
         "source": {
           "path": [{ "type": "static", "name": "test" }]
         },
         "destination": {
-          "formula": {
+          "url": {
             "type": "value",
             "value": "https://toddle.dev"
+          },
+          "path": {
+            "xyz": {
+              "formula": {
+                "type": "value",
+                "value": "docs"
+              },
+              "index": 0
+            }
+          },
+          "queryParams": {
+            "utm_source": {
+              "formula": {
+                "type": "value",
+                "value": "toddle"
+              }
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.7",
+  "version": "0.0.3-alpha.8",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -3,6 +3,7 @@ import { omitKeys, sortObjectEntries } from '../utils/collections'
 import { hash } from '../utils/hash'
 import { isDefined, isObject, toBoolean } from '../utils/util'
 import {
+  ApiBase,
   ApiMethod,
   ApiPerformance,
   ApiRequest,
@@ -41,8 +42,8 @@ export const createApiRequest = <Handler>({
   return { url, requestSettings }
 }
 
-export const getUrl = <Handler>(
-  api: ApiRequest | ToddleApiV2<Handler>,
+export const getUrl = (
+  api: ApiBase,
   formulaContext: FormulaContext,
   baseUrl?: string,
 ): URL => {

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -43,13 +43,21 @@ export enum ApiMethod {
 
 export type RedirectStatusCode = 301 | 302 | 307 | 308
 
-export interface ApiRequest {
+export interface ApiBase {
+  url?: Formula
+  path?: Record<string, { formula: Formula; index: number }>
+  queryParams?: Record<
+    string,
+    // The enabled formula is used to determine if the query parameter should be included in the request or not
+    { formula: Formula; enabled?: Formula | null }
+  >
+}
+
+export interface ApiRequest extends ApiBase {
   version: 2
   name: string
   type: 'http' | 'ws' // The structure for web sockets might look different
   autoFetch?: Formula | null
-  url?: Formula
-  path?: Record<string, { formula: Formula; index: number }>
   headers?: Record<string, { formula: Formula; enabled?: Formula | null }>
   method?: ApiMethod
   body?: Formula
@@ -57,11 +65,6 @@ export interface ApiRequest {
   inputs: Record<string, { formula: Formula }>
   service?: string | null
   servicePath?: string | null
-  queryParams?: Record<
-    string,
-    // The enabled formula is used to determine if the query parameter should be included in the request or not
-    { formula: Formula; enabled?: Formula | null }
-  >
   server?: {
     // We should only accept server side proxy requests if proxy is defined
     proxy?: {

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -1,9 +1,8 @@
+import { getUrl } from '@toddledev/core/dist/api/api'
 import {
   PageComponent,
   PageRoute,
 } from '@toddledev/core/dist/component/component.types'
-import { applyFormula } from '@toddledev/core/dist/formula/formula'
-import { validateUrl } from '@toddledev/core/dist/utils/url'
 import { isDefined } from '@toddledev/core/dist/utils/util'
 import {
   getDataUrlParameters,
@@ -92,9 +91,9 @@ export const getRouteDestination = ({
   req: Request
   route: Route
 }) => {
-  return validateUrl(
-    applyFormula(
-      route.destination.formula,
+  try {
+    return getUrl(
+      route.destination,
       // destination formulas should only have access to URL parameters from
       // the route's source definition. Not from anything else atm.
       {
@@ -106,8 +105,10 @@ export const getRouteDestination = ({
         },
         toddle: getServerToddleObject(files),
       } as any,
-    ),
-  )
+    )
+  } catch {
+    return false
+  }
 }
 
 export const get404Page = (components: ProjectFiles['components']) =>

--- a/packages/ssr/src/ssr.types.ts
+++ b/packages/ssr/src/ssr.types.ts
@@ -1,3 +1,4 @@
+import { ApiBase } from '@toddledev/core/dist/api/apiTypes'
 import type {
   Component,
   RouteDeclaration,
@@ -64,7 +65,5 @@ export interface PluginAction {
 
 export interface Route {
   source: RouteDeclaration
-  destination: {
-    formula: Formula
-  }
+  destination: ApiBase
 }

--- a/packages/ssr/src/ssr.types.ts
+++ b/packages/ssr/src/ssr.types.ts
@@ -1,4 +1,4 @@
-import { ApiBase } from '@toddledev/core/dist/api/apiTypes'
+import type { ApiBase } from '@toddledev/core/dist/api/apiTypes'
 import type {
   Component,
   RouteDeclaration,


### PR DESCRIPTION
To make it easier to setup a destination for a route/rewrite, it's useful to use the same structure that we currently use for API requests. This will also allow us to reuse UI elements on the front-end to better explain the similarities.