### PR TITLE
Temporarily disable formula input rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/formula/formulaTypes.ts
+++ b/packages/core/src/formula/formulaTypes.ts
@@ -5,7 +5,8 @@ export interface BaseFormula {
   description?: string
   arguments: Array<{
     name: string
-    formula: Formula
+    formula?: Formula | null
+    testValue?: unknown
   }>
   // exported indicates that a formula is exported in a package
   exported?: boolean

--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -29,9 +29,7 @@ import { unknownTriggerEventRule } from './rules/events/unknownTriggerEventRule'
 import { legacyFormulaRule } from './rules/formulas/legacyFormulaRule'
 import { noReferenceComponentFormulaRule } from './rules/formulas/noReferenceComponentFormulaRule'
 import { noReferenceProjectFormulaRule } from './rules/formulas/noReferenceProjectFormulaRule'
-import { unknownComponentFormulaInputRule } from './rules/formulas/unknownComponentFormulaInputRule'
 import { unknownFormulaRule } from './rules/formulas/unknownFormulaRule'
-import { unknownProjectFormulaInputRule } from './rules/formulas/unknownProjectFormulaInputRule'
 import { unknownProjectFormulaRule } from './rules/formulas/unknownProjectFormulaRule'
 import { unknownRepeatIndexFormulaRule } from './rules/formulas/unknownRepeatIndexFormulaRule'
 import { unknownRepeatItemFormulaRule } from './rules/formulas/unknownRepeatItemFormulaRule'
@@ -142,7 +140,7 @@ const RULES = [
   unknownApiInputRule,
   unknownAttributeRule,
   unknownClassnameRule,
-  unknownComponentFormulaInputRule,
+  // unknownComponentFormulaInputRule,
   unknownComponentRule,
   unknownComponentSlotRule,
   unknownContextFormulaRule,
@@ -154,7 +152,7 @@ const RULES = [
   unknownEventRule,
   unknownFormulaRule,
   unknownProjectActionRule,
-  unknownProjectFormulaInputRule,
+  // unknownProjectFormulaInputRule,
   unknownProjectFormulaRule,
   unknownRepeatIndexFormulaRule,
   unknownRepeatItemFormulaRule,


### PR DESCRIPTION
The rules did not work for nested formula calls, e.g. a component formula that references a project formula. This meant that they would report issues that were not actually issues.