### PR TITLE
Support non-xhtml namespace at SSR

### DIFF
--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -351,3 +351,12 @@ export interface ComponentAttribute extends ToddleMetadata {
   name: string
   testValue: unknown
 }
+
+/**
+ * We must specify the namespace for some nodes when created programmatically that are not in the default namespace.
+ * We infer the namespace based on the tag name, but it would be interesting to also allow the user to specify it explicitly with the `xmlns` attribute.
+ */
+export type SupportedNamespaces =
+  | 'http://www.w3.org/1999/xhtml'
+  | 'http://www.w3.org/2000/svg'
+  | 'http://www.w3.org/1998/Math/MathML'

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -2,6 +2,7 @@ import { isLegacyApi, sortApiObjects } from '@toddledev/core/dist/api/api'
 import type {
   ComponentData,
   ComponentNodeModel,
+  SupportedNamespaces,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import type { RequireFields } from '@toddledev/core/dist/types'
@@ -15,12 +16,7 @@ import { registerComponentToLogState } from '../debug/logState'
 import { handleAction } from '../events/handleAction'
 import type { Signal } from '../signal/signal'
 import { signal } from '../signal/signal'
-import type {
-  ComponentChild,
-  ComponentContext,
-  ContextApi,
-  SupportedNamespaces,
-} from '../types'
+import type { ComponentChild, ComponentContext, ContextApi } from '../types'
 import { createFormulaCache } from '../utils/createFormulaCache'
 import { renderComponent } from './renderComponent'
 

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -1,6 +1,7 @@
 import type {
   ElementNodeModel,
   NodeModel,
+  SupportedNamespaces,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import {
@@ -10,7 +11,6 @@ import {
 import { isDefined, toBoolean } from '@toddledev/core/dist/utils/util'
 import { handleAction } from '../events/handleAction'
 import type { Signal } from '../signal/signal'
-import type { SupportedNamespaces } from '../types'
 import { getDragData } from '../utils/getDragData'
 import { getElementTagName } from '../utils/getElementTagName'
 import { setAttribute } from '../utils/setAttribute'

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -2,12 +2,13 @@
 import type {
   ComponentData,
   NodeModel,
+  SupportedNamespaces,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import { toBoolean } from '@toddledev/core/dist/utils/util'
 import type { Signal } from '../signal/signal'
 import { signal } from '../signal/signal'
-import type { ComponentContext, SupportedNamespaces } from '../types'
+import type { ComponentContext } from '../types'
 import { ensureEfficientOrdering, getNextSiblingElement } from '../utils/nodes'
 import { createComponent } from './createComponent'
 import { createElement } from './createElement'

--- a/packages/runtime/src/components/createText.ts
+++ b/packages/runtime/src/components/createText.ts
@@ -1,10 +1,11 @@
 import type {
   ComponentData,
+  SupportedNamespaces,
   TextNodeModel,
 } from '@toddledev/core/dist/component/component.types'
 import { applyFormula } from '@toddledev/core/dist/formula/formula'
 import type { Signal } from '../signal/signal'
-import type { ComponentContext, SupportedNamespaces } from '../types'
+import type { ComponentContext } from '../types'
 
 export type RenderTextProps = {
   node: TextNodeModel

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -1,6 +1,7 @@
 import type {
   Component,
   ComponentData,
+  SupportedNamespaces,
 } from '@toddledev/core/dist/component/component.types'
 import type { ToddleEnv } from '@toddledev/core/dist/formula/formula'
 import type { Toddle } from '@toddledev/core/dist/types'
@@ -13,7 +14,6 @@ import type {
   FormulaCache,
   LocationSignal,
   PreviewShowSignal,
-  SupportedNamespaces,
 } from '../types'
 import { BatchQueue } from '../utils/BatchQueue'
 import { createNode } from './createNode'

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -91,12 +91,3 @@ export type FormulaCache = Record<
     set: (data: ComponentData, result: any) => void
   }
 >
-
-/**
- * We must specify the namespace for some nodes when created programmatically that are not in the default namespace.
- * In toddle, we infer the namespace based on the tag name, but it would be interesting to also allow the user to specify it explicitly with the `xmlns` attribute.
- */
-export type SupportedNamespaces =
-  | 'http://www.w3.org/1999/xhtml'
-  | 'http://www.w3.org/2000/svg'
-  | 'http://www.w3.org/1998/Math/MathML'


### PR DESCRIPTION
This was working client-side already, but had some issues SSR.

Check issue on https://start-red_palpatine_manual_rat.toddle.site/chart by disabling javascript. Do the same while testing changes and notice that the output looks correct from the server.