### PR TITLE
Fix an infinite loop in editor preview by keeping track of created context providers

### DIFF
--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1054,12 +1054,19 @@ export const createRoot = (
       })
     }
     if (fastDeepEqual(_component.contexts, ctx?.component.contexts) === false) {
+      const contextProvidersCreated = new Set<string>()
       Contexts = (function createStaticContextFromComponent(
         component: Component,
       ) {
+        contextProvidersCreated.add(component.name)
         return mapObject(
           component.contexts ?? {},
           ([providerName, context]) => {
+            if (contextProvidersCreated.has(providerName)) {
+              // Circular dependency detected in context-providers (ie. A -> B -> A -> ...), stop recursion
+              return [providerName, {}]
+            }
+
             const providerComponent = getAllComponents().find(
               (c) => c.name === providerName,
             )

--- a/packages/runtime/src/utils/BatchQueue.ts
+++ b/packages/runtime/src/utils/BatchQueue.ts
@@ -3,22 +3,22 @@
  * This is more efficient than processing each callback in a separate requestAnimationFrame due to the overhead.
  */
 export class BatchQueue {
-  private batchQueue = new Set<() => void>()
+  private batchQueue: Array<() => void> = []
   private isProcessing = false
-
   private processBatch() {
     if (this.isProcessing) return
     this.isProcessing = true
 
     requestAnimationFrame(() => {
-      this.batchQueue.forEach((callback) => callback())
-      this.batchQueue.clear()
+      while (this.batchQueue.length > 0) {
+        const callback = this.batchQueue.shift()
+        callback?.()
+      }
       this.isProcessing = false
     })
   }
-
   public add(callback: () => void) {
-    this.batchQueue.add(callback)
+    this.batchQueue.push(callback)
     this.processBatch()
   }
 }


### PR DESCRIPTION
I doubt anyone is actually using recursive context providers, but I just realised that it had a potential infinite loop. I tested it before/after with success.