### PR TITLE
Adjust unknown input rules to ignore parent/item

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/search/src/rules/formulas/unknownComponentFormulaInputRule.test.ts
+++ b/packages/search/src/rules/formulas/unknownComponentFormulaInputRule.test.ts
@@ -90,4 +90,51 @@ describe('unknownComponentFormulaInput', () => {
 
     expect(problems).toHaveLength(0)
   })
+  test('should not detect @toddle.parent/item path formulas', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {
+                myFormula: {
+                  name: 'Test',
+                  formula: {
+                    type: 'function',
+                    name: '@toddle/concatenate',
+                    arguments: [
+                      {
+                        name: '0',
+                        formula: { type: 'path', path: ['Args', 'item'] },
+                      },
+                      {
+                        name: '1',
+                        formula: {
+                          type: 'path',
+                          path: ['Args', '@toddle.parent', 'test'],
+                        },
+                      },
+                    ],
+                    variableArguments: true,
+                    display_name: 'Concatenate',
+                  },
+                  arguments: [{ name: 'Input', testValue: 'Input' }],
+                  memoize: false,
+                  exposeInContext: false,
+                },
+              },
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [unknownComponentFormulaInputRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
 })

--- a/packages/search/src/rules/formulas/unknownComponentFormulaInputRule.ts
+++ b/packages/search/src/rules/formulas/unknownComponentFormulaInputRule.ts
@@ -14,7 +14,7 @@ export const unknownComponentFormulaInputRule: Rule<{
       nodeType !== 'formula' ||
       value.type !== 'path' ||
       value.path?.[0] !== 'Args' ||
-      ['@toddle.parent', 'item'].includes(value.path[1]) ||
+      ['@toddle.parent', 'item', 'index'].includes(value.path[1]) ||
       value.path.length < 2 ||
       path[0] !== 'components' ||
       path[2] !== 'formulas' ||

--- a/packages/search/src/rules/formulas/unknownComponentFormulaInputRule.ts
+++ b/packages/search/src/rules/formulas/unknownComponentFormulaInputRule.ts
@@ -14,6 +14,7 @@ export const unknownComponentFormulaInputRule: Rule<{
       nodeType !== 'formula' ||
       value.type !== 'path' ||
       value.path?.[0] !== 'Args' ||
+      ['@toddle.parent', 'item'].includes(value.path[1]) ||
       value.path.length < 2 ||
       path[0] !== 'components' ||
       path[2] !== 'formulas' ||

--- a/packages/search/src/rules/formulas/unknownProjectFormulaInputRule.test.ts
+++ b/packages/search/src/rules/formulas/unknownProjectFormulaInputRule.test.ts
@@ -71,4 +71,41 @@ describe('unknownProjectFormulaInput', () => {
 
     expect(problems).toHaveLength(0)
   })
+  test('should not detect @toddle.parent/item path formulas', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {
+            myFormula: {
+              name: 'Test',
+              formula: {
+                type: 'function',
+                name: '@toddle/concatenate',
+                arguments: [
+                  {
+                    name: '0',
+                    formula: { type: 'path', path: ['Args', 'item'] },
+                  },
+                  {
+                    name: '0',
+                    formula: {
+                      type: 'path',
+                      path: ['Args', '@toddle.parent', 'test'],
+                    },
+                  },
+                ],
+                variableArguments: true,
+                display_name: 'Concatenate',
+              },
+              arguments: [],
+            },
+          },
+          components: {},
+        },
+        rules: [unknownProjectFormulaInputRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
 })

--- a/packages/search/src/rules/formulas/unknownProjectFormulaInputRule.ts
+++ b/packages/search/src/rules/formulas/unknownProjectFormulaInputRule.ts
@@ -14,6 +14,7 @@ export const unknownProjectFormulaInputRule: Rule<{
       nodeType !== 'formula' ||
       value.type !== 'path' ||
       value.path?.[0] !== 'Args' ||
+      ['@toddle.parent', 'item'].includes(value.path[1]) ||
       value.path.length < 2 ||
       path[0] !== 'formulas' ||
       path.length < 2

--- a/packages/search/src/rules/formulas/unknownProjectFormulaInputRule.ts
+++ b/packages/search/src/rules/formulas/unknownProjectFormulaInputRule.ts
@@ -14,7 +14,7 @@ export const unknownProjectFormulaInputRule: Rule<{
       nodeType !== 'formula' ||
       value.type !== 'path' ||
       value.path?.[0] !== 'Args' ||
-      ['@toddle.parent', 'item'].includes(value.path[1]) ||
+      ['@toddle.parent', 'item', 'index'].includes(value.path[1]) ||
       value.path.length < 2 ||
       path[0] !== 'formulas' ||
       path.length < 2


### PR DESCRIPTION
Since path formulas for a formula's item or a parent formula are also using the `Args` scope, we would report more issues than necessary.