### PR TITLE
Make sure BatchQueue time updates to just before next render

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.8",
+  "version": "0.0.3-alpha.9",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/utils/BatchQueue.ts
+++ b/packages/runtime/src/utils/BatchQueue.ts
@@ -1,7 +1,6 @@
 /**
- * A helper class to batch multiple callbacks and process them in a single tick.
- * This is more efficient than processing each callback in a separate tick, as creating a new tick is expensive.
- * It also allows batching DOM updates, which can help to reduce layout thrashing.
+ * A helper class to batch multiple callbacks and process them in a single update step just before the next frame render, but after the current stack.
+ * This is more efficient than processing each callback in a separate requestAnimationFrame due to the overhead.
  */
 export class BatchQueue {
   private batchQueue = new Set<() => void>()
@@ -11,7 +10,7 @@ export class BatchQueue {
     if (this.isProcessing) return
     this.isProcessing = true
 
-    setTimeout(() => {
+    requestAnimationFrame(() => {
       this.batchQueue.forEach((callback) => callback())
       this.batchQueue.clear()
       this.isProcessing = false


### PR DESCRIPTION
This is similar to before when we used requestAnimationFrame instead of setTimeout. My thought, and reason of changing as part of the BatchQueue performance update, was to split the calculations and render to separate frames to cause less freezing of the main thread. However, this change instead caused some jumping of content in some cases for that exact reason. 

For future reference, we should always stick to requestAnimationFrame to ensure updates are applied not immediately, but before the next frame-render.

This fixes an issue where a user saw some repeated lists jump a bit when switching quickly between them.