### PR TITLE
Do not report global formula/actions that are exported from packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.4-alpha.4",
+  "version": "0.0.4-alpha.5",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/search/src/rules/noReferenceProjectActionRule.test.ts
+++ b/packages/search/src/rules/noReferenceProjectActionRule.test.ts
@@ -91,4 +91,37 @@ describe('noReferenceProjectAction', () => {
 
     expect(problems).toEqual([])
   })
+
+  describe('noReferenceProjectAction', () => {
+    test('should not detect exported unused global actions', () => {
+      const problems = Array.from(
+        searchProject({
+          files: {
+            actions: {
+              'my-action': {
+                name: 'my-action',
+                arguments: [],
+                handler: '() => console.log("test")',
+                variableArguments: false,
+                exported: true,
+              },
+            },
+            components: {
+              test: {
+                name: 'test',
+                nodes: {},
+                formulas: {},
+                apis: {},
+                attributes: {},
+                variables: {},
+              },
+            },
+          },
+          rules: [noReferenceProjectActionRule],
+        }),
+      )
+
+      expect(problems).toHaveLength(0)
+    })
+  })
 })

--- a/packages/search/src/rules/noReferenceProjectActionRule.ts
+++ b/packages/search/src/rules/noReferenceProjectActionRule.ts
@@ -7,7 +7,7 @@ export const noReferenceProjectActionRule: Rule<void> = {
   level: 'warning',
   category: 'No References',
   visit: (report, { path, files, value, nodeType, memo }) => {
-    if (nodeType !== 'project-action') {
+    if (nodeType !== 'project-action' || value.exported === true) {
       return
     }
 

--- a/packages/search/src/rules/noReferenceProjectFormulaRule.test.ts
+++ b/packages/search/src/rules/noReferenceProjectFormulaRule.test.ts
@@ -248,4 +248,37 @@ describe('noReferenceFormulaRule', () => {
 
     expect(problems).toEqual([])
   })
+
+  test('should not detect unused exported global formulas', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {
+            'my-formula': {
+              name: 'my-formula',
+              arguments: [],
+              formula: {
+                type: 'value',
+                value: 'value',
+              },
+              exported: true,
+            },
+          },
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noReferenceProjectFormulaRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
 })

--- a/packages/search/src/rules/noReferenceProjectFormulaRule.ts
+++ b/packages/search/src/rules/noReferenceProjectFormulaRule.ts
@@ -10,7 +10,7 @@ export const noReferenceProjectFormulaRule: Rule<void> = {
   level: 'warning',
   category: 'No References',
   visit: (report, { path, files, value, nodeType, memo }) => {
-    if (nodeType !== 'project-formula') {
+    if (nodeType !== 'project-formula' || value.exported === true) {
       return
     }
 


### PR DESCRIPTION
We already had a similar check for component, but were missing from formulas/actions.