### PR TITLE
Fix an issue when styling repeat items in the editor

### DIFF
--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1435,15 +1435,16 @@ export const createRoot = (
             (!fastDeepEqual(newNode.style, oldNode.style) ||
               !fastDeepEqual(newNode.variants, oldNode.variants))
           ) {
-            const nodeInstance = document.querySelector(
-              `[data-node-id="${nodeId}"]`,
-            )
-            nodeInstance?.classList.remove(
-              getClassName([oldNode.style, oldNode.variants]),
-            )
-            nodeInstance?.classList.add(
-              getClassName([newNode.style, newNode.variants]),
-            )
+            document
+              .querySelectorAll(`[data-node-id="${nodeId}"]`)
+              .forEach((nodeInstance) => {
+                nodeInstance.classList.remove(
+                  getClassName([oldNode.style, oldNode.variants]),
+                )
+                nodeInstance.classList.add(
+                  getClassName([newNode.style, newNode.variants]),
+                )
+              })
           }
         })
       } else {


### PR DESCRIPTION
Repeat items have the same ID. Before we would only replace styling for the first item, so would not work for repeated nodes.