### PR TITLE
Do not omit styles from non-unique node ids ("root")

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "toddle",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "homepage": "https://github.com/toddledev/toddle",
   "private": "false",
   "workspaces": [

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -53,7 +53,7 @@ import type {
 } from './types'
 import { createFormulaCache } from './utils/createFormulaCache'
 import { getNodeAndAncestors, isNodeOrAncestorConditional } from './utils/nodes'
-import { omitStyleForComponent } from './utils/omitStyle'
+import { omitSubnodeStyleForComponent } from './utils/omitStyle'
 import { rectHasPoint } from './utils/rectHasPoint'
 
 type ToddlePreviewEvent =
@@ -1417,14 +1417,14 @@ export const createRoot = (
     ) {
       updateStyle()
 
-      // Remove preview styles
+      // Remove preview styles automatically when the component changes
       document.head.querySelector('[data-id="selected-node-styles"]')?.remove()
-
-      // Is only style change, no need to re-render
-      // Remove style and styleVariants from each node
-      const newComponentWithoutStyles = omitStyleForComponent(newCtx.component)
-      const oldComponentWithoutStyles = omitStyleForComponent(ctx?.component)
-      if (fastDeepEqual(newComponentWithoutStyles, oldComponentWithoutStyles)) {
+      if (
+        fastDeepEqual(
+          omitSubnodeStyleForComponent(newCtx.component),
+          omitSubnodeStyleForComponent(ctx?.component),
+        )
+      ) {
         // If we're in here, then the latest update was only a style change, so we should try some optimistic updates
         Object.keys(newCtx.component.nodes).forEach((nodeId) => {
           const newNode = newCtx.component.nodes[nodeId]

--- a/packages/runtime/src/utils/omitStyle.ts
+++ b/packages/runtime/src/utils/omitStyle.ts
@@ -1,11 +1,14 @@
 import type { Component } from '@toddledev/core/dist/component/component.types'
 
-export function omitStyleForComponent<T extends Component | undefined>(
+export function omitSubnodeStyleForComponent<T extends Component | undefined>(
   component: T,
 ): T {
   const clone = structuredClone(component)
-  Object.values(clone?.nodes ?? {}).forEach((node) => {
-    if (node.type === 'element' || node.type === 'component') {
+  Object.entries(clone?.nodes ?? {}).forEach(([nodeId, node]) => {
+    if (
+      (node.type === 'element' || node.type === 'component') &&
+      nodeId !== 'root'
+    ) {
       delete node.style
       delete node.variants
       delete node.animations


### PR DESCRIPTION
This is a lazy solution, as I could probably find the element by the node-path, but we do not yet have a function to generate node paths from a node to a component root. We need this or some other form of unique IDs if we want hydration to work.

This fixes an issue (editor only) where styling root nodes would affect the appearance of other root nodes (components)