### PR TITLE
Load external page stylesheet from new endpoint

### DIFF
--- a/examples/cloudflare-worker/src/index.ts
+++ b/examples/cloudflare-worker/src/index.ts
@@ -11,6 +11,7 @@ import { manifest } from './routes/manifest'
 import { robots } from './routes/robots'
 import { serviceWorker } from './routes/serviceWorker'
 import { sitemap } from './routes/sitemap'
+import { stylesheetHandler } from './routes/stylesheetHandler'
 import { toddlePage } from './routes/toddlePage'
 
 // Inject isEqual on globalThis
@@ -53,6 +54,7 @@ app.get('/serviceWorker.js', serviceWorker)
 
 // toddle specific endpoints/services on /.toddle/ subpath 👇
 app.route('/.toddle/fonts', fontRouter)
+app.get('/.toddle/stylesheet/:pageName{.+.css}', stylesheetHandler)
 app.get('/.toddle/custom-code.js', customCode)
 app.all(
   '/.toddle/omvej/components/:componentName/apis/:apiName',

--- a/examples/cloudflare-worker/src/routes/stylesheetHandler.ts
+++ b/examples/cloudflare-worker/src/routes/stylesheetHandler.ts
@@ -1,0 +1,43 @@
+import { isPageComponent } from '@toddledev/core/dist/component/isPageComponent'
+import { createStylesheet } from '@toddledev/core/dist/styling/style.css'
+import { theme as defaultTheme } from '@toddledev/core/dist/styling/theme.const'
+import { takeIncludedComponents } from '@toddledev/ssr/dist/components/utils'
+import type { Context } from 'hono'
+import type { HonoEnv } from '../../hono'
+
+export const stylesheetHandler = async (
+  c: Context<HonoEnv, '/.toddle/stylesheet/:pageName{.+.css}'>,
+) => {
+  const project = c.var.project
+  let pageName = c.req.param('pageName')
+  // Remove the .css extension
+  pageName = pageName.slice(0, '.css'.length * -1)
+  const page = project.files.components[pageName]
+  if (!page || !isPageComponent(page)) {
+    return new Response(null, {
+      headers: { 'content-type': 'text/css' },
+      status: 404,
+    })
+  }
+  // Find the theme to use for the page
+  const theme =
+    (project.files.themes
+      ? Object.values(project.files.themes)[0]
+      : project.files.config?.theme) ?? defaultTheme
+
+  // Get all included components on the page
+  const includedComponents = takeIncludedComponents({
+    root: page,
+    projectComponents: project.files.components,
+    packages: project.files.packages,
+    includeRoot: true,
+  })
+
+  const styles = createStylesheet(page, includedComponents, theme, {
+    // The reset stylesheet is loaded separately
+    includeResetStyle: false,
+    // Font faces are created from a stylesheet referenced in the head
+    createFontFaces: false,
+  })
+  return c.text(styles, 200, { 'content-type': 'text/css' })
+}

--- a/examples/cloudflare-worker/src/routes/toddlePage.ts
+++ b/examples/cloudflare-worker/src/routes/toddlePage.ts
@@ -1,6 +1,5 @@
 import { ToddleComponent } from '@toddledev/core/dist/component/ToddleComponent'
 import { type ToddleServerEnv } from '@toddledev/core/dist/formula/formula'
-import { createStylesheet } from '@toddledev/core/dist/styling/style.css'
 import { theme as defaultTheme } from '@toddledev/core/dist/styling/theme.const'
 import type { ToddleInternals } from '@toddledev/core/dist/types'
 import { isDefined } from '@toddledev/core/dist/utils/util'
@@ -69,12 +68,6 @@ export const toddlePage = async (c: Context<HonoEnv>) => {
     includeRoot: true,
   })
 
-  // Currently, styles are inlined, but we want to serve these from a separate endpoint
-  const styles = createStylesheet(page, includedComponents, theme, {
-    includeResetStyle: false,
-    // Font faces are created from a stylesheet referenced in the head
-    createFontFaces: false,
-  })
   const toddleComponent = new ToddleComponent<string>({
     component: page,
     getComponent: (name, packageName) => {
@@ -176,11 +169,7 @@ export const toddlePage = async (c: Context<HonoEnv>) => {
     html`<!doctype html>
       <html lang="${language}">
         <head>
-          ${raw(head)}
-          <style>
-            ${raw(styles)}
-          </style>
-          ${raw(codeImport)}
+          ${raw(head)} ${raw(codeImport)}
         </head>
         <body>
           <div id="App">${raw(body)}</div>

--- a/examples/hono/src/index.ts
+++ b/examples/hono/src/index.ts
@@ -13,6 +13,7 @@ import { manifest } from './routes/manifest'
 import { robots } from './routes/robots'
 import { serviceWorker } from './routes/serviceWorker'
 import { sitemap } from './routes/sitemap'
+import { stylesheetHandler } from './routes/stylesheetHandler'
 import { toddlePage } from './routes/toddlePage'
 
 // Inject isEqual on globalThis
@@ -53,6 +54,7 @@ app.get('/serviceWorker.js', serviceWorker)
 
 // toddle specific endpoints/services on /.toddle/ subpath 👇
 app.route('/.toddle/fonts', fontRouter)
+app.get('/.toddle/stylesheet/:pageName{.+.css}', stylesheetHandler)
 app.get('/.toddle/custom-code.js', customCode)
 app.all(
   '/.toddle/omvej/components/:componentName/apis/:apiName',

--- a/examples/hono/src/routes/stylesheetHandler.ts
+++ b/examples/hono/src/routes/stylesheetHandler.ts
@@ -33,8 +33,8 @@ export const stylesheetHandler = async (
     includeRoot: true,
   })
 
-  // Currently, styles are inlined, but we want to serve these from a separate endpoint
   const styles = createStylesheet(page, includedComponents, theme, {
+    // The reset stylesheet is loaded separately
     includeResetStyle: false,
     // Font faces are created from a stylesheet referenced in the head
     createFontFaces: false,

--- a/examples/hono/src/routes/stylesheetHandler.ts
+++ b/examples/hono/src/routes/stylesheetHandler.ts
@@ -1,0 +1,43 @@
+import { isPageComponent } from '@toddledev/core/dist/component/isPageComponent'
+import { createStylesheet } from '@toddledev/core/dist/styling/style.css'
+import { theme as defaultTheme } from '@toddledev/core/dist/styling/theme.const'
+import { takeIncludedComponents } from '@toddledev/ssr/dist/components/utils'
+import type { Context } from 'hono'
+import type { HonoEnv } from '../../hono'
+
+export const stylesheetHandler = async (
+  c: Context<HonoEnv, '/.toddle/stylesheet/:pageName{.+.css}'>,
+) => {
+  const project = c.var.project
+  let pageName = c.req.param('pageName')
+  // Remove the .css extension
+  pageName = pageName.slice(0, '.css'.length * -1)
+  const page = project.files.components[pageName]
+  if (!page || !isPageComponent(page)) {
+    return new Response(null, {
+      headers: { 'content-type': 'text/css' },
+      status: 404,
+    })
+  }
+  // Find the theme to use for the page
+  const theme =
+    (project.files.themes
+      ? Object.values(project.files.themes)[0]
+      : project.files.config?.theme) ?? defaultTheme
+
+  // Get all included components on the page
+  const includedComponents = takeIncludedComponents({
+    root: page,
+    projectComponents: project.files.components,
+    packages: project.files.packages,
+    includeRoot: true,
+  })
+
+  // Currently, styles are inlined, but we want to serve these from a separate endpoint
+  const styles = createStylesheet(page, includedComponents, theme, {
+    includeResetStyle: false,
+    // Font faces are created from a stylesheet referenced in the head
+    createFontFaces: false,
+  })
+  return c.text(styles, 200, { 'content-type': 'text/css' })
+}

--- a/examples/hono/src/routes/toddlePage.ts
+++ b/examples/hono/src/routes/toddlePage.ts
@@ -1,6 +1,5 @@
 import { ToddleComponent } from '@toddledev/core/dist/component/ToddleComponent'
 import { type ToddleServerEnv } from '@toddledev/core/dist/formula/formula'
-import { createStylesheet } from '@toddledev/core/dist/styling/style.css'
 import { theme as defaultTheme } from '@toddledev/core/dist/styling/theme.const'
 import type { ToddleInternals } from '@toddledev/core/dist/types'
 import { isDefined } from '@toddledev/core/dist/utils/util'
@@ -69,12 +68,6 @@ export const toddlePage = async (c: Context<HonoEnv>) => {
     includeRoot: true,
   })
 
-  // Currently, styles are inlined, but we want to serve these from a separate endpoint
-  const styles = createStylesheet(page, includedComponents, theme, {
-    includeResetStyle: false,
-    // Font faces are created from a stylesheet referenced in the head
-    createFontFaces: false,
-  })
   const toddleComponent = new ToddleComponent<string>({
     component: page,
     getComponent: (name, packageName) => {
@@ -176,11 +169,7 @@ export const toddlePage = async (c: Context<HonoEnv>) => {
     html`<!doctype html>
       <html lang="${language}">
         <head>
-          ${raw(head)}
-          <style>
-            ${raw(styles)}
-          </style>
-          ${raw(codeImport)}
+          ${raw(head)} ${raw(codeImport)}
         </head>
         <body>
           <div id="App">${raw(body)}</div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.5",
+  "version": "0.0.5-alpha.1",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/styling/style.css.ts
+++ b/packages/core/src/styling/style.css.ts
@@ -239,12 +239,10 @@ ${selector}::-webkit-scrollbar {
         )
         if (childComponent) {
           insertComponentStyles(childComponent, node.package ?? package_name)
-          stylesheet +=
-            '\n' +
-            getNodeStyles(
-              node as any,
-              toValidClassName(`${component.name}:${id}`, true),
-            )
+          stylesheet += getNodeStyles(
+            node as any,
+            toValidClassName(`${component.name}:${id}`, true),
+          )
 
           return
         }
@@ -257,7 +255,7 @@ ${selector}::-webkit-scrollbar {
         return ''
       }
       hashes.add(classHash)
-      stylesheet += '\n' + getNodeStyles(node as any, classHash)
+      stylesheet += getNodeStyles(node as any, classHash)
     })
   }
   insertComponentStyles(root)

--- a/packages/core/src/styling/theme.ts
+++ b/packages/core/src/styling/theme.ts
@@ -85,9 +85,7 @@ export const getThemeCss = (theme: Theme | OldTheme, options: ThemeOptions) => {
   if ('breakpoints' in theme) {
     return getOldThemeCss(theme)
   }
-  return `
-${options.includeResetStyle ? RESET_STYLES : ''}
-
+  return `${options.includeResetStyle ? RESET_STYLES : ''}
 @layer base {
   ${
     options.createFontFaces
@@ -117,7 +115,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
           .join('\n')
       : ''
   }
-
   body, :host {
     /* Color */
       ${theme.color
@@ -143,7 +140,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
         ),
       )
       .join('\n')}
-
     /* Font weight */
     ${theme['font-weight']
       .flatMap((group) => {
@@ -157,7 +153,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
         )
       })
       .join('\n')}
-
     /* Shadows */
     ${theme.shadow
       .flatMap((group) => {
@@ -171,7 +166,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
         )
       })
       .join('\n')}
-
     /* Border radius */
     ${theme['border-radius']
       .flatMap((group) => {
@@ -183,7 +177,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
         )
       })
       .join('\n')}
-
     /* Spacing */
     ${theme.spacing
       .map((group) => {
@@ -199,7 +192,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
           .join('\n')
       })
       .join('\n')}
-
     /* Z-index */
     ${theme['z-index']
       .map((group) => {
@@ -216,7 +208,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
       })
       .join('\n')}
   }
-
   @keyframes animation-spin {
     from {
       transform: rotate(0deg);
@@ -225,7 +216,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
       transform: rotate(360deg);
     }
   }
-
   @keyframes animation-fade-in {
     from {
       opacity:0;
@@ -234,8 +224,6 @@ ${options.includeResetStyle ? RESET_STYLES : ''}
       opacity:1;
     }
   }
-
-
   @keyframes animation-fade-out {
     from {
       opacity:1;

--- a/packages/ssr/src/rendering/head.ts
+++ b/packages/ssr/src/rendering/head.ts
@@ -26,8 +26,10 @@ export const getHeadItems = ({
   cacheBuster,
   context,
   cssBasePath = '/.toddle/fonts/stylesheet/css2',
-  files,
   page,
+  resetStylesheetPath = '/_static/reset.css',
+  pageStylesheetPath = `/.toddle/stylesheet/${page.name}.css`,
+  files,
   project,
   theme,
   url,
@@ -38,6 +40,8 @@ export const getHeadItems = ({
   cssBasePath?: string
   files: ProjectFiles
   page: ToddleComponent<string>
+  resetStylesheetPath?: string
+  pageStylesheetPath?: string
   project: ToddleProject
   theme: OldTheme | Theme
   url: URL
@@ -83,7 +87,6 @@ export const getHeadItems = ({
     }
   }
 
-  const stylesheetUrl = urlWithCacheBuster('/_static/reset.css', cacheBuster)
   const charset = getCharset({ pageInfo, formulaContext: context })
   const descriptionItems: [HeadItemType, string][] = []
   if (typeof description === 'string') {
@@ -102,8 +105,11 @@ export const getHeadItems = ({
   const headItems = new Map<HeadItemType, string>([
     [
       'link:reset',
-      // The reset stylesheet should be loaded asap to avoid any flickering
-      `<link rel="stylesheet" fetchpriority="high" href="${escapeAttrValue(stylesheetUrl)}" />`,
+      `<link rel="stylesheet" fetchpriority="high" href="${escapeAttrValue(urlWithCacheBuster(resetStylesheetPath, cacheBuster))}" />`,
+    ],
+    [
+      'link:page',
+      `<link rel="stylesheet" fetchpriority="high" href="${escapeAttrValue(urlWithCacheBuster(pageStylesheetPath, cacheBuster))}" />`,
     ],
     ...preloadFonts,
     // Initialize default head items (meta + links)
@@ -338,7 +344,9 @@ export const defaultHeadOrdering: HeadItemType[] = [
   'meta:apple-mobile-web-app-title',
   'meta:msapplication-tilecolor',
   'meta:og:locale',
+  // The stylesheets should be loaded asap to avoid any flickering
   'link:reset',
+  'link:page',
   // Everything else comes after these predefined tags
 ]
 


### PR DESCRIPTION
Currently, we inline CSS for all components in the page. To improve the browser's chance of caching the CSS, reduce the page (HTML document) size and improve the performance of the page, we should load the CSS from a separate endpoint.

This PR:
- Adds a link element in the `<head>` that loads an external stylesheet
- Adds an endpoint in the hono example that serves the stylesheet (uncached in the example)
- Stops inlining the component styles
- Reduces the amount of whitespace in the style output