### PR TITLE
Adjust rule to ensure unique path parameter names

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.19",
+  "version": "0.0.3-alpha.20",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/search/src/rules/duplicateUrlParameterRule.test.ts
+++ b/packages/search/src/rules/duplicateUrlParameterRule.test.ts
@@ -51,6 +51,44 @@ describe('duplicateUrlParameterRule', () => {
       'id',
     ])
   })
+  test('should detect duplicate path parameters', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              route: {
+                path: [
+                  {
+                    type: 'param',
+                    name: 'company',
+                    testValue: '1',
+                  },
+                  {
+                    type: 'static',
+                    name: 'company',
+                  },
+                ],
+                query: {},
+              },
+            },
+          },
+        },
+        rules: [duplicateUrlParameterRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('duplicate url parameter')
+    expect(problems[0].path).toEqual(['components', 'test', 'route', 'path', 1])
+  })
   test('should not detect non-duplicate URL parameters', () => {
     const problems = Array.from(
       searchProject({
@@ -77,8 +115,8 @@ describe('duplicateUrlParameterRule', () => {
                   },
                 ],
                 query: {
-                  name: {
-                    name: 'name',
+                  other: {
+                    name: 'other',
                     testValue: '1',
                   },
                 },
@@ -89,7 +127,6 @@ describe('duplicateUrlParameterRule', () => {
         rules: [duplicateUrlParameterRule],
       }),
     )
-
     expect(problems).toHaveLength(0)
   })
 })

--- a/packages/search/src/rules/duplicateUrlParameterRule.ts
+++ b/packages/search/src/rules/duplicateUrlParameterRule.ts
@@ -10,17 +10,17 @@ export const duplicateUrlParameterRule: Rule<{ trigger: string }> = {
       nodeType !== 'component' ||
       !isDefined(value.route) ||
       !isDefined(value.route.path) ||
-      !isDefined(value.route.query) ||
-      value.route.path.length === 0 ||
-      Object.values(value.route.query).length === 0
+      !isDefined(value.route.query)
     ) {
       return
     }
-    const pathNames = new Set(
-      value.route.path
-        .filter((path) => path.type === 'param' || path.optional)
-        .map((path) => path.name),
-    )
+    const pathNames = new Set<string>()
+    value.route.path.forEach((p, i) => {
+      if (pathNames.has(p.name)) {
+        report([...path, 'route', 'path', i])
+      }
+      pathNames.add(p.name)
+    })
     Object.keys(value.route.query).forEach((key) => {
       if (pathNames.has(key)) {
         report([...path, 'route', 'query', key])


### PR DESCRIPTION
Our client-side routing would fail if two path parameters had the same name. See example here: 
- https://start-peach_roos_tarpals_wee_hoverfly.toddle.site/toddle/company
- https://toddle.dev/projects/peach_roos_tarpals_wee_hoverfly/branches/start/components/company?leftpanel=design&rightpanel=attributes&canvas-width=800&canvas-height=800

This change ensures that path parameters are unique while still ensuring that path and query parameters are named uniquely.

Closes https://github.com/toddledev/toddle-internal/issues/2191