### PR TITLE
Add duplicateWorkflowParameterRule

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -37,6 +37,7 @@ import { unknownTriggerEventRule } from './rules/unknownTriggerEventRule'
 import { unknownUrlParameterRule } from './rules/unknownUrlParameterRule'
 import { unknownVariableRule } from './rules/unknownVariableRule'
 import { unknownVariableSetterRule } from './rules/unknownVariableSetterRule'
+import { duplicateWorkflowParameterRule } from './rules/workflows/duplicateWorkflowParameterRule'
 import { noReferenceComponentWorkflowRule } from './rules/workflows/noReferenceComponentWorkflowRule'
 import { unknownContextProviderWorkflowRule } from './rules/workflows/unknownContextProviderWorkflowRule'
 import { unknownContextWorkflowRule } from './rules/workflows/unknownContextWorkflowRule'
@@ -104,6 +105,7 @@ const RULES = [
   createRequiredDirectChildRule(['dl'], ['dd', 'dt', 'script', 'template']),
   duplicateEventTriggerRule,
   duplicateUrlParameterRule,
+  duplicateWorkflowParameterRule,
   imageWithoutDimensionRule,
   legacyActionRule,
   legacyFormulaRule,

--- a/packages/search/src/rules/workflows/duplicateWorkflowParameterRule.test.ts
+++ b/packages/search/src/rules/workflows/duplicateWorkflowParameterRule.test.ts
@@ -1,0 +1,99 @@
+import { searchProject } from '../../searchProject'
+import { duplicateWorkflowParameterRule } from './duplicateWorkflowParameterRule'
+
+describe('duplicateWorkflowParameterRule', () => {
+  test('should detect duplicate workflow parameters', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              route: {
+                path: [],
+                query: {},
+              },
+              workflows: {
+                myWorkflow: {
+                  name: 'myWorkflow',
+                  parameters: [
+                    {
+                      name: 'myParameter',
+                      testValue: '1',
+                    },
+                    {
+                      name: 'myParameter',
+                      testValue: '1',
+                    },
+                  ],
+                  actions: [],
+                },
+              },
+            },
+          },
+        },
+        rules: [duplicateWorkflowParameterRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('duplicate workflow parameter')
+    expect(problems[0].path).toEqual([
+      'components',
+      'test',
+      'workflows',
+      'myWorkflow',
+      'parameters',
+      1,
+    ])
+    expect(problems[0].details).toEqual({ parameterName: 'myParameter' })
+  })
+  test('should not detect unique workflow parameters', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              route: {
+                path: [],
+                query: {},
+              },
+              workflows: {
+                myWorkflow: {
+                  name: 'myWorkflow',
+                  parameters: [
+                    {
+                      name: 'myParameter',
+                      testValue: '1',
+                    },
+                    {
+                      name: 'myOtherParameter',
+                      testValue: '1',
+                    },
+                  ],
+                  actions: [],
+                },
+              },
+            },
+          },
+        },
+        rules: [duplicateWorkflowParameterRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
+})

--- a/packages/search/src/rules/workflows/duplicateWorkflowParameterRule.ts
+++ b/packages/search/src/rules/workflows/duplicateWorkflowParameterRule.ts
@@ -1,0 +1,23 @@
+import type { Rule } from '../../types'
+
+export const duplicateWorkflowParameterRule: Rule<{ parameterName: string }> = {
+  code: 'duplicate workflow parameter',
+  level: 'warning',
+  category: 'Quality',
+  visit: (report, { nodeType, path, value }) => {
+    if (
+      nodeType !== 'component-workflow' ||
+      !value.parameters ||
+      (value.parameters ?? []).length === 0
+    ) {
+      return
+    }
+    const parameterNames = new Set<string>()
+    value.parameters.forEach((p, i) => {
+      if (parameterNames.has(p.name)) {
+        report([...path, 'parameters', i], { parameterName: p.name })
+      }
+      parameterNames.add(p.name)
+    })
+  },
+}

--- a/packages/search/src/rules/workflows/unknownWorkflowParameterRule.ts
+++ b/packages/search/src/rules/workflows/unknownWorkflowParameterRule.ts
@@ -6,7 +6,6 @@ export const unknownWorkflowParameterRule: Rule<{ parameter: string }> = {
   category: 'Unknown Reference',
   visit: (report, args) => {
     const { path, value, nodeType } = args
-    console.log({ path })
     if (
       nodeType !== 'formula' ||
       value.type !== 'path' ||

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -24,6 +24,7 @@ import type {
 type Code =
   | 'duplicate event trigger'
   | 'duplicate url parameter'
+  | 'duplicate workflow parameter'
   | 'legacy action'
   | 'legacy formula'
   | 'no-console'
@@ -171,10 +172,12 @@ type ComponentWorkflowNode = {
   nodeType: 'component-workflow'
   value: {
     name: string
-    parameters: {
-      name: string
-      testValue: any
-    }[]
+    parameters?:
+      | {
+          name: string
+          testValue: any
+        }[]
+      | null
     actions: ActionModel[]
     exposeInContext?: boolean | undefined
   }


### PR DESCRIPTION
Since workflow parameters are in an array (not an object), we can have duplicate parameter names. This rule will check for duplicate parameter names in the workflow parameters array.

I also:
- Relaxed types for workflow parameters
- Removed console.log