### PR TITLE
Fix an issue where instance styling would not be applied in the correct order

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -372,12 +372,6 @@ export const createRoot = (
             return
           }
           if (message.data.component.name != component?.name) {
-            // Clean up all styles before switching components
-            document.head
-              .querySelectorAll('style[data-hash]')
-              .forEach((style) => {
-                style.remove()
-              })
             showSignal.cleanSubscribers()
           }
 
@@ -1162,15 +1156,15 @@ export const createRoot = (
           }
         }
       }
-      const selectedNode = getDOMNodeFromNodeId(selectedNodeId)
-      window.parent?.postMessage(
-        {
-          type: 'selectionRect',
-          rect: getRectData(selectedNode),
-        },
-        '*',
-      )
     }
+    const selectedNode = getDOMNodeFromNodeId(selectedNodeId)
+    window.parent?.postMessage(
+      {
+        type: 'selectionRect',
+        rect: getRectData(selectedNode),
+      },
+      '*',
+    )
   }
 
   const update = () => {


### PR DESCRIPTION
Order is very important for editor styling. So we have to apply it all each time or otherwise create some complex order management.

This is still a lot faster than before as we apply styles only ones instead of nearly O(n^2) as previously. I utilize fragments to ensure no relayouts between adding styles (most browsers likely does this optimization anyway).