### PR TITLE
Fix an issue with drag and drop highlight when canvas was scrolled

### DIFF
--- a/packages/runtime/src/editor/drag-drop/dragEnded.ts
+++ b/packages/runtime/src/editor/drag-drop/dragEnded.ts
@@ -1,15 +1,14 @@
 import type { DragState } from '../types'
-import { DRAG_MOVE_CLASSNAME } from './dragMove'
-import { DRAG_REORDER_CLASSNAME } from './dragReorder'
 import { removeDropHighlight } from './dropHighlight'
 
 export function dragEnded(dragState: DragState | null) {
-  dragState?.element.classList.remove(DRAG_REORDER_CLASSNAME)
-  dragState?.element.classList.remove(DRAG_MOVE_CLASSNAME)
   dragState?.element.style.removeProperty('translate')
   dragState?.copy?.remove()
   dragState?.repeatedNodes.toReversed().forEach((node) => {
     dragState?.element.insertAdjacentElement('afterend', node)
   })
   removeDropHighlight()
+  if (dragState?.mode === 'insert') {
+    dragState?.element.remove()
+  }
 }

--- a/packages/runtime/src/editor/drag-drop/dragMove.ts
+++ b/packages/runtime/src/editor/drag-drop/dragMove.ts
@@ -1,10 +1,7 @@
 import { findNearestLine } from '../../utils/findNearestLine'
 import type { DragState } from '../types'
-import { DRAG_REORDER_CLASSNAME } from './dragReorder'
 import { removeDropHighlight, setExternalDropHighlight } from './dropHighlight'
 import { getInsertAreas } from './getInsertAreas'
-
-export const DRAG_MOVE_CLASSNAME = '__drag-mode--move'
 
 export function dragMove(dragState: DragState | null, exclude: HTMLElement[]) {
   if (!dragState) {
@@ -26,8 +23,6 @@ export function dragMove(dragState: DragState | null, exclude: HTMLElement[]) {
     dragState.element.style.setProperty('translate', '0')
     const rect = dragState.element.getBoundingClientRect()
     document.body.appendChild(dragState.element)
-    dragState.element.classList.add(DRAG_MOVE_CLASSNAME)
-    dragState.element.classList.remove(DRAG_REORDER_CLASSNAME)
     dragState.element.style.setProperty(
       '--drag-mode--move-left',
       `${rect.left}px`,

--- a/packages/runtime/src/editor/drag-drop/dragReorder.ts
+++ b/packages/runtime/src/editor/drag-drop/dragReorder.ts
@@ -1,9 +1,7 @@
 import { tryStartViewTransition } from '../../utils/tryStartViewTransition'
 import type { DragState } from '../types'
-import { DRAG_MOVE_CLASSNAME } from './dragMove'
 import { setDropHighlight } from './dropHighlight'
 
-export const DRAG_REORDER_CLASSNAME = '__drag-mode--reorder'
 const OVERLAP_OFFSET_PX = 100
 
 export function dragReorder(dragState: DragState | null) {
@@ -17,8 +15,6 @@ export function dragReorder(dragState: DragState | null) {
 
     // Move back to the original container
     const prevRect = dragState.element.getBoundingClientRect()
-    dragState.element.classList.add(DRAG_REORDER_CLASSNAME)
-    dragState.element.classList.remove(DRAG_MOVE_CLASSNAME)
     dragState.initialContainer.insertBefore(
       dragState.element,
       dragState.initialNextSibling,

--- a/packages/runtime/src/editor/drag-drop/dragStarted.ts
+++ b/packages/runtime/src/editor/drag-drop/dragStarted.ts
@@ -1,6 +1,4 @@
 import type { DragState, Point } from '../types'
-import { DRAG_MOVE_CLASSNAME } from './dragMove'
-import { DRAG_REORDER_CLASSNAME } from './dragReorder'
 import { setDropHighlight } from './dropHighlight'
 
 export function dragStarted({
@@ -41,8 +39,6 @@ export function dragStarted({
   if (asCopy) {
     dragState.copy = element.cloneNode(true) as HTMLElement
     dragState.copy.style.setProperty('opacity', '0.5')
-    dragState.copy.classList.remove(DRAG_REORDER_CLASSNAME)
-    dragState.copy.classList.remove(DRAG_MOVE_CLASSNAME)
     dragState.initialContainer.insertBefore(
       dragState.copy,
       dragState.initialNextSibling,
@@ -79,7 +75,6 @@ export function dragStarted({
   dragState.initialContainer.insertBefore(element, dragState.initialNextSibling)
 
   // Highlight container
-  element.classList.add(DRAG_REORDER_CLASSNAME)
   window.parent?.postMessage(
     {
       type: 'highlight',

--- a/packages/runtime/src/editor/drag-drop/dropHighlight.ts
+++ b/packages/runtime/src/editor/drag-drop/dropHighlight.ts
@@ -16,16 +16,28 @@ export function setDropHighlight(
   }
 
   highlight = document.createElement('div')
-  highlight.classList.add('__drop-area')
   const { top, left } = targetContainer.getBoundingClientRect()
+  highlight.style.setProperty('position', 'fixed')
   highlight.style.setProperty('left', `${element.offsetLeft + left}px`)
   highlight.style.setProperty('top', `${element.offsetTop + top}px`)
   highlight.style.setProperty('width', `${element.offsetWidth}px`)
   highlight.style.setProperty('height', `${element.offsetHeight}px`)
-  highlight.style.setProperty('border', `2px solid #${color}`)
+  highlight.style.setProperty('view-transition-name', 'drop-highlight')
+  highlight.style.setProperty('outline', `2px solid #${color}`)
+  highlight.style.setProperty('outline-offset', '-2px')
   highlight.style.setProperty(
     'border-radius',
     window.getComputedStyle(element).borderRadius,
+  )
+  highlight.style.setProperty('background-size', '9px 9px')
+  highlight.style.setProperty('background-color', 'rgba(0, 0, 0, 0)')
+  highlight.style.setProperty(
+    '--dashed-line-color',
+    `color-mix(in srgb, #${color} 33%, transparent)`,
+  )
+  highlight.style.setProperty(
+    'background-image',
+    'repeating-linear-gradient(45deg, var(--dashed-line-color) 0, var(--dashed-line-color) 1px, transparent 0, transparent 50%)',
   )
   document.body.append(highlight)
 }
@@ -48,7 +60,6 @@ export function setExternalDropHighlight({
 }) {
   highlight?.remove()
   highlight = document.createElement('div')
-  highlight.classList.add('__drop-area-line')
   highlight.style.setProperty('top', `${center.y}px`)
   highlight.style.setProperty('left', `${center.x}px`)
   if (layout === 'block') {


### PR DESCRIPTION
A couple different fixes:
- Use fixed instead of absolute position to avoid issues when the canvas was scrolled
- Make sure to remove to duplicate element on drag end
- Add a patterned background to the dragged element position to make it more obvious
- Add a view transition to the dragged element position so it moves smoothly.