### PR TITLE
Pass namespace through components and support MathML node namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.3-alpha.28",
+  "version": "0.0.3-alpha.29",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/styling/theme.const.ts
+++ b/packages/core/src/styling/theme.const.ts
@@ -19,7 +19,7 @@ export const RESET_STYLES = `
     margin:0;
   }
 
-  [data-node-id]:not([data-unset-toddle-styles],[data-node-type="text"],noscript,br,script,style,link,template,meta,title,base), [data-node-id]:not([data-unset-toddle-styles],noscript)::before, [data-node-id]:not([data-unset-toddle-styles],noscript)::after {
+  [data-node-id]:not([data-unset-toddle-styles],[data-node-type="text"],noscript,br,script,style,math,math *,link,template,meta,title,base), [data-node-id]:not([data-unset-toddle-styles],noscript)::before, [data-node-id]:not([data-unset-toddle-styles],noscript)::after {
     display: flex;
     flex-direction: column;
     flex-grow: 0;

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -4,7 +4,7 @@ import type {
   ComponentNodeModel,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
-import { RequireFields } from '@toddledev/core/dist/types'
+import type { RequireFields } from '@toddledev/core/dist/types'
 import { mapObject } from '@toddledev/core/dist/utils/collections'
 import { isDefined } from '@toddledev/core/dist/utils/util'
 import { createLegacyAPI } from '../api/createAPI'
@@ -13,8 +13,14 @@ import { isContextProvider } from '../context/isContextProvider'
 import { subscribeToContext } from '../context/subscribeToContext'
 import { registerComponentToLogState } from '../debug/logState'
 import { handleAction } from '../events/handleAction'
-import { Signal, signal } from '../signal/signal'
-import { ComponentChild, ComponentContext, ContextApi } from '../types'
+import type { Signal } from '../signal/signal'
+import { signal } from '../signal/signal'
+import type {
+  ComponentChild,
+  ComponentContext,
+  ContextApi,
+  SupportedNamespaces,
+} from '../types'
 import { createFormulaCache } from '../utils/createFormulaCache'
 import { renderComponent } from './renderComponent'
 
@@ -25,6 +31,7 @@ export type RenderComponentNodeProps = {
   ctx: ComponentContext
   parentElement: Element | ShadowRoot
   instance: Record<string, string>
+  namespace?: SupportedNamespaces
 }
 
 export function createComponent({
@@ -34,6 +41,7 @@ export function createComponent({
   ctx,
   parentElement,
   instance,
+  namespace,
 }: RenderComponentNodeProps): Element[] {
   const nodeLookupKey = [ctx.package, node.name].filter(isDefined).join('/')
   const component = ctx.components?.find((comp) => comp.name === nodeLookupKey)
@@ -265,6 +273,7 @@ export function createComponent({
     onEvent,
     toddle: ctx.toddle,
     env: ctx.env,
+    namespace,
     // If the root node is another component, then append and forward previous instance
     instance:
       node.id === 'root'

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -226,7 +226,6 @@ export function createElement({
         path: path + '.' + i,
         dataSignal,
         ctx,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         namespace,
         instance,
       })

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -1,11 +1,12 @@
-import {
+import type {
   ComponentData,
   NodeModel,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import { toBoolean } from '@toddledev/core/dist/utils/util'
-import { Signal, signal } from '../signal/signal'
-import { ComponentContext } from '../types'
+import type { Signal } from '../signal/signal'
+import { signal } from '../signal/signal'
+import type { ComponentContext, SupportedNamespaces } from '../types'
 import { ensureEfficientOrdering, getNextSiblingElement } from '../utils/nodes'
 import { createComponent } from './createComponent'
 import { createElement } from './createElement'
@@ -17,7 +18,7 @@ export function createNode({
   dataSignal,
   path,
   ctx,
-  isSvg,
+  namespace,
   parentElement,
   instance,
 }: {
@@ -25,7 +26,7 @@ export function createNode({
   dataSignal: Signal<ComponentData>
   path: string
   ctx: ComponentContext
-  isSvg?: boolean
+  namespace?: SupportedNamespaces
   parentElement: Element | ShadowRoot
   instance: Record<string, string>
 }): Element[] {
@@ -56,6 +57,7 @@ export function createNode({
               node.package ?? (isLocalComponent ? undefined : ctx.package),
           },
           parentElement,
+          namespace,
         })
       case 'text':
         return [createText({ ...props, node })]
@@ -70,7 +72,7 @@ export function createNode({
     id,
     path,
     ctx,
-    isSvg,
+    namespace,
     parentElement,
     instance,
   }: NodeRenderer<NodeModel>): Element[] {
@@ -102,7 +104,7 @@ export function createNode({
             path,
             id,
             ctx,
-            isSvg,
+            namespace,
             parentElement,
             instance,
           }),
@@ -278,7 +280,7 @@ export function createNode({
               dataSignal: childDataSignal,
               path: Key === '0' ? path : `${path}(${Key})`,
               ctx,
-              isSvg,
+              namespace,
               parentElement,
               instance,
             }
@@ -347,7 +349,7 @@ export function createNode({
       ctx,
       id,
       path,
-      isSvg,
+      namespace,
       parentElement,
       instance,
     })
@@ -358,7 +360,7 @@ export function createNode({
     ctx,
     id,
     path,
-    isSvg,
+    namespace,
     parentElement,
     instance,
   })
@@ -369,7 +371,7 @@ export type NodeRenderer<NodeType> = {
   id: string
   path: string
   ctx: ComponentContext
-  isSvg?: boolean
+  namespace?: SupportedNamespaces
   parentElement: Element | ShadowRoot
   instance: Record<string, string>
 }

--- a/packages/runtime/src/components/createSlot.ts
+++ b/packages/runtime/src/components/createSlot.ts
@@ -8,6 +8,7 @@ export function createSlot({
   ctx,
   parentElement,
   instance,
+  namespace,
 }: NodeRenderer<SlotNodeModel>): Element[] {
   const slotName = node.name ?? 'default'
   let children: Element[] = []
@@ -27,6 +28,7 @@ export function createSlot({
           providers: ctx.providers,
         },
         instance,
+        namespace,
       })
     })
   } else {
@@ -39,6 +41,7 @@ export function createSlot({
         ctx,
         parentElement,
         instance,
+        namespace,
       })
     })
   }

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -1,18 +1,19 @@
-import {
+import type {
   Component,
   ComponentData,
 } from '@toddledev/core/dist/component/component.types'
-import { ToddleEnv } from '@toddledev/core/dist/formula/formula'
-import { Toddle } from '@toddledev/core/dist/types'
+import type { ToddleEnv } from '@toddledev/core/dist/formula/formula'
+import type { Toddle } from '@toddledev/core/dist/types'
 import deepEqual from 'fast-deep-equal'
 import { handleAction } from '../events/handleAction'
-import { Signal } from '../signal/signal'
-import {
+import type { Signal } from '../signal/signal'
+import type {
   ComponentChild,
   ComponentContext,
   FormulaCache,
   LocationSignal,
   PreviewShowSignal,
+  SupportedNamespaces,
 } from '../types'
 import { BatchQueue } from '../utils/BatchQueue'
 import { createNode } from './createNode'
@@ -41,6 +42,7 @@ interface RenderComponentProps {
   parentElement: Element | ShadowRoot
   instance: Record<string, string>
   toddle: Toddle<LocationSignal, PreviewShowSignal>
+  namespace?: SupportedNamespaces
   env: ToddleEnv
 }
 
@@ -63,6 +65,7 @@ export function renderComponent({
   parentElement,
   instance,
   toddle,
+  namespace,
   env,
 }: RenderComponentProps): Element[] {
   const ctx: ComponentContext = {
@@ -79,6 +82,7 @@ export function renderComponent({
     providers,
     package: packageName,
     toddle,
+    namespace,
     env,
   }
 
@@ -88,6 +92,7 @@ export function renderComponent({
     dataSignal,
     ctx,
     parentElement,
+    namespace,
     instance,
   })
   BATCH_QUEUE.add(() => {

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -71,6 +71,7 @@ export interface ComponentContext {
       ctx: ComponentContext
     }
   >
+  namespace?: SupportedNamespaces
   toddle: Toddle<LocationSignal, PreviewShowSignal>
   env: ToddleEnv
 }
@@ -89,3 +90,11 @@ export type FormulaCache = Record<
     set: (data: ComponentData, result: any) => void
   }
 >
+
+/**
+ * We must specify the namespace for some nodes when created programmatically that are not in the default namespace.
+ * In toddle, we infer the namespace based on the tag name, but it would be interesting to also allow the user to specify it explicitly with the `xmlns` attribute.
+ */
+export type SupportedNamespaces =
+  | 'http://www.w3.org/2000/svg'
+  | 'http://www.w3.org/1998/Math/MathML'

--- a/packages/runtime/src/utils/setAttribute.ts
+++ b/packages/runtime/src/utils/setAttribute.ts
@@ -4,7 +4,7 @@ import { isDefined, toBoolean } from '@toddledev/core/dist/utils/util'
  * Some attributes need special handling.
  */
 export function setAttribute(
-  elem: HTMLElement | SVGElement,
+  elem: HTMLElement | SVGElement | MathMLElement,
   attr: string,
   value: any,
 ) {


### PR DESCRIPTION
This change allows us to split a single SVG (or MathML) into multiple components. Previously the current namespace was lost when moving into child components.

In this PR, I also extend toddle to support the MathML namespace. There does exist more namespaces, but MathML is already a pretty obscure use case.

When versioning is supported, I suggest we explicitly set the namespace if a node has an `xmlns` attribute instead of only inferring it from the tag name.