### PR TITLE
Add unknown trigger workflow rule

### DIFF
--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -50,6 +50,7 @@ import { noReferenceComponentWorkflowRule } from './rules/workflows/noReferenceC
 import { unknownContextProviderWorkflowRule } from './rules/workflows/unknownContextProviderWorkflowRule'
 import { unknownContextWorkflowRule } from './rules/workflows/unknownContextWorkflowRule'
 import { unknownTriggerWorkflowParameterRule } from './rules/workflows/unknownTriggerWorkflowParameterRule'
+import { unknownTriggerWorkflowRule } from './rules/workflows/unknownTriggerWorkflowRule'
 import { unknownWorkflowParameterRule } from './rules/workflows/unknownWorkflowParameterRule'
 import { searchProject } from './searchProject'
 import type { ApplicationState, Category, Code, Level, Result } from './types'
@@ -159,6 +160,7 @@ const RULES = [
   unknownSetUrlParameterRule,
   unknownTriggerEventRule,
   unknownTriggerWorkflowParameterRule,
+  unknownTriggerWorkflowRule,
   unknownUrlParameterRule,
   unknownVariableRule,
   unknownVariableSetterRule,

--- a/packages/search/src/rules/workflows/unknownTriggerWorkflowRule.test.ts
+++ b/packages/search/src/rules/workflows/unknownTriggerWorkflowRule.test.ts
@@ -1,0 +1,104 @@
+import { searchProject } from '../../searchProject'
+import { unknownTriggerWorkflowRule } from './unknownTriggerWorkflowRule'
+
+describe('unknownTriggerWorkflowRule', () => {
+  test('should detect unknown workflows', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            myComponent: {
+              name: 'myComponent',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {
+                    click: {
+                      trigger: 'click',
+                      actions: [
+                        {
+                          type: 'TriggerWorkflow',
+                          workflow: 'unknown-workflow',
+                          parameters: {},
+                        },
+                      ],
+                    },
+                  },
+                  tag: 'div',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              workflows: {
+                ['my-workflow']: {
+                  actions: [],
+                  name: 'my-workflow',
+                  parameters: [],
+                },
+              },
+            },
+          },
+        },
+        rules: [unknownTriggerWorkflowRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('unknown trigger workflow')
+  })
+  test('should not fail on valid workflow triggers', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            myComponent: {
+              name: 'myComponent',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {},
+                  classes: {},
+                  events: {
+                    click: {
+                      trigger: 'click',
+                      actions: [
+                        {
+                          type: 'TriggerWorkflow',
+                          workflow: 'my-workflow',
+                          parameters: {},
+                        },
+                      ],
+                    },
+                  },
+                  tag: 'div',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              workflows: {
+                ['my-workflow']: {
+                  actions: [],
+                  name: 'my-workflow',
+                  parameters: [],
+                },
+              },
+            },
+          },
+        },
+        rules: [unknownTriggerWorkflowRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
+})

--- a/packages/search/src/rules/workflows/unknownTriggerWorkflowRule.ts
+++ b/packages/search/src/rules/workflows/unknownTriggerWorkflowRule.ts
@@ -1,0 +1,22 @@
+import type { Rule } from '../../types'
+
+export const unknownTriggerWorkflowRule: Rule<void> = {
+  code: 'unknown trigger workflow',
+  level: 'error',
+  category: 'Unknown Reference',
+  visit: (report, args) => {
+    const { path, value, nodeType } = args
+    if (
+      nodeType !== 'action-model' ||
+      value.type !== 'TriggerWorkflow' ||
+      typeof value.contextProvider === 'string'
+    ) {
+      return
+    }
+
+    const workflow = args.component.workflows?.[value.workflow]
+    if (!workflow) {
+      report(path)
+    }
+  },
+}

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -75,6 +75,7 @@ type Code =
   | 'unknown repeat item formula'
   | 'unknown set url parameter'
   | 'unknown trigger event'
+  | 'unknown trigger workflow'
   | 'unknown url parameter'
   | 'unknown variable setter'
   | 'unknown variable'


### PR DESCRIPTION
We only had a rule for unknown triggers on context workflows - not on component workflows.