### PR TITLE
Adjust default array formulas for lib formulas

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.4-alpha.4",
+  "version": "0.0.4-alpha.3",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.4-alpha.3",
+  "version": "0.0.4-alpha.4",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/component/isPageComponent.ts
+++ b/packages/core/src/component/isPageComponent.ts
@@ -1,5 +1,6 @@
 import { isDefined } from '../utils/util'
-import type { Component } from './component.types'
+import type { Component, PageComponent } from './component.types'
 
-export const isPageComponent = (component: Component) =>
-  isDefined(component.route)
+export const isPageComponent = (
+  component: Component,
+): component is PageComponent => isDefined(component.route)

--- a/packages/lib/formulas/append/formula.json
+++ b/packages/lib/formulas/append/formula.json
@@ -7,12 +7,7 @@
         "type": "Array"
       },
       "description": "The array to append to",
-      "formula": {
-        "type": "function",
-        "name": "@toddle/list",
-        "arguments": [],
-        "variableArguments": true
-      }
+      "formula": { "type": "array", "arguments": [] }
     },
     {
       "name": "Item",

--- a/packages/lib/formulas/flatten/formula.json
+++ b/packages/lib/formulas/flatten/formula.json
@@ -6,12 +6,7 @@
       "name": "Array",
       "description": "An array containing one or more arrays",
       "type": { "type": "Array" },
-      "formula": {
-        "type": "function",
-        "name": "@toddle/list",
-        "arguments": [],
-        "variableArguments": true
-      }
+      "formula": { "type": "array", "arguments": [] }
     }
   ],
   "output": {

--- a/packages/lib/formulas/prepend/formula.json
+++ b/packages/lib/formulas/prepend/formula.json
@@ -7,12 +7,7 @@
         "type": "Array"
       },
       "description": "The array to prepend to",
-      "formula": {
-        "type": "function",
-        "name": "@toddle/list",
-        "arguments": [],
-        "variableArguments": true
-      }
+      "formula": { "type": "array", "arguments": [] }
     },
     {
       "name": "Item",

--- a/packages/lib/formulas/sum/formula.json
+++ b/packages/lib/formulas/sum/formula.json
@@ -5,12 +5,7 @@
       "name": "Array",
       "type": { "type": "Array" },
       "description": "The array of numbers to sum",
-      "formula": {
-        "type": "function",
-        "name": "@toddle/list",
-        "arguments": [],
-        "variableArguments": true
-      }
+      "formula": { "type": "array", "arguments": [] }
     }
   ],
   "description": "Return the sum of an array of numbers",


### PR DESCRIPTION
In the editor, sometimes it would suggest using a `List` formula that doesn't exist anymore. This PR adjusts the default formulas to use the builtin `lib` formulas instead.

Originally reported here https://discord.com/channels/972416966683926538/1345886710231334972

Currently, it looks like this in the live editor:
![Screenshot 2025-03-05 at 09 46 18](https://github.com/user-attachments/assets/da0d7025-77b2-409e-8aba-b1c06f756df4)