### PR TITLE
Initialize variables after context subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.11",
+  "version": "0.0.3-alpha.12",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/signal/signal.ts
+++ b/packages/runtime/src/signal/signal.ts
@@ -17,14 +17,13 @@ export class Signal<T> {
     return this.value
   }
   set(value: T) {
+    this.value = value
     // Short circuit and skip expensive `deepEqual` if there are not currently any subscribers
     if (this.subscribers.size === 0) {
-      this.value = value
       return
     }
 
     if (deepEqual(value, this.value) === false) {
-      this.value = value
       this.subscribers.forEach(({ notify }) => notify(this.value))
     }
   }

--- a/packages/runtime/src/signal/signal.ts
+++ b/packages/runtime/src/signal/signal.ts
@@ -17,13 +17,14 @@ export class Signal<T> {
     return this.value
   }
   set(value: T) {
-    this.value = value
     // Short circuit and skip expensive `deepEqual` if there are not currently any subscribers
     if (this.subscribers.size === 0) {
+      this.value = value
       return
     }
 
     if (deepEqual(value, this.value) === false) {
+      this.value = value
       this.subscribers.forEach(({ notify }) => notify(this.value))
     }
   }

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -448,7 +448,13 @@ const createComponent = async ({
     Attributes: attrs,
     Contexts: contexts,
     Variables: mapValues(component.variables, ({ initialValue }) => {
-      return applyFormula(initialValue, formulaContext)
+      return applyFormula(initialValue, {
+        ...formulaContext,
+        data: {
+          ...formulaContext.data,
+          Contexts: contexts,
+        },
+      })
     }),
     Apis: apis,
   }


### PR DESCRIPTION
This fixes an issue where some users could not use context values in the variables' initial value.

The easy fix was to set the data signal in a few steps, but this could have some overhead as we deep-equal-checked values even before the signal was used. I updated the signal implementation to short circuit if there are no subscribers. This alone seems to have improved performance slightly for many projects. I also changed our signal to use sets instead of arrays to further improve performance when destructing signals (not related and very minor performance improvement).

This should not be breaking in any way, but please test as well 👍 SSR as well

I used this very simple example to test. It should say "value: 5": https://start-harlequin_r5d4_ready_blackbird.toddle.site/