### PR TITLE
Support SVG text tag

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,12 +61,12 @@ export default [
       '@typescript-eslint/no-confusing-non-null-assertion': 'error',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/restrict-template-expressions': 'warn',
+      '@typescript-eslint/consistent-type-imports': 'warn',
       'no-unused-vars': 'off',
       'inclusive-language/use-inclusive-words': [
         'error',
         './lint/inclusive-words.json',
       ],
-
       '@typescript-eslint/no-unused-vars': [
         'error',
         {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.26",
+  "version": "0.0.3-alpha.27",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/formula/formula.ts
+++ b/packages/core/src/formula/formula.ts
@@ -231,7 +231,7 @@ export function applyFormula(
             return null
           }
         } else if (typeof legacyFunc === 'function') {
-          const args = formula.arguments.map((arg) =>
+          const args = (formula.arguments ?? []).map((arg) =>
             arg.isFunction
               ? (Args: any) =>
                   applyFormula(arg.formula, {

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ElementNodeModel,
   NodeModel,
 } from '@toddledev/core/dist/component/component.types'
@@ -13,7 +13,7 @@ import type { Signal } from '../signal/signal'
 import { getDragData } from '../utils/getDragData'
 import { getElementTagName } from '../utils/getElementTagName'
 import { setAttribute } from '../utils/setAttribute'
-import { NodeRenderer, createNode } from './createNode'
+import type { NodeRenderer, createNode } from './createNode'
 
 export function createElement({
   node,
@@ -162,10 +162,11 @@ export function createElement({
   })
 
   // for script, style & SVG<text> tags we only render text child.
+  const nodeTag = node.tag.toLocaleLowerCase()
   if (
-    node.tag.toLocaleLowerCase() === 'script' ||
-    node.tag.toLocaleLowerCase() === 'style' ||
-    (node.tag.toLocaleLowerCase() === 'text' && isSvg)
+    nodeTag === 'script' ||
+    nodeTag === 'style' ||
+    (nodeTag === 'text' && isSvg)
   ) {
     const textValues: Array<Signal<string> | string> = []
     node.children

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -1,4 +1,7 @@
-import { ElementNodeModel } from '@toddledev/core/dist/component/component.types'
+import {
+  ElementNodeModel,
+  NodeModel,
+} from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import {
   getClassName,
@@ -158,35 +161,52 @@ export function createElement({
     elem.addEventListener(event.trigger, handler)
   })
 
-  // for script and style tags we just render the first text child.
+  // for script, style & SVG<text> tags we only render text child.
   if (
     node.tag.toLocaleLowerCase() === 'script' ||
-    node.tag.toLocaleLowerCase() === 'style'
+    node.tag.toLocaleLowerCase() === 'style' ||
+    (node.tag.toLocaleLowerCase() === 'text' && isSvg)
   ) {
-    const childId = node.children[0]
-    const childNode = childId ? ctx.component.nodes[childId] : undefined
-    if (childNode?.type === 'text') {
-      if (childNode.value.type === 'value') {
-        elem.textContent = String(childNode.value.value)
-      } else {
-        const textSignal = dataSignal.map((data) => {
-          return String(
-            applyFormula(childNode.value, {
-              data,
-              component: ctx.component,
-              formulaCache: ctx.formulaCache,
-              root: ctx.root,
-              package: ctx.package,
-              toddle: ctx.toddle,
-              env: ctx.env,
-            }),
-          )
-        })
-        textSignal.subscribe((value) => {
-          elem.textContent = value
-        })
-      }
+    const textValues: Array<Signal<string> | string> = []
+    node.children
+      .map<NodeModel | undefined>((child) => ctx.component.nodes[child])
+      .filter((node) => node?.type === 'text')
+      .forEach((node) => {
+        if (node.value.type === 'value') {
+          textValues.push(String(node.value.value))
+        } else {
+          const textSignal = dataSignal.map((data) => {
+            return String(
+              applyFormula(node.value, {
+                data,
+                component: ctx.component,
+                formulaCache: ctx.formulaCache,
+                root: ctx.root,
+                package: ctx.package,
+                toddle: ctx.toddle,
+                env: ctx.env,
+              }),
+            )
+          })
+          textValues.push(textSignal)
+        }
+      })
+
+    // if all values are string, we can directly set textContent
+    if (textValues.every((value) => typeof value === 'string')) {
+      elem.textContent = textValues.join('')
     }
+
+    // for each signal, we subscribe and rewrite the entire textContent from all text nodes
+    textValues
+      .filter((value) => typeof value !== 'string')
+      .forEach((valueSignal) => {
+        valueSignal.subscribe(() => {
+          elem.textContent = textValues
+            .map((value) => (typeof value === 'string' ? value : value.get()))
+            .join('')
+        })
+      })
   } else {
     node.children.forEach((child, i) => {
       const childNodes = createNode({

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -13,7 +13,8 @@ import type { Signal } from '../signal/signal'
 import { getDragData } from '../utils/getDragData'
 import { getElementTagName } from '../utils/getElementTagName'
 import { setAttribute } from '../utils/setAttribute'
-import type { NodeRenderer, createNode } from './createNode'
+import type { NodeRenderer } from './createNode'
+import { createNode } from './createNode'
 
 export function createElement({
   node,


### PR DESCRIPTION
This also fixes an issue where only the first text-node inside script and style tags would be rendered.

Handling text differently for some elements is a temporary measure until we merge (we have a POC) a change to skip the span around text-nodes, which should also greatly reduce the DOM element count.

Can be tested here https://svgtext-jacob_test.toddle.site/ uses SVG and should render a style tag combined of three text nodes where one is dynamic to change the background.