### PR TITLE
Add name to details in duplicateUrlParameterRule

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.20",
+  "version": "0.0.3-alpha.21",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/search/src/rules/duplicateUrlParameterRule.test.ts
+++ b/packages/search/src/rules/duplicateUrlParameterRule.test.ts
@@ -50,6 +50,7 @@ describe('duplicateUrlParameterRule', () => {
       'query',
       'id',
     ])
+    expect(problems[0].details).toEqual({ name: 'id' })
   })
   test('should detect duplicate path parameters', () => {
     const problems = Array.from(
@@ -88,6 +89,7 @@ describe('duplicateUrlParameterRule', () => {
     expect(problems).toHaveLength(1)
     expect(problems[0].code).toBe('duplicate url parameter')
     expect(problems[0].path).toEqual(['components', 'test', 'route', 'path', 1])
+    expect(problems[0].details).toEqual({ name: 'company' })
   })
   test('should not detect non-duplicate URL parameters', () => {
     const problems = Array.from(

--- a/packages/search/src/rules/duplicateUrlParameterRule.ts
+++ b/packages/search/src/rules/duplicateUrlParameterRule.ts
@@ -1,7 +1,7 @@
 import { isDefined } from '@toddledev/core/dist/utils/util'
 import type { Rule } from '../types'
 
-export const duplicateUrlParameterRule: Rule<{ trigger: string }> = {
+export const duplicateUrlParameterRule: Rule<{ name: string }> = {
   code: 'duplicate url parameter',
   level: 'warning',
   category: 'Quality',
@@ -17,13 +17,13 @@ export const duplicateUrlParameterRule: Rule<{ trigger: string }> = {
     const pathNames = new Set<string>()
     value.route.path.forEach((p, i) => {
       if (pathNames.has(p.name)) {
-        report([...path, 'route', 'path', i])
+        report([...path, 'route', 'path', i], { name: p.name })
       }
       pathNames.add(p.name)
     })
     Object.keys(value.route.query).forEach((key) => {
       if (pathNames.has(key)) {
-        report([...path, 'route', 'query', key])
+        report([...path, 'route', 'query', key], { name: key })
       }
     })
   },


### PR DESCRIPTION
This is useful to report the query/path parameter even when the path parameter is currently in an array