### PR TITLE
Specify test root for relevant packages

### DIFF
--- a/packages/core/bunfig.toml
+++ b/packages/core/bunfig.toml
@@ -1,4 +1,3 @@
 [test]
-preload = "./happydom.ts"
 # To ensure bun doesn't test in our dist folder
 root = "./src"

--- a/packages/ssr/bunfig.toml
+++ b/packages/ssr/bunfig.toml
@@ -1,4 +1,3 @@
 [test]
-preload = "./happydom.ts"
 # To ensure bun doesn't test in our dist folder
 root = "./src"


### PR DESCRIPTION
We only use jest for our lib/ package. The rest use `bun test`, and should be informed to only run tests in the respective `src/` folders (not `dist/`)