### PR TITLE
Remove more test data from components

### DIFF
--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -190,7 +190,7 @@ export interface Component {
 
 export interface ComponentFormula extends ToddleMetadata {
   name: string
-  arguments: Array<{ name: string; testValue: any }>
+  arguments?: Array<{ name: string; testValue: any }> | null
   memoize?: boolean
   exposeInContext?: boolean
   formula: Formula

--- a/packages/core/src/utils/collections.ts
+++ b/packages/core/src/utils/collections.ts
@@ -13,8 +13,14 @@ export const mapValues = <T, T2>(
   f: (value: T) => T2,
 ): Record<string, T2> => mapObject(object, ([key, value]) => [key, f(value)])
 
-export const omit = <T = unknown>(collection: T, key: string[]): T => {
-  const [head, ...rest] = key
+/**
+ * Deletes potentially nested keys from an object
+ * @param collection Array or Object
+ * @param path Path to the key to delete. For instance ['foo', 0, 'bar']
+ * @returns The updated object/array
+ */
+export const omit = <T = unknown>(collection: T, path: string[]): T => {
+  const [head, ...rest] = path
 
   const clone: any = Array.isArray(collection)
     ? [...collection]
@@ -30,8 +36,13 @@ export const omit = <T = unknown>(collection: T, key: string[]): T => {
   return clone as T
 }
 
-export const omitKeys = (object: Record<string, any>, keys: string[]) =>
-  Object.fromEntries(Object.entries(object).filter(([k]) => !keys.includes(k)))
+export const omitKeys = <T extends Record<string, any>>(
+  object: T,
+  keys: Array<keyof T>,
+): T =>
+  Object.fromEntries(
+    Object.entries(object).filter(([k]) => !keys.includes(k)),
+  ) as T
 
 export const omitPaths = (object: Record<string, any>, keys: string[][]) =>
   keys.reduce((acc, key) => omit(acc, key), { ...object })

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -950,7 +950,7 @@ export const createRoot = (
                 ${Object.values(keyframes)
                   .map(
                     ({ key, value, position, easing }) =>
-                      `${position * 100}% { 
+                      `${position * 100}% {
                         ${key}: ${value};
                         ${easing ? `animation-timing-function: ${easing};` : ''}
                       }`,
@@ -1333,14 +1333,14 @@ export const createRoot = (
     for (const api in newCtx.component.apis) {
       // check if the api has changed (ignoring onCompleted and onFailed).
       const apiInstance = newCtx.component.apis[api]
+      const previousApiInstance = ctx?.component.apis[api]
       if (isLegacyApi(apiInstance)) {
         if (
           fastDeepEqual(
-            omitKeys(newCtx.component.apis[api], ['onCompleted', 'onFailed']),
-            omitKeys(ctx?.component.apis[api] ?? {}, [
-              'onCompleted',
-              'onFailed',
-            ]),
+            omitKeys(apiInstance, ['onCompleted', 'onFailed']),
+            previousApiInstance && isLegacyApi(previousApiInstance)
+              ? omitKeys(previousApiInstance, ['onCompleted', 'onFailed'])
+              : (previousApiInstance ?? {}),
           ) === false
         ) {
           newCtx.apis[api]?.destroy()

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -201,10 +201,12 @@ type ComponentFormulaNode = {
   nodeType: 'component-formula'
   value: {
     name: string
-    arguments: {
-      name: string
-      testValue: any
-    }[]
+    arguments?:
+      | {
+          name: string
+          testValue: any
+        }[]
+      | null
     memoize?: boolean | undefined
     exposeInContext?: boolean | undefined
     formula: Formula

--- a/packages/ssr/src/rendering/testData.test.ts
+++ b/packages/ssr/src/rendering/testData.test.ts
@@ -1,23 +1,152 @@
-import { describe, expect, test } from '@jest/globals'
+import { valueFormula } from '@toddledev/core/dist/formula/formulaUtils'
 import { removeTestData } from './testData'
 
 describe('removeTestData', () => {
   test('it removes testValue from attributes', () => {
     expect(
       removeTestData({
+        name: 'test',
+        variables: {},
+        apis: {},
+        nodes: {},
         attributes: {
           '1': {
             name: 'foo',
             testValue: 'bar',
           },
         },
-      } as any),
+      }).attributes,
     ).toEqual({
-      attributes: {
-        '1': {
-          name: 'foo',
+      '1': {
+        name: 'foo',
+      },
+    })
+  })
+  test('it removes testValue from route parameters', () => {
+    expect(
+      removeTestData({
+        name: 'test',
+        variables: {},
+        apis: {},
+        nodes: {},
+        attributes: {},
+        route: {
+          path: [
+            {
+              name: 'blog',
+              type: 'static',
+            },
+            {
+              name: 'slug',
+              type: 'param',
+              testValue: '123',
+            },
+          ],
+          query: {
+            q: {
+              name: 'q',
+              testValue: '123',
+            },
+          },
+        },
+      }).route,
+    ).toEqual({
+      path: [
+        {
+          name: 'blog',
+          type: 'static',
+        },
+        {
+          name: 'slug',
+          type: 'param',
+        },
+      ],
+      query: {
+        q: {
+          name: 'q',
         },
       },
+    })
+  })
+  test('it removes testValue from formula arguments', () => {
+    expect(
+      removeTestData({
+        name: 'test',
+        variables: {},
+        apis: {},
+        nodes: {},
+        attributes: {},
+        formulas: {
+          a: {
+            name: 'foo',
+            arguments: [
+              {
+                name: 'bar',
+                testValue: 'baz',
+              },
+            ],
+            formula: valueFormula(true),
+          },
+        },
+      }).formulas?.['a']?.arguments,
+    ).toEqual([
+      {
+        name: 'bar',
+      },
+    ])
+  })
+  test('it removes testValue from workflow parameters', () => {
+    expect(
+      removeTestData({
+        name: 'test',
+        variables: {},
+        apis: {},
+        nodes: {},
+        attributes: {},
+        workflows: {
+          p: {
+            name: 'foo',
+            parameters: [
+              {
+                name: 'bar',
+                testValue: 'baz',
+              },
+            ],
+            actions: [],
+          },
+        },
+      }).workflows?.['p']?.parameters,
+    ).toEqual([
+      {
+        name: 'bar',
+      },
+    ])
+  })
+  test('it removes service refs from APIs', () => {
+    expect(
+      removeTestData({
+        name: 'test',
+        variables: {},
+        nodes: {},
+        attributes: {},
+        apis: {
+          a: {
+            name: 'foo',
+            service: 'bar',
+            servicePath: 'baz',
+            url: valueFormula('https://example.com'),
+            version: 2,
+            type: 'http',
+            inputs: {},
+          },
+        },
+      }).apis['a'],
+    ).toEqual({
+      name: 'foo',
+      url: valueFormula('https://example.com'),
+      version: 2,
+      type: 'http',
+      inputs: {},
     })
   })
 })

--- a/packages/ssr/src/rendering/testData.test.ts
+++ b/packages/ssr/src/rendering/testData.test.ts
@@ -122,6 +122,40 @@ describe('removeTestData', () => {
       },
     ])
   })
+  test('it removes description from workflow actions', () => {
+    expect(
+      removeTestData({
+        name: 'test',
+        variables: {},
+        apis: {},
+        nodes: {},
+        attributes: {},
+        workflows: {
+          p: {
+            name: 'foo',
+            parameters: [
+              {
+                name: 'bar',
+                testValue: 'baz',
+              },
+            ],
+            actions: [
+              {
+                type: 'Custom',
+                description: 'A long description',
+                name: 'My Action',
+              },
+            ],
+          },
+        },
+      }).workflows?.['p']?.actions,
+    ).toEqual([
+      {
+        type: 'Custom',
+        name: 'My Action',
+      },
+    ])
+  })
   test('it removes service refs from APIs', () => {
     expect(
       removeTestData({

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -1,5 +1,10 @@
+import { isLegacyApi } from '@toddledev/core/dist/api/api'
 import type { Component } from '@toddledev/core/dist/component/component.types'
-import { mapObject, omit } from '@toddledev/core/dist/utils/collections'
+import {
+  mapObject,
+  omit,
+  omitKeys,
+} from '@toddledev/core/dist/utils/collections'
 
 export function removeTestData(component: Component): Component {
   return {
@@ -20,5 +25,38 @@ export function removeTestData(component: Component): Component {
           },
         }
       : {}),
+    ...(component.formulas
+      ? {
+          formulas: mapObject(component.formulas, ([key, value]) => [
+            key,
+            {
+              ...value,
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+              arguments: (value.arguments || []).map((a) =>
+                omit(a, ['testValue']),
+              ),
+            },
+          ]),
+        }
+      : {}),
+    ...(component.workflows
+      ? {
+          workflows: mapObject(component.workflows, ([key, value]) => [
+            key,
+            {
+              ...value,
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+              parameters: (value.parameters || []).map((p) =>
+                omit(p, ['testValue']),
+              ),
+            },
+          ]),
+        }
+      : {}),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    apis: mapObject(component.apis ?? {}, ([key, api]) => [
+      key,
+      isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
+    ]),
   }
 }

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -45,6 +45,11 @@ export function removeTestData(component: Component): Component {
             key,
             {
               ...value,
+              // We should find all actions (also nested actions and non-workflow actions) and remove
+              // the description from them. This is a start though
+              actions: value.actions.map((a) =>
+                a.type === 'Custom' ? omitKeys(a, ['description']) : a,
+              ),
               // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
               parameters: (value.parameters || []).map((p) =>
                 omit(p, ['testValue']),
@@ -56,6 +61,8 @@ export function removeTestData(component: Component): Component {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     apis: mapObject(component.apis ?? {}, ([key, api]) => [
       key,
+      // service and servicePath are only necessary in the editor. All information about an API
+      // request is available on the api object itself
       isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
     ]),
   }

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -32,7 +32,7 @@ export function removeTestData(component: Component): Component {
             {
               ...value,
               // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              arguments: (value.arguments || []).map((a) =>
+              arguments: (value.arguments ?? []).map((a) =>
                 omit(a, ['testValue']),
               ),
             },

--- a/packages/ssr/src/ssr.types.ts
+++ b/packages/ssr/src/ssr.types.ts
@@ -10,6 +10,14 @@ import type { Formula } from '@toddledev/core/dist/formula/formula'
 import type { PluginFormula } from '@toddledev/core/dist/formula/formulaTypes'
 import type { OldTheme, Theme } from '@toddledev/core/dist/styling/theme'
 
+export type FileGetter = (args: {
+  package?: string
+  name: string
+  type: keyof ProjectFiles
+}) => Promise<
+  Component | PluginAction | PluginFormula<string> | Route | Theme | ApiService
+>
+
 export interface ToddleProject {
   name: string
   description?: string | null


### PR DESCRIPTION
We were not removing:

- Test data from workflow parameters
- Test data from formula inputs
- Service references from APIs
  
I also improved the type safety of the `omitKeys` utility function. I tried to adjust the `omit` function as well, but since we sometimes use it recursively, it's difficult to keep type safety.