### PR TITLE
Pass componentData to API fetch function + friends

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.5-alpha.4",
+  "version": "0.0.6",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,7 +13,8 @@
     "sourceMap": true,
     "strict": true,
     "strictBuiltinIteratorReturn": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "verbatimModuleSyntax": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -11,7 +11,8 @@
     "strict": true,
     "strictBuiltinIteratorReturn": true,
     "target": "ESNext",
-    "types": []
+    "types": [],
+    "verbatimModuleSyntax": true
   },
   "include": ["actions", "formulas", "./actions.ts", "./formulas.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/runtime/src/api/apiUtils.ts
+++ b/packages/runtime/src/api/apiUtils.ts
@@ -1,0 +1,4 @@
+import type { ContextApi, ContextApiV2 } from '../types'
+
+export const isContextApiV2 = (api: ContextApi): api is ContextApiV2 =>
+  'triggerActions' in api

--- a/packages/runtime/src/api/createAPI.ts
+++ b/packages/runtime/src/api/createAPI.ts
@@ -24,7 +24,7 @@ export type ApiRequest = {
 export function createLegacyAPI(
   api: LegacyComponentAPI,
   ctx: ComponentContext,
-): { fetch: Function; destroy: Function } {
+) {
   let timer: any = null
 
   // Create the payload we send to toddle's back-end

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -4,9 +4,9 @@ import type {
   ComponentNodeModel,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
-import type { RequireFields } from '@toddledev/core/dist/types'
 import { mapObject } from '@toddledev/core/dist/utils/collections'
 import { isDefined } from '@toddledev/core/dist/utils/util'
+import { isContextApiV2 } from '../api/apiUtils'
 import { createLegacyAPI } from '../api/createAPI'
 import { createAPI } from '../api/createAPIv2'
 import { isContextProvider } from '../context/isContextProvider'
@@ -149,35 +149,36 @@ export function createComponent({
         },
       })
     } else {
-      apis[name] = createAPI(api, {
-        ...ctx,
-        apis,
-        component,
-        dataSignal: componentDataSignal,
-        abortSignal: abortController.signal,
-        isRootComponent: false,
-        formulaCache,
-        package: node.package ?? ctx.package,
-        triggerEvent: (eventTrigger, data) => {
-          const eventHandler = Object.values(node.events).find(
-            (e) => e.trigger === eventTrigger,
-          )
-          if (eventHandler) {
-            eventHandler.actions.forEach((action) =>
-              handleAction(action, { ...dataSignal.get(), Event: data }, ctx),
+      apis[name] = createAPI({
+        apiRequest: api,
+        ctx: {
+          ...ctx,
+          apis,
+          component,
+          dataSignal: componentDataSignal,
+          abortSignal: abortController.signal,
+          isRootComponent: false,
+          formulaCache,
+          package: node.package ?? ctx.package,
+          triggerEvent: (eventTrigger, data) => {
+            const eventHandler = Object.values(node.events).find(
+              (e) => e.trigger === eventTrigger,
             )
-          }
+            if (eventHandler) {
+              eventHandler.actions.forEach((action) =>
+                handleAction(action, { ...dataSignal.get(), Event: data }, ctx),
+              )
+            }
+          },
         },
+        componentData: componentDataSignal.get(),
       })
     }
   })
   Object.values(apis)
-    .filter(
-      (api): api is RequireFields<ContextApi, 'triggerActions'> =>
-        api.triggerActions !== undefined,
-    )
+    .filter(isContextApiV2)
     .forEach((api) => {
-      api.triggerActions()
+      api.triggerActions(componentDataSignal.get())
     })
 
   const onEvent = (eventTrigger: string, data: any) => {

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -10,6 +10,7 @@ import type { Signal } from '../signal/signal'
 import type {
   ComponentChild,
   ComponentContext,
+  ContextApi,
   FormulaCache,
   LocationSignal,
   PreviewShowSignal,
@@ -22,7 +23,7 @@ interface RenderComponentProps {
   component: Component
   components: Component[]
   dataSignal: Signal<ComponentData>
-  apis: Record<string, { fetch: Function; destroy: Function }>
+  apis: Record<string, ContextApi>
   abortSignal: AbortSignal
   onEvent: (event: string, data: unknown) => void
   isRootComponent: boolean

--- a/packages/runtime/src/custom-element/ToddleComponent.ts
+++ b/packages/runtime/src/custom-element/ToddleComponent.ts
@@ -8,15 +8,16 @@ import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import { createStylesheet } from '@toddledev/core/dist/styling/style.css'
 import type { Theme } from '@toddledev/core/dist/styling/theme'
 import { theme as defaultTheme } from '@toddledev/core/dist/styling/theme.const'
-import type { RequireFields, Toddle } from '@toddledev/core/dist/types'
+import type { Toddle } from '@toddledev/core/dist/types'
 import { mapObject } from '@toddledev/core/dist/utils/collections'
+import { isContextApiV2 } from '../api/apiUtils'
 import { createLegacyAPI } from '../api/createAPI'
 import { createAPI } from '../api/createAPIv2'
 import { renderComponent } from '../components/renderComponent'
 import { isContextProvider } from '../context/isContextProvider'
 import type { Signal } from '../signal/signal'
 import { signal } from '../signal/signal'
-import type { ComponentContext, ContextApi, LocationSignal } from '../types'
+import type { ComponentContext, LocationSignal } from '../types'
 
 /**
  * Base class for all toddle components
@@ -97,17 +98,18 @@ export class ToddleComponent extends HTMLElement {
         if (isLegacyApi(api)) {
           this.#ctx.apis[name] = createLegacyAPI(api, this.#ctx)
         } else {
-          this.#ctx.apis[name] = createAPI(api, this.#ctx)
+          this.#ctx.apis[name] = createAPI({
+            apiRequest: api,
+            ctx: this.#ctx,
+            componentData: this.#signal.get(),
+          })
         }
       },
     )
     Object.values(this.#ctx.apis)
-      .filter(
-        (api): api is RequireFields<ContextApi, 'triggerActions'> =>
-          api.triggerActions !== undefined,
-      )
+      .filter(isContextApiV2)
       .forEach((api) => {
-        api.triggerActions()
+        api.triggerActions(this.#signal.get())
       })
 
     let providers = this.#ctx.providers

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -44,6 +44,7 @@ import { signal } from './signal/signal'
 import { insertStyles, styleToCss } from './styles/style'
 import type {
   ComponentContext,
+  ContextApiV2,
   LocationSignal,
   PreviewShowSignal,
 } from './types'
@@ -758,7 +759,7 @@ export const createRoot = (
               },
             },
           }))
-          ctx?.apis[apiKey]?.fetch({})
+          void ctx?.apis[apiKey]?.fetch({} as any)
           break
         case 'drag-started':
           const draggedElement = getDOMNodeFromNodeId(selectedNodeId)
@@ -1217,11 +1218,16 @@ export const createRoot = (
           newCtx.apis[api] = createLegacyAPI(apiInstance, newCtx)
         }
       } else {
-        if (!newCtx.apis[api]) {
-          newCtx.apis[api] = createAPI(apiInstance, newCtx)
+        const existingApi = newCtx.apis[api] as ContextApiV2 | undefined
+        if (!existingApi) {
+          newCtx.apis[api] = createAPI({
+            apiRequest: apiInstance,
+            ctx: newCtx,
+            componentData: dataSignal.get(),
+          })
         } else {
-          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-          newCtx.apis[api].update && newCtx.apis[api].update(apiInstance)
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          existingApi?.update(apiInstance, dataSignal.get())
         }
       }
     }

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -1,13 +1,20 @@
+import type { ApiRequest as CoreApiRequest } from '@toddledev/core/dist/api/apiTypes'
 import type {
+  ActionModel,
   Component,
   ComponentData,
 } from '@toddledev/core/dist/component/component.types'
-import type { ToddleEnv } from '@toddledev/core/dist/formula/formula'
+import type {
+  Formula,
+  ToddleEnv,
+  ValueOperationValue,
+} from '@toddledev/core/dist/formula/formula'
 import type {
   Toddle as NewToddle,
   Toddle,
   ToddleInternals,
 } from '@toddledev/core/dist/types'
+import type { ApiRequest } from './api/createAPI'
 import type { Signal } from './signal/signal'
 
 declare global {
@@ -75,11 +82,33 @@ export interface ComponentContext {
   env: ToddleEnv
 }
 
-export type ContextApi = {
-  fetch: Function
+export type ContextApi = ContextApiV1 | ContextApiV2
+
+export interface ContextApiV1 {
+  fetch: (api?: ApiRequest) => Promise<unknown>
   destroy: Function
-  update?: Function // for updating the dataSignal (v2 only)
-  triggerActions?: Function // for triggering actions explicitly. Useful when initializing apis (v2 only)
+}
+
+export interface ContextApiV2 {
+  fetch: (args: {
+    actionInputs?: Record<
+      string,
+      | ValueOperationValue
+      | {
+          name: string
+          formula?: Formula
+        }
+    >
+    actionModels?: {
+      onCompleted: ActionModel[]
+      onFailed: ActionModel[]
+      onMessage: ActionModel[]
+    }
+    componentData: ComponentData
+  }) => Promise<unknown>
+  destroy: Function
+  update: (newApi: CoreApiRequest, componentData: ComponentData) => void // for updating the dataSignal (v2 only)
+  triggerActions: (componentData: ComponentData) => void // for triggering actions explicitly. Useful when initializing apis (v2 only)
 }
 
 export type FormulaCache = Record<

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -3,7 +3,6 @@
     "alwaysStrict": true,
     "declaration": true,
     "esModuleInterop": true,
-    "verbatimModuleSyntax": true,
     "jsx": "react",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
@@ -13,7 +12,8 @@
     "sourceMap": true,
     "strict": true,
     "strictBuiltinIteratorReturn": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "verbatimModuleSyntax": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -3,6 +3,7 @@
     "alwaysStrict": true,
     "declaration": true,
     "esModuleInterop": true,
+    "verbatimModuleSyntax": true,
     "jsx": "react",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -11,7 +11,8 @@
     "sourceMap": true,
     "strict": true,
     "strictBuiltinIteratorReturn": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "verbatimModuleSyntax": true
   },
   "include": ["src"]
 }

--- a/packages/ssr/tsconfig.json
+++ b/packages/ssr/tsconfig.json
@@ -1,17 +1,18 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
+    "declaration": true,
     "esModuleInterop": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "outDir": "dist",
     "preserveConstEnums": true,
     "sourceMap": true,
     "strict": true,
     "strictBuiltinIteratorReturn": true,
     "target": "ESNext",
-    "outDir": "dist",
-    "declaration": true
+    "verbatimModuleSyntax": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
During API fetching, the (updated) `componentData` was not available which meant that we couldn't access workflow parameters for instance.
I'm not sure the approach in this PR is correct - perhaps we could just access a data signal instead?

To test, check this project/branch: https://custom-actions-awesome_blog.toddle.site/
Project here: https://toddle.dev/projects/awesome_blog/branches/custom-actions/components/my-component?leftpanel=design&canvas-width=800&canvas-height=800&rightpanel=events&selection=workflows.5pvRjU.actions.1

Reported issue here: https://discord.com/channels/972416966683926538/1346548793029693450