### PR TITLE
Fix an issue where params would be set into query in editor mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.27",
+  "version": "0.0.3-alpha.28",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1007,6 +1007,7 @@ export const createRoot = (
 
           return {
             ...location,
+            route: _component.route,
             params: Object.fromEntries(
               _component.route.path
                 .filter((p) => p.type === 'param')
@@ -1033,13 +1034,6 @@ export const createRoot = (
             Attributes: route,
           })),
         )
-
-        const route = routeSignal.get()
-        dataSignal.update((data) => ({
-          ...data,
-          'URL parameters': route,
-          Attributes: route,
-        }))
       }
 
       Attributes = mapObject(_component.attributes, ([name, { testValue }]) => [


### PR DESCRIPTION
There was an issue where params would be stored as query params in editor mode after the latest changes. This was due to our logic at https://github.com/toddledev/toddle/blob/fix-location-signal-editor-mode/packages/runtime/src/events/handleAction.ts#L92 where if the route path is not correct (or not given as previously), it would assume it was a query param instead of path param.

I am not sure why we interlop the parameters so much instead of keeping them separate in the signal, but I am not going to change it right now.