### PR TITLE
Unknown event rule should look up pckg components

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.9",
+  "version": "0.0.3-alpha.10",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/search/src/rules/unknownEventRule.test.ts
+++ b/packages/search/src/rules/unknownEventRule.test.ts
@@ -38,6 +38,25 @@ describe('unknownEvent', () => {
                   },
                   children: [],
                 },
+                myOtherNode: {
+                  type: 'component',
+                  package: 'my_package',
+                  name: 'package_component',
+                  attrs: {},
+                  events: {
+                    click: {
+                      trigger: 'click',
+                      actions: [
+                        {
+                          type: 'TriggerEvent',
+                          event: 'unknown-event',
+                          data: valueFormula(null),
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
               },
               formulas: {},
               apis: {},
@@ -54,12 +73,39 @@ describe('unknownEvent', () => {
               ],
             },
           },
+          packages: {
+            my_package: {
+              manifest: {
+                commit: 'commit',
+                name: 'my_package',
+              },
+              components: {
+                package_component: {
+                  name: 'package_component',
+                  nodes: {},
+                  formulas: {},
+                  apis: {},
+                  attributes: {},
+                  variables: {},
+                  events: [
+                    {
+                      name: 'known-event',
+                      // eslint-disable-next-line inclusive-language/use-inclusive-words
+                      dummyEvent: {
+                        name: 'Name',
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
         },
         rules: [unknownEventRule],
       }),
     )
 
-    expect(problems).toHaveLength(1)
+    expect(problems).toHaveLength(2)
     expect(problems[0].code).toBe('unknown event')
     expect(problems[0].details).toEqual({ name: 'click' })
     expect(problems[0].path).toEqual([
@@ -107,6 +153,25 @@ describe('unknownEvent', () => {
                   },
                   children: [],
                 },
+                myOtherNode: {
+                  type: 'component',
+                  package: 'my_package',
+                  name: 'package_component',
+                  attrs: {},
+                  events: {
+                    'known-event': {
+                      trigger: 'known-event',
+                      actions: [
+                        {
+                          type: 'TriggerEvent',
+                          event: 'unknown-event',
+                          data: valueFormula(null),
+                        },
+                      ],
+                    },
+                  },
+                  children: [],
+                },
               },
               formulas: {},
               apis: {},
@@ -121,6 +186,33 @@ describe('unknownEvent', () => {
                   },
                 },
               ],
+            },
+          },
+          packages: {
+            my_package: {
+              manifest: {
+                commit: 'commit',
+                name: 'my_package',
+              },
+              components: {
+                package_component: {
+                  name: 'package_component',
+                  nodes: {},
+                  formulas: {},
+                  apis: {},
+                  attributes: {},
+                  variables: {},
+                  events: [
+                    {
+                      name: 'known-event',
+                      // eslint-disable-next-line inclusive-language/use-inclusive-words
+                      dummyEvent: {
+                        name: 'Name',
+                      },
+                    },
+                  ],
+                },
+              },
             },
           },
         },

--- a/packages/search/src/rules/unknownEventRule.ts
+++ b/packages/search/src/rules/unknownEventRule.ts
@@ -16,7 +16,9 @@ export const unknownEventRule: Rule<{
       return
     }
 
-    const component = files.components[value.name]
+    const component = value.package
+      ? files.packages?.[value.package]?.components[value.name]
+      : files.components[value.name]
     const componentEvents = new Set(
       (component?.events ?? []).map((e) => e.name),
     )


### PR DESCRIPTION
The rule would report incorrect results since it wasn't checking the available events in package components.

See reported issue here https://discord.com/channels/972416966683926538/1331948264106491934