### PR TITLE
Fixed an issue where url params was available in formula editor on a …

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1355,10 +1355,12 @@ export const createRoot = (
     dataSignal.update((data) => {
       return {
         ...data,
-        'URL parameters': {
-          ...window.toddle.locationSignal.get().query,
-          ...window.toddle.locationSignal.get().params,
-        } as Record<string, string>,
+        'URL parameters': component?.route
+          ? ({
+              ...window.toddle.locationSignal.get().query,
+              ...window.toddle.locationSignal.get().params,
+            } as Record<string, string>)
+          : {},
         Attributes,
         Variables,
         Contexts,


### PR DESCRIPTION
…component

This could be reproduced by doing the following:

1. Navigate to a page
2. Navigate to a component
3. Open the formula editor.
4. Open the formula selector

You will see that URL params are available from the previous Page.