### PR TITLE
Decode path parameters correctly in routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.22",
+  "version": "0.0.3-alpha.23",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -146,3 +146,4 @@ export const getPathSegments = (url: URL) =>
     .substring(1)
     .split('/')
     .filter((s) => s !== '')
+    .map((s) => decodeURIComponent(s))


### PR DESCRIPTION
During SSR, path parameters were not being decoded correctly, leading to invalid data when evaluating formulas. This PR fixes the issue by decoding path parameters before populating the formula context.