### PR TITLE
Change output format for esm files in runtime

### DIFF
--- a/examples/hono/scripts/syncStaticAssets.js
+++ b/examples/hono/scripts/syncStaticAssets.js
@@ -6,9 +6,10 @@ import { RESET_STYLES } from '@toddledev/core/dist/styling/theme.const'
 // assets/_static/ folder
 fs.mkdirSync(`${__dirname}/../assets/_static`, { recursive: true })
 ;[
-  'esm-page.main.js',
-  'esm-page.main.js.map',
-  'esm-custom-element.main.js',
+  'page.main.esm.js',
+  'page.main.esm.js.map',
+  'custom-element.main.esm.js',
+  'custom-element.main.esm.js.map',
 ].forEach((f) =>
   fs.copyFileSync(
     `${__dirname}/../../../packages/runtime/dist/${f}`,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.5-alpha.4",
+  "version": "0.0.5-alpha.5",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/scripts/build.js
+++ b/packages/runtime/scripts/build.js
@@ -11,5 +11,5 @@ esbuild.build({
   write: true,
   outdir: 'dist',
   format: 'esm',
-  entryNames: '[dir]/esm-[name]',
+  entryNames: '[dir]/[name].esm',
 })


### PR DESCRIPTION
Following the discussion [here](https://github.com/toddledev/toddle/pull/92#discussion_r1944877998), this PR changes the output format for esm files in runtime + updates the references from the Hono example.
