### PR TITLE
Make URL parsing more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.18",
+  "version": "0.0.3-alpha.19",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -131,6 +131,50 @@ describe('getUrl()', () => {
     )
     expect(url.href).toBe('https://example.com/test/path/hello/world')
   })
+  test('numbers are accepted as path parameters in url definition', () => {
+    const url = getUrl(
+      {
+        url: valueFormula(88),
+        path: {
+          a: { formula: valueFormula('hello'), index: 0 },
+          b: { formula: valueFormula('world'), index: 1 },
+        },
+      },
+      undefined as any,
+      'https://example.com',
+    )
+    expect(url.href).toBe('https://example.com/88/hello/world')
+  })
+  test('supports relative urls', () => {
+    const url = getUrl(
+      {
+        url: valueFormula('/test/path/'),
+        path: {
+          a: { formula: valueFormula('hello'), index: 0 },
+          b: { formula: valueFormula('world'), index: 1 },
+        },
+      },
+      undefined as any,
+      'https://mysite.com',
+    )
+    expect(url.href).toBe('https://mysite.com/test/path/hello/world')
+  })
+})
+test('supports query parameters in url declaration', () => {
+  const url = getUrl(
+    {
+      url: valueFormula('/test/path/?q=test&hello=world'),
+      path: {
+        a: { formula: valueFormula('hello'), index: 0 },
+        b: { formula: valueFormula('world'), index: 1 },
+      },
+    },
+    undefined as any,
+    'https://mysite.com',
+  )
+  expect(url.href).toBe(
+    'https://mysite.com/test/path/hello/world?q=test&hello=world',
+  )
 })
 describe('getApiHeaders()', () => {
   test('it returns valid headers', () => {

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -168,12 +168,17 @@ test('supports query parameters in url declaration', () => {
         a: { formula: valueFormula('hello'), index: 0 },
         b: { formula: valueFormula('world'), index: 1 },
       },
+      queryParams: {
+        search: {
+          formula: valueFormula('test'),
+        },
+      },
     },
     undefined as any,
     'https://mysite.com',
   )
   expect(url.href).toBe(
-    'https://mysite.com/test/path/hello/world?q=test&hello=world',
+    'https://mysite.com/test/path/hello/world?q=test&hello=world&search=test',
   )
 })
 describe('getApiHeaders()', () => {

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -5,6 +5,7 @@ import {
   getRequestHeaders,
   getRequestPath,
   getRequestQueryParams,
+  getUrl,
 } from './api'
 import { ApiMethod, ApiRequest } from './apiTypes'
 
@@ -75,6 +76,60 @@ describe('getQueryParams()', () => {
     expect(params.get('q[b][c]')).toEqual('world')
     expect(params.get('q[b][d]')).toEqual('')
     expect(params.size).toBe(3)
+  })
+})
+describe('getUrl()', () => {
+  test('it returns a valid url for null url', () => {
+    const url = getUrl(
+      {
+        url: valueFormula(null),
+        path: {
+          a: { formula: valueFormula('hello'), index: 0 },
+          b: { formula: valueFormula('world'), index: 1 },
+        },
+        queryParams: {
+          q: {
+            formula: valueFormula('test'),
+          },
+        },
+      },
+      undefined as any,
+      'https://example.com',
+    )
+    expect(url.href).toBe('https://example.com/hello/world?q=test')
+  })
+  test('it returns a valid url for url with included path params', () => {
+    const url = getUrl(
+      {
+        url: valueFormula('https://example.com/test/path'),
+        path: {
+          a: { formula: valueFormula('hello'), index: 0 },
+          b: { formula: valueFormula('world'), index: 1 },
+        },
+        queryParams: {
+          q: {
+            formula: valueFormula('test'),
+          },
+        },
+      },
+      undefined as any,
+      'https://example.com',
+    )
+    expect(url.href).toBe('https://example.com/test/path/hello/world?q=test')
+  })
+  test('it ignores trailing slashes in urls', () => {
+    const url = getUrl(
+      {
+        url: valueFormula('https://example.com/test/path/'),
+        path: {
+          a: { formula: valueFormula('hello'), index: 0 },
+          b: { formula: valueFormula('world'), index: 1 },
+        },
+      },
+      undefined as any,
+      'https://example.com',
+    )
+    expect(url.href).toBe('https://example.com/test/path/hello/world')
   })
 })
 describe('getApiHeaders()', () => {

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -47,20 +47,19 @@ export const getUrl = (
   formulaContext: FormulaContext,
   baseUrl?: string,
 ): URL => {
-  const url = applyFormula(api.url, formulaContext)
   let urlPathname = ''
   let urlQueryParams = new URLSearchParams()
   let parsedUrl: URL | undefined
-  if (typeof url === 'string') {
+  const url = applyFormula(api.url, formulaContext)
+  if (['string', 'number'].includes(typeof url)) {
+    const urlInput = typeof url === 'number' ? String(url) : url
     try {
       // Try to parse the URL to extract potential path and query parameters
-      parsedUrl = new URL(url)
+      parsedUrl = new URL(urlInput, baseUrl)
       urlPathname = parsedUrl.pathname
       urlQueryParams = parsedUrl.searchParams
-    } catch {
-      // If the URL is not valid, we will assume it's a path
-      urlPathname = url
-    }
+      // eslint-disable-next-line no-empty
+    } catch {}
   }
   const pathParams = getRequestPath(api.path, formulaContext)
   // Combine potential path parameters from the url declaration with the actual path parameters
@@ -73,9 +72,9 @@ export const getUrl = (
   const queryString =
     [...queryParams.entries()].length > 0 ? `?${queryParams.toString()}` : ''
   if (parsedUrl) {
-    const combinedUrl = new URL(url.origin, baseUrl)
+    const combinedUrl = new URL(parsedUrl.origin, baseUrl)
     combinedUrl.pathname = path
-    combinedUrl.search = queryString
+    combinedUrl.search = queryParams.toString()
     return combinedUrl
   } else {
     return new URL(`${path}${queryString}`, baseUrl)


### PR DESCRIPTION

- Allow combining path/query parameters between url and path/query declarations
- Allow parsing URLs where the declared `url` is not a string (`null` for instance)
- Add additional tests
  