### PR TITLE
Update classname for each node rather than class

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1430,16 +1430,15 @@ export const createRoot = (
             (!fastDeepEqual(newNode.style, oldNode.style) ||
               !fastDeepEqual(newNode.variants, oldNode.variants))
           ) {
-            const prevClassName = getClassName([
-              oldNode.style,
-              oldNode.variants,
-            ])
-            document.querySelectorAll(`.${prevClassName}`).forEach((elem) => {
-              elem.classList.remove(prevClassName)
-              elem.classList.add(
-                getClassName([newNode.style, newNode.variants]),
-              )
-            })
+            const nodeInstance = document.querySelector(
+              `[data-node-id="${nodeId}"]`,
+            )
+            nodeInstance?.classList.remove(
+              getClassName([oldNode.style, oldNode.variants]),
+            )
+            nodeInstance?.classList.add(
+              getClassName([newNode.style, newNode.variants]),
+            )
           }
         })
       } else {


### PR DESCRIPTION
This solves an issue where, if multiple nodes had the same class-hash, they would simultaneously update in the editor, while only the changed node should.

The issue did not affect production, only the editor.