### PR TITLE
Support historyMode in SetURLParameterAction

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -303,6 +303,7 @@ export type SetURLParameterAction = {
   type: 'SetURLParameter'
   parameter: string
   data: Formula
+  historyMode?: 'replace' | 'push' | null
 }
 
 export type EventActionModel = {

--- a/packages/runtime/src/events/handleAction.ts
+++ b/packages/runtime/src/events/handleAction.ts
@@ -84,18 +84,15 @@ export function handleAction(
       }
       case 'SetURLParameter': {
         ctx.toddle.locationSignal.update((current) => {
-          // We only evaluate the formula if the parameter is
-          // available in the page's route
-          const getValue = () =>
-            applyFormula(action.data, {
-              data,
-              component: ctx.component,
-              formulaCache: ctx.formulaCache,
-              root: ctx.root,
-              package: ctx.package,
-              toddle: ctx.toddle,
-              env: ctx.env,
-            })
+          const value = applyFormula(action.data, {
+            data,
+            component: ctx.component,
+            formulaCache: ctx.formulaCache,
+            root: ctx.root,
+            package: ctx.package,
+            toddle: ctx.toddle,
+            env: ctx.env,
+          })
           // historyMode was previously not declared explicitly, and we default
           // to push for state changes and replace for query changes
           let historyMode: SetURLParameterAction['historyMode'] | undefined
@@ -104,7 +101,6 @@ export function handleAction(
           // that would technically be a breaking change
           if (current.route?.path.some((p) => p.name === action.parameter)) {
             historyMode = 'push'
-            const value = getValue()
             newLocation = {
               ...current,
               params: {
@@ -118,7 +114,6 @@ export function handleAction(
           // else if (Object.values(current.route?.query ?? {}).some((q) => q.name === action.parameter))
           else {
             historyMode = 'replace'
-            const value = getValue()
             newLocation = {
               ...current,
               query: {

--- a/packages/runtime/src/events/handleAction.ts
+++ b/packages/runtime/src/events/handleAction.ts
@@ -1,11 +1,13 @@
 import type {
   ActionModel,
   ComponentData,
+  SetURLParameterAction,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import { mapValues, omitKeys } from '@toddledev/core/dist/utils/collections'
 import { isDefined, toBoolean } from '@toddledev/core/dist/utils/util'
-import type { ComponentContext } from '../types'
+import type { ComponentContext, Location } from '../types'
+import { getLocationUrl } from '../utils/url'
 
 // eslint-disable-next-line max-params
 export function handleAction(
@@ -82,25 +84,42 @@ export function handleAction(
       }
       case 'SetURLParameter': {
         ctx.toddle.locationSignal.update((current) => {
-          const value = applyFormula(action.data, {
-            data,
-            component: ctx.component,
-            formulaCache: ctx.formulaCache,
-            root: ctx.root,
-            package: ctx.package,
-            toddle: ctx.toddle,
-            env: ctx.env,
-          })
+          // We only evaluate the formula if the parameter is
+          // available in the page's route
+          const getValue = () =>
+            applyFormula(action.data, {
+              data,
+              component: ctx.component,
+              formulaCache: ctx.formulaCache,
+              root: ctx.root,
+              package: ctx.package,
+              toddle: ctx.toddle,
+              env: ctx.env,
+            })
+          // historyMode was previously not declared explicitly, and we default
+          // to push for state changes and replace for query changes
+          let historyMode: SetURLParameterAction['historyMode'] | undefined
+          let newLocation: Location | undefined
+          // We should only match on p.type === 'param', but
+          // that would technically be a breaking change
           if (current.route?.path.some((p) => p.name === action.parameter)) {
-            return {
+            historyMode = 'push'
+            const value = getValue()
+            newLocation = {
               ...current,
               params: {
                 ...omitKeys(current.params, [action.parameter]),
                 [action.parameter]: value,
               },
             }
-          } else {
-            return {
+          }
+          // We should check if the query parameter exists in the route
+          // but that would technically be a breaking change
+          // else if (Object.values(current.route?.query ?? {}).some((q) => q.name === action.parameter))
+          else {
+            historyMode = 'replace'
+            const value = getValue()
+            newLocation = {
               ...current,
               query: {
                 ...omitKeys(current.query, [action.parameter]),
@@ -108,6 +127,25 @@ export function handleAction(
               },
             }
           }
+          if (!historyMode) {
+            // No path/query parameter matched
+            return current
+          }
+
+          const currentUrl = getLocationUrl(current)
+          const historyUrl = getLocationUrl(newLocation)
+          if (historyUrl !== currentUrl) {
+            // Default to the historyMode from the action, and fallback
+            // to the default (push for path change, replace for query change)
+            historyMode = action.historyMode ?? historyMode
+            // Update the window's history state
+            if (historyMode === 'push') {
+              window.history.pushState({}, '', historyUrl)
+            } else {
+              window.history.replaceState({}, '', historyUrl)
+            }
+          }
+          return newLocation
         })
         break
       }

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -20,7 +20,7 @@ import { isDefined } from '@toddledev/core/dist/utils/util'
 import * as libActions from '@toddledev/std-lib/dist/actions'
 import * as libFormulas from '@toddledev/std-lib/dist/formulas'
 import fastDeepEqual from 'fast-deep-equal'
-import { compile, match } from 'path-to-regexp'
+import { match } from 'path-to-regexp'
 import { createLegacyAPI } from './api/createAPI'
 import { createAPI } from './api/createAPIv2'
 import { renderComponent } from './components/renderComponent'
@@ -134,44 +134,6 @@ export const createRoot = (domNode: HTMLElement) => {
     throw new Error('Missing components')
   }
 
-  const urlSignal = window.toddle.locationSignal.map(
-    ({ query, page, route, params, hash }) => {
-      let path: string
-      if (route) {
-        const pathSegments: string[] = []
-        for (const segment of route.path) {
-          if (segment.type === 'static') {
-            pathSegments.push(segment.name)
-          } else {
-            const segmentValue = params[segment.name]
-            if (isDefined(segmentValue)) {
-              pathSegments.push(segmentValue)
-            } else {
-              // If a param is missing, we can't build the rest of the path
-              break
-            }
-          }
-        }
-        path = '/' + pathSegments.join('/')
-      } else {
-        path = compile(page as string, { encode: encodeURIComponent })(params)
-      }
-      const hashString = hash === undefined || hash === '' ? '' : '#' + hash
-      const queryString = Object.entries(query)
-        .filter(([_, q]) => q !== null)
-        .map(([key, value]) => {
-          return `${encodeURIComponent(
-            component?.route?.query[key]?.name ?? key,
-          )}=${encodeURIComponent(String(value))}`
-        })
-        .join('&')
-
-      return `${path}${hashString}${
-        queryString.length > 0 ? '?' + queryString : ''
-      }`
-    },
-  )
-
   window.addEventListener('popstate', () => {
     if (!component) {
       return
@@ -187,15 +149,6 @@ export const createRoot = (domNode: HTMLElement) => {
         hash,
       }
     })
-  })
-
-  urlSignal.subscribe((url) => {
-    const [path] = url.split('?')
-    if (path == window.location.pathname) {
-      window.history.replaceState({}, '', url)
-    } else {
-      window.history.pushState({}, '', url)
-    }
   })
 
   const routeSignal = window.toddle.locationSignal.map(({ query, params }) => {

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -18,14 +18,16 @@ declare global {
   }
 }
 
-export type LocationSignal = Signal<{
+export type LocationSignal = Signal<Location>
+
+export interface Location {
   route: Component['route']
   page?: string
   path: string
   params: Record<string, string | null>
   query: Record<string, string | string[] | null>
   hash?: string
-}>
+}
 
 export type PreviewShowSignal = Signal<{
   displayedNodes: string[]

--- a/packages/runtime/src/utils/url.ts
+++ b/packages/runtime/src/utils/url.ts
@@ -1,0 +1,45 @@
+import { isDefined } from '@toddledev/core/dist/utils/util'
+import { compile } from 'path-to-regexp'
+import type { Location } from '../types'
+
+export const getLocationUrl = ({
+  query,
+  page,
+  route,
+  params,
+  hash,
+}: Location) => {
+  let path: string
+  if (route) {
+    const pathSegments: string[] = []
+    for (const segment of route.path) {
+      if (segment.type === 'static') {
+        pathSegments.push(segment.name)
+      } else {
+        const segmentValue = params[segment.name]
+        if (isDefined(segmentValue)) {
+          pathSegments.push(segmentValue)
+        } else {
+          // If a param is missing, we can't build the rest of the path
+          break
+        }
+      }
+    }
+    path = '/' + pathSegments.join('/')
+  } else {
+    path = compile(page as string, { encode: encodeURIComponent })(params)
+  }
+  const hashString = hash === undefined || hash === '' ? '' : '#' + hash
+  const queryString = Object.entries(query)
+    .filter(([_, q]) => q !== null)
+    .map(([key, value]) => {
+      return `${encodeURIComponent(
+        route?.query[key]?.name ?? key,
+      )}=${encodeURIComponent(String(value))}`
+    })
+    .join('&')
+
+  return `${path}${hashString}${
+    queryString.length > 0 ? '?' + queryString : ''
+  }`
+}


### PR DESCRIPTION
To allow more flexibility when updating path/query parameters, we want to allow setting whether the action should push or replace the history state. This is also useful when you want to update multiple parameters - although we should have a separate/similar action for that scenario.
