### PR TITLE
Allow div as a direct child of dl

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -102,7 +102,10 @@ const RULES = [
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend#technical_summary
   createRequiredDirectParentRule(['fieldset'], ['legend']),
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl#technical_summary
-  createRequiredDirectChildRule(['dl'], ['dd', 'dt', 'script', 'template']),
+  createRequiredDirectChildRule(
+    ['dl'],
+    ['dd', 'dt', 'div', 'script', 'template'],
+  ),
   duplicateEventTriggerRule,
   duplicateUrlParameterRule,
   duplicateWorkflowParameterRule,


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl#wrapping_name-value_groups_in_div_elements

Also, see reported issue here https://discord.com/channels/972416966683926538/1348724790013464596