### PR TITLE
Don't allow redirect.source = redirect.destination

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.17",
+  "version": "0.0.3-alpha.18",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -109,9 +109,17 @@ export const getRouteDestination = ({
       // Redirects can redirect to relative URLs - rewrites can't
       route.type === 'redirect' ? requestUrl.origin : undefined,
     )
-    // Rewrites are not allowed from the same origin as the source
-    // This prevents potential recursive fetch calls from the server to itself
+    if (
+      route.type === 'redirect' &&
+      requestUrl.origin === url.origin &&
+      requestUrl.pathname === url.pathname
+    ) {
+      // Redirects are not allowed to redirect to the same URL as their source
+      return
+    }
     if (route.type === 'rewrite' && requestUrl.origin === url.origin) {
+      // Rewrites are not allowed from the same origin as the source
+      // This prevents potential recursive fetch calls from the server to itself
       return
     }
     return url


### PR DESCRIPTION
It should not be possible to create a redirect that points to itself.