### PR TITLE
Enable unknownApiInputRule

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -5,6 +5,7 @@ import { noReferenceProjectActionRule } from './rules/actions/noReferenceProject
 import { unknownProjectActionRule } from './rules/actions/unknownProjectActionRule'
 import { legacyApiRule } from './rules/apis/legacyApiRule'
 import { noReferenceApiRule } from './rules/apis/noReferenceApiRule'
+import { unknownApiInputRule } from './rules/apis/unknownApiInputRule'
 import { unknownApiRule } from './rules/apis/unknownApiRule'
 import { noReferenceAttributeRule } from './rules/attributes/noReferenceAttributeRule'
 import { unknownAttributeRule } from './rules/attributes/unknownAttributeRule'
@@ -134,6 +135,7 @@ const RULES = [
   noUnnecessaryConditionTruthy,
   requireExtensionRule,
   unknownApiRule,
+  unknownApiInputRule,
   unknownAttributeRule,
   unknownClassnameRule,
   unknownComponentRule,

--- a/packages/search/src/rules/apis/unknownApiInputRule.test.ts
+++ b/packages/search/src/rules/apis/unknownApiInputRule.test.ts
@@ -21,7 +21,7 @@ describe('unknownApiInput', () => {
                   inputs: {},
                   body: {
                     type: 'path',
-                    path: ['Args', 'unknown-input'],
+                    path: ['ApiInputs', 'unknown-input'],
                   },
                   '@toddle/metadata': {
                     comments: null,
@@ -64,7 +64,7 @@ describe('unknownApiInput', () => {
                   },
                   body: {
                     type: 'path',
-                    path: ['Args', 'known-input'],
+                    path: ['ApiInputs', 'known-input'],
                   },
                   '@toddle/metadata': {
                     comments: null,

--- a/packages/search/src/rules/apis/unknownApiInputRule.ts
+++ b/packages/search/src/rules/apis/unknownApiInputRule.ts
@@ -11,8 +11,9 @@ export const unknownApiInputRule: Rule<{
     if (
       nodeType !== 'formula' ||
       value.type !== 'path' ||
-      value.path[0] !== 'Args' ||
-      typeof value.path[1] !== 'string'
+      value.path[0] !== 'ApiInputs' ||
+      typeof value.path[1] !== 'string' ||
+      path.length < 4
     ) {
       return
     }


### PR DESCRIPTION
We created this rule a while ago, but it was never enabled. I adjusted it to the updated API format and enabled it.