### PR TITLE
Structure and editor messages for handling animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -37,6 +37,13 @@ export interface ComponentData {
   ListItem?: ListItem
 }
 
+export interface AnimationKeyframe {
+  position: number
+  key: string
+  value: string
+  easing?: never
+}
+
 export interface StyleVariant {
   id?: string
   className?: string
@@ -79,6 +86,7 @@ export interface ElementNodeModel {
   attrs: Partial<Record<string, Formula>>
   style: NodeStyleModel
   variants?: StyleVariant[]
+  animations?: Record<string, Record<string, AnimationKeyframe>>
   children: string[]
   events: Record<string, EventModel>
   classes: Record<string, { formula?: Formula }>
@@ -102,6 +110,7 @@ export interface ComponentNodeModel {
   repeatKey?: Formula
   style?: NodeStyleModel
   variants?: StyleVariant[]
+  animations?: Record<string, Record<string, AnimationKeyframe>>
   attrs: Record<string, Formula>
   children: string[]
   events: Record<string, EventModel>

--- a/packages/core/src/styling/style.css.ts
+++ b/packages/core/src/styling/style.css.ts
@@ -207,6 +207,28 @@ ${selector}::-webkit-scrollbar {
           return renderedVariant
         })
         .join('\n')}
+        ${
+          node.animations
+            ? Object.entries(node.animations)
+                .map(([animationName, keyframes]) => {
+                  return `
+                  @keyframes ${animationName} {
+                    ${Object.values(keyframes)
+                      .sort((a, b) => a.position - b.position)
+                      .map(({ key, position, value }) => {
+                        return `
+                        ${position * 100}% {
+                          ${key}: ${value};
+                        }
+                        `
+                      })
+                      .join('\n')}
+                  }
+                  `
+                })
+                .join('\n')
+            : ''
+        }
       `
     } catch (e) {
       console.error(e)

--- a/packages/core/src/styling/variantSelector.ts
+++ b/packages/core/src/styling/variantSelector.ts
@@ -1,5 +1,8 @@
 import type { CSSProperties } from 'react'
-import type { EventModel } from '../component/component.types'
+import type {
+  AnimationKeyframe,
+  EventModel,
+} from '../component/component.types'
 import type { Formula } from '../formula/formula'
 
 export type Shadow = {
@@ -98,6 +101,7 @@ export type ElementNodeModel = {
   attrs: Record<string, Formula>
   style: NodeStyleModel
   variants?: StyleVariant[]
+  animations?: Record<string, Record<string, AnimationKeyframe>>
   children: NodeModel[]
   events: EventModel[]
 }
@@ -112,6 +116,7 @@ export type ComponentNodeModel = {
   repeatKey?: Formula
   style?: NodeStyleModel
   variants?: StyleVariant[]
+  animations?: Record<string, Record<string, AnimationKeyframe>>
   attrs: Record<string, Formula>
   children: NodeModel[]
   events: EventModel[]

--- a/packages/runtime/src/editor/drag-drop/dragMove.ts
+++ b/packages/runtime/src/editor/drag-drop/dragMove.ts
@@ -43,7 +43,7 @@ export function dragMove(dragState: DragState | null, exclude: HTMLElement[]) {
     dragState.element.style.setProperty('translate', translate)
   }
   dragState.repeatedNodes.forEach((node, i) => {
-    node.style.setProperty('--drag-repeat-node-opacity', i < 4 ? '0.2' : '0')
+    node.style.setProperty('--drag-repeat-node-opacity', i < 3 ? '0.2' : '0')
   })
 
   const lines = dragState.insertAreas?.map((line) => {

--- a/packages/runtime/src/editor/drag-drop/dragReorder.ts
+++ b/packages/runtime/src/editor/drag-drop/dragReorder.ts
@@ -24,7 +24,7 @@ export function dragReorder(dragState: DragState | null) {
       dragState.initialNextSibling,
     )
     dragState.repeatedNodes.forEach((node, i) => {
-      node.style.setProperty('--drag-repeat-node-opacity', i < 4 ? '1' : '0')
+      node.style.setProperty('--drag-repeat-node-opacity', i < 3 ? '1' : '0')
     })
     const nextRect = dragState.element.getBoundingClientRect()
     dragState.offset.x += nextRect.left - prevRect.left

--- a/packages/runtime/src/editor/drag-drop/dragStarted.ts
+++ b/packages/runtime/src/editor/drag-drop/dragStarted.ts
@@ -33,7 +33,7 @@ export function dragStarted({
         '--drag-repeat-node-rotate',
         `${Math.random() * 9 - 4.5}deg`,
       )
-      node.style.setProperty('--drag-repeat-node-opacity', i < 4 ? '1' : '0')
+      node.style.setProperty('--drag-repeat-node-opacity', i < 3 ? '1' : '0')
     })
 
   initialNextSibling ??= element.nextElementSibling

--- a/packages/runtime/src/styles/style.ts
+++ b/packages/runtime/src/styles/style.ts
@@ -108,6 +108,29 @@ ${
         .join('\n')
     : ''
 }
+
+${
+  node.animations
+    ? Object.entries(node.animations)
+        .map(([animationName, keyframes]) => {
+          return `
+          @keyframes ${animationName} {
+            ${Object.values(keyframes)
+              .sort((a, b) => a.position - b.position)
+              .map(({ key, position, value }) => {
+                return `
+                ${position * 100}% {
+                  ${key}: ${value};
+                }
+                `
+              })
+              .join('\n')}
+          }
+          `
+        })
+        .join('\n')
+    : ''
+}
   `),
     )
     return styleElem


### PR DESCRIPTION
Animations will be stored on nodes for now. I hope to have it stored on a styles object v2 one day.

The editor can now communicate some new messages, like emitting the computed styles for a node and setting a keyframe animation dynamically.

This requires a commit to toddle-internal to set up some styling in the head (the editor global styling should probably live in the toddle repo 🤔)