### PR TITLE
Skip wrapping non-default namespace text in spans

### DIFF
--- a/packages/core/src/formula/formula.ts
+++ b/packages/core/src/formula/formula.ts
@@ -155,11 +155,16 @@ export function applyFormula(
       case 'value':
         return formula.value
       case 'path': {
-        return formula.path.reduce(
-          (input: any, key) =>
-            input && typeof input === 'object' ? input[key] : null,
-          ctx.data,
-        )
+        let input: any = ctx.data
+        for (const key of formula.path) {
+          if (input && typeof input === 'object') {
+            input = input[key]
+          } else {
+            return null
+          }
+        }
+
+        return input
       }
       case 'switch': {
         for (const branch of formula.cases) {

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -42,7 +42,7 @@ export function createComponent({
   parentElement,
   instance,
   namespace,
-}: RenderComponentNodeProps): Element[] {
+}: RenderComponentNodeProps): ReadonlyArray<Element | Text> {
   const nodeLookupKey = [ctx.package, node.name].filter(isDefined).join('/')
   const component = ctx.components?.find((comp) => comp.name === nodeLookupKey)
   if (!component) {

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -10,6 +10,7 @@ import {
 import { isDefined, toBoolean } from '@toddledev/core/dist/utils/util'
 import { handleAction } from '../events/handleAction'
 import type { Signal } from '../signal/signal'
+import type { SupportedNamespaces } from '../types'
 import { getDragData } from '../utils/getDragData'
 import { getElementTagName } from '../utils/getElementTagName'
 import { setAttribute } from '../utils/setAttribute'
@@ -35,6 +36,11 @@ export function createElement({
       namespace = 'http://www.w3.org/1998/Math/MathML'
       break
     }
+  }
+
+  // Explicitly setting a namespace has precedence over inferring it from the tag
+  if (node.attrs['xmlns'] && node.attrs['xmlns'].type === 'value') {
+    namespace = String(node.attrs['xmlns'].value) as SupportedNamespaces
   }
 
   const elem = namespace
@@ -172,12 +178,9 @@ export function createElement({
   })
 
   // for script, style & SVG<text> tags we only render text child.
+  // this can be removed once we fix the editor to handle raw text nodes without wrapping <span>
   const nodeTag = node.tag.toLocaleLowerCase()
-  if (
-    nodeTag === 'script' ||
-    nodeTag === 'style' ||
-    (nodeTag === 'text' && namespace === 'http://www.w3.org/2000/svg')
-  ) {
+  if (nodeTag === 'script' || nodeTag === 'style') {
     const textValues: Array<Signal<string> | string> = []
     node.children
       .map<NodeModel | undefined>((child) => ctx.component.nodes[child])

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -29,12 +29,15 @@ export function createNode({
   namespace?: SupportedNamespaces
   parentElement: Element | ShadowRoot
   instance: Record<string, string>
-}): Element[] {
+}): ReadonlyArray<Element | Text> {
   const node = ctx.component.nodes[id]
   if (!node) {
     return []
   }
-  const create = ({ node, ...props }: NodeRenderer<NodeModel>): Element[] => {
+  const create = ({
+    node,
+    ...props
+  }: NodeRenderer<NodeModel>): ReadonlyArray<Element | Text> => {
     switch (node.type) {
       case 'element':
         return [
@@ -60,7 +63,7 @@ export function createNode({
           namespace,
         })
       case 'text':
-        return [createText({ ...props, node })]
+        return [createText({ ...props, namespace, node })]
       case 'slot':
         return createSlot({ ...props, node })
     }
@@ -75,7 +78,7 @@ export function createNode({
     namespace,
     parentElement,
     instance,
-  }: NodeRenderer<NodeModel>): Element[] {
+  }: NodeRenderer<NodeModel>): ReadonlyArray<Element | Text> {
     let firstRun = true
     let childDataSignal: Signal<ComponentData> | null = null
     const showSignal = dataSignal.map((data) =>
@@ -92,7 +95,7 @@ export function createNode({
       ),
     )
 
-    const elements: Element[] = []
+    const elements: Array<Element | Text> = []
     const toggle = (show: boolean) => {
       if (show && elements.length === 0) {
         childDataSignal?.destroy()
@@ -162,14 +165,14 @@ export function createNode({
     return elements
   }
 
-  function repeat(): Element[] {
+  function repeat(): ReadonlyArray<Element | Text> {
     let firstRun = true
     let repeatItems = new Map<
       string | number,
       {
         dataSignal: Signal<ComponentData>
         cleanup: () => void
-        elements: Element[]
+        elements: ReadonlyArray<Element | Text>
       }
     >()
     const repeatSignal = dataSignal.map((data) => {
@@ -195,7 +198,7 @@ export function createNode({
           {
             dataSignal: Signal<ComponentData>
             cleanup: () => void
-            elements: Element[]
+            elements: ReadonlyArray<Element | Text>
           }
         >()
 

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -60,10 +60,9 @@ export function createNode({
               node.package ?? (isLocalComponent ? undefined : ctx.package),
           },
           parentElement,
-          namespace,
         })
       case 'text':
-        return [createText({ ...props, namespace, node })]
+        return [createText({ ...props, node })]
       case 'slot':
         return createSlot({ ...props, node })
     }

--- a/packages/runtime/src/components/createSlot.ts
+++ b/packages/runtime/src/components/createSlot.ts
@@ -9,9 +9,9 @@ export function createSlot({
   parentElement,
   instance,
   namespace,
-}: NodeRenderer<SlotNodeModel>): Element[] {
+}: NodeRenderer<SlotNodeModel>): ReadonlyArray<Element | Text> {
   const slotName = node.name ?? 'default'
-  let children: Element[] = []
+  let children: Array<Element | Text> = []
   // Is slotted content provided?
   if (ctx.children[slotName]) {
     children = ctx.children[slotName].flatMap((child) => {

--- a/packages/runtime/src/components/createText.test.ts
+++ b/packages/runtime/src/components/createText.test.ts
@@ -11,8 +11,8 @@ describe('createText()', () => {
       ctx: {
         isRootComponent: false,
         component: { name: 'My Component' },
-        namespace: 'http://www.w3.org/1999/xhtml',
       } as Partial<ComponentContext> as any,
+      namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal: undefined as any,
       path: 'test-text-element',
       id: 'test-text-element-id',
@@ -37,8 +37,8 @@ describe('createText()', () => {
       ctx: {
         isRootComponent: false,
         component: { name: 'My Component' },
-        namespace: 'http://www.w3.org/2000/svg',
       } as Partial<ComponentContext> as any,
+      namespace: 'http://www.w3.org/2000/svg',
       dataSignal: undefined as any,
       path: 'test-text-element',
       id: 'test-text-element-id',

--- a/packages/runtime/src/components/createText.test.ts
+++ b/packages/runtime/src/components/createText.test.ts
@@ -2,15 +2,16 @@ import { describe, expect, test } from '@jest/globals'
 import type { ComponentData } from '@toddledev/core/dist/component/component.types'
 import { valueFormula } from '@toddledev/core/dist/formula/formulaUtils'
 import { Signal } from '../signal/signal'
-import { ComponentContext } from '../types'
+import type { ComponentContext } from '../types'
 import { createText } from './createText'
 
 describe('createText()', () => {
-  test('it returns a span element with text in it', () => {
-    const textElement = createText({
+  test('it returns a span element with text in it while in default namespace', () => {
+    let textElement = createText({
       ctx: {
         isRootComponent: false,
         component: { name: 'My Component' },
+        namespace: 'http://www.w3.org/1999/xhtml',
       } as Partial<ComponentContext> as any,
       dataSignal: undefined as any,
       path: 'test-text-element',
@@ -20,6 +21,8 @@ describe('createText()', () => {
         value: valueFormula('Hello world'),
       },
     })
+    expect(textElement instanceof HTMLSpanElement).toBe(true)
+    textElement = textElement as HTMLSpanElement
     expect(textElement.tagName).toBe('SPAN')
     expect(textElement.getAttribute('data-node-id')).toBe(
       'test-text-element-id',
@@ -29,9 +32,13 @@ describe('createText()', () => {
     expect(textElement.children.length).toBe(0)
     expect(textElement.innerText).toBe('Hello world')
   })
-  test('it does not add a data-component attribute for root elements', () => {
+  test('it returns a text node while not in the default namespace', () => {
     const textElement = createText({
-      ctx: { isRootComponent: true } as Partial<ComponentContext> as any,
+      ctx: {
+        isRootComponent: false,
+        component: { name: 'My Component' },
+        namespace: 'http://www.w3.org/2000/svg',
+      } as Partial<ComponentContext> as any,
       dataSignal: undefined as any,
       path: 'test-text-element',
       id: 'test-text-element-id',
@@ -39,7 +46,23 @@ describe('createText()', () => {
         type: 'text',
         value: valueFormula('Hello world'),
       },
-    })
+    }) as Text
+    expect(textElement instanceof Text).toBe(true)
+    expect(textElement.textContent).toBe('Hello world')
+  })
+  test('it does not add a data-component attribute for root elements', () => {
+    const textElement = createText({
+      ctx: {
+        isRootComponent: true,
+      } as Partial<ComponentContext> as any,
+      dataSignal: undefined as any,
+      path: 'test-text-element',
+      id: 'test-text-element-id',
+      node: {
+        type: 'text',
+        value: valueFormula('Hello world'),
+      },
+    }) as HTMLSpanElement
     expect(textElement.getAttribute('data-component')).toBeNull()
   })
   test('Signal changes update the text element', () => {
@@ -59,9 +82,9 @@ describe('createText()', () => {
         },
       },
     })
-    expect(textElement.innerText).toBe('Hello world')
+    expect(textElement.textContent).toBe('Hello world')
     dataSignal.set({ Attributes: { text: 'Goodbye world' } })
-    expect(textElement.innerText).toBe('Goodbye world')
+    expect(textElement.textContent).toBe('Goodbye world')
   })
   test('Show formulas are not respected for text elements', () => {
     const textElement = createText({
@@ -75,7 +98,7 @@ describe('createText()', () => {
         condition: valueFormula(false),
       },
     })
-    expect(textElement.innerText).toBe('Hello world')
+    expect(textElement.textContent).toBe('Hello world')
   })
   test('Repeat formulas are not respected for text elements', () => {
     const textElement = createText({
@@ -89,6 +112,6 @@ describe('createText()', () => {
         repeat: valueFormula(['1', '2', '3']),
       },
     })
-    expect(textElement.innerText).toBe('Hello world')
+    expect(textElement.textContent).toBe('Hello world')
   })
 })

--- a/packages/runtime/src/components/createText.ts
+++ b/packages/runtime/src/components/createText.ts
@@ -26,10 +26,11 @@ export function createText({
   id,
   path,
   dataSignal,
+  namespace,
   ctx,
 }: RenderTextProps): HTMLSpanElement | Text {
   // Span element is not valid outside of the default namespace
-  if (ctx.namespace && ctx.namespace !== 'http://www.w3.org/1999/xhtml') {
+  if (namespace && namespace !== 'http://www.w3.org/1999/xhtml') {
     return createTextNS({ node, dataSignal, ctx })
   }
 

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -67,7 +67,7 @@ export function renderComponent({
   toddle,
   namespace,
   env,
-}: RenderComponentProps): Element[] {
+}: RenderComponentProps): ReadonlyArray<Element | Text> {
   const ctx: ComponentContext = {
     triggerEvent: onEvent,
     component,

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -82,7 +82,6 @@ export function renderComponent({
     providers,
     package: packageName,
     toddle,
-    namespace,
     env,
   }
 

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -96,5 +96,6 @@ export type FormulaCache = Record<
  * In toddle, we infer the namespace based on the tag name, but it would be interesting to also allow the user to specify it explicitly with the `xmlns` attribute.
  */
 export type SupportedNamespaces =
+  | 'http://www.w3.org/1999/xhtml'
   | 'http://www.w3.org/2000/svg'
   | 'http://www.w3.org/1998/Math/MathML'

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -71,7 +71,6 @@ export interface ComponentContext {
       ctx: ComponentContext
     }
   >
-  namespace?: SupportedNamespaces
   toddle: Toddle<LocationSignal, PreviewShowSignal>
   env: ToddleEnv
 }

--- a/packages/runtime/src/utils/nodes.ts
+++ b/packages/runtime/src/utils/nodes.ts
@@ -94,8 +94,8 @@ export const getNextSiblingElement = (
  */
 export function ensureEfficientOrdering(
   parentElement: Element | ShadowRoot,
-  items: Element[],
-  nextElement: Element | null = null,
+  items: ReadonlyArray<Element | Text>,
+  nextElement: Element | Text | null = null,
 ) {
   // Identify the starting point for comparisons.
   let insertBeforeElement = nextElement // If insertBeforeElement is null, items will be appended at the end.


### PR DESCRIPTION
Lucas made me aware that my approach to rendering text in SVGs was naive. While SVGs does not support html elements such as `<span>`s, it does allow nesting with special elements such as `<text><tspan>text</tspan></text>`. It even supports a `<foreignObject>` element that allows you to move back to HTML or another namespace (think `MathML` inside of an SVG).

This PR moves away from handing SVG text similar to scripts and style elements, and instead simply skips the `<span>` wrapping when inside non-default namespaces.

When versioning is ready, I would like to look into removing the spans altogether to avoid all this special handling. The work on namespacing is going to stay though.

I used this example to test various SVG text elements: https://start-magenta_mas_amedda_wide_stork.toddle.site/