### PR TITLE
Add rule for detecting unknown component refs

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -9,6 +9,7 @@ import { unknownApiRule } from './rules/apis/unknownApiRule'
 import { noReferenceAttributeRule } from './rules/attributes/noReferenceAttributeRule'
 import { unknownAttributeRule } from './rules/attributes/unknownAttributeRule'
 import { noReferenceComponentRule } from './rules/components/noReferenceComponentRule'
+import { unknownComponentRule } from './rules/components/unknownComponentRule'
 import { noContextConsumersRule } from './rules/context/noContextConsumersRule'
 import { unknownContextFormulaRule } from './rules/context/unknownContextFormulaRule'
 import { unknownContextProviderFormulaRule } from './rules/context/unknownContextProviderFormulaRule'
@@ -135,6 +136,7 @@ const RULES = [
   unknownApiRule,
   unknownAttributeRule,
   unknownClassnameRule,
+  unknownComponentRule,
   unknownComponentSlotRule,
   unknownContextFormulaRule,
   unknownContextProviderFormulaRule,

--- a/packages/search/src/rules/components/unknownComponentRule.test.ts
+++ b/packages/search/src/rules/components/unknownComponentRule.test.ts
@@ -1,0 +1,114 @@
+import { searchProject } from '../../searchProject'
+import { unknownComponentRule } from './unknownComponentRule'
+
+describe('unknownComponent', () => {
+  test('should report unknown component node references', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  name: 'unknown',
+                  type: 'component',
+                  attrs: {},
+                  events: {},
+                  children: ['test'],
+                  style: {},
+                },
+                test: {
+                  name: 'unknown-package',
+                  package: 'unknown',
+                  type: 'component',
+                  attrs: {},
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [unknownComponentRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(2)
+    expect(problems[0].code).toBe('unknown component')
+    expect(problems[0].details).toEqual({ name: 'unknown' })
+    expect(problems[1].code).toBe('unknown component')
+    expect(problems[1].details).toEqual({ name: 'unknown-package' })
+  })
+
+  test('should not report known component node references', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          packages: {
+            known_package: {
+              manifest: {
+                commit: '123',
+                name: 'known_package',
+              },
+              components: {
+                known_package_component: {
+                  name: 'known_package_component',
+                  nodes: {},
+                  formulas: {},
+                  apis: {},
+                  attributes: {},
+                  variables: {},
+                },
+              },
+            },
+          },
+          components: {
+            known: {
+              name: 'known',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  name: 'known',
+                  type: 'component',
+                  attrs: {},
+                  events: {},
+                  children: ['test'],
+                  style: {},
+                },
+                test: {
+                  name: 'known_package_component',
+                  package: 'known_package',
+                  type: 'component',
+                  attrs: {},
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [unknownComponentRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+})

--- a/packages/search/src/rules/components/unknownComponentRule.ts
+++ b/packages/search/src/rules/components/unknownComponentRule.ts
@@ -1,0 +1,24 @@
+import { isDefined } from '@toddledev/core/dist/utils/util'
+import type { Rule } from '../../types'
+
+export const unknownComponentRule: Rule<{
+  name: string
+}> = {
+  code: 'unknown component',
+  level: 'error',
+  category: 'Unknown Reference',
+  visit: (report, { path, files, value, nodeType }) => {
+    if (
+      nodeType !== 'component-node' ||
+      value.type !== 'component' ||
+      // Check if the component exists in the project
+      (!isDefined(value.package) && isDefined(files.components[value.name])) ||
+      // Check if the component exists in a specified package
+      (value.package &&
+        isDefined(files.packages?.[value.package]?.components[value.name]))
+    ) {
+      return
+    }
+    report(path, { name: value.name })
+  },
+}

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -64,6 +64,7 @@ type Code =
   | 'unknown context provider'
   | 'unknown context workflow'
   | 'unknown cookie'
+  | 'unknown component'
   | 'unknown event'
   | 'unknown formula'
   | 'unknown project action'


### PR DESCRIPTION
We were missing an important rule to detect unknown component node refs. This will help detect references to components that have been deleted or don't exist in the project.
Closes #2412