### PR TITLE
Allow global formulas in packages to use other global formulas

### DIFF
--- a/packages/core/src/api/LegacyToddleApi.ts
+++ b/packages/core/src/api/LegacyToddleApi.ts
@@ -131,7 +131,11 @@ export class LegacyToddleApi<Handler> {
   get onFailed() {
     return this.api.onFailed
   }
-  *formulasInApi(): Generator<[(string | number)[], Formula]> {
+  *formulasInApi(): Generator<{
+    path: (string | number)[]
+    formula: Formula
+    packageName?: string
+  }> {
     const api = this.api
     const apiKey = this.key
     yield* getFormulasInFormula({

--- a/packages/core/src/api/ToddleApiV2.ts
+++ b/packages/core/src/api/ToddleApiV2.ts
@@ -169,7 +169,11 @@ export class ToddleApiV2<Handler> implements ApiRequest {
     return this.api['@toddle/metadata']
   }
 
-  *formulasInApi(): Generator<[(string | number)[], Formula]> {
+  *formulasInApi(): Generator<{
+    path: (string | number)[]
+    formula: Formula
+    packageName?: string
+  }> {
     const api = this.api
     const apiKey = this.key
     for (const [input, value] of Object.entries(this.api.inputs)) {

--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -81,10 +81,19 @@ export class ToddleComponent<Handler> {
     return new Set(
       Array.from(this.formulasInComponent())
         .filter(
-          (entry): entry is [(string | number)[], FunctionOperation] =>
-            entry[1].type === 'function',
+          (
+            entry,
+          ): entry is {
+            path: (string | number)[]
+            formula: FunctionOperation
+            packageName?: string
+          } => entry.formula.type === 'function',
         )
-        .map(([, f]) => [f.package, f.name].filter(isDefined).join('/')),
+        .map((entry) =>
+          [entry.formula.package ?? entry.packageName, entry.formula.name]
+            .filter(isDefined)
+            .join('/'),
+        ),
     )
   }
 
@@ -103,12 +112,20 @@ export class ToddleComponent<Handler> {
    * Traverse all formulas in the component.
    * @returns An iterable that yields the path and formula.
    */
-  *formulasInComponent(): Generator<[(string | number)[], Formula]> {
+  *formulasInComponent(): Generator<{
+    path: (string | number)[]
+    formula: Formula
+    packageName?: string
+  }> {
     const globalFormulas = this.globalFormulas
     function* visitNode(
       node: NodeModel,
       path: (string | number)[] = [],
-    ): Generator<[(string | number)[], Formula]> {
+    ): Generator<{
+      path: (string | number)[]
+      formula: Formula
+      packageName?: string
+    }> {
       switch (node.type) {
         case 'text':
           yield* getFormulasInFormula({

--- a/packages/core/src/formula/ToddleFormula.ts
+++ b/packages/core/src/formula/ToddleFormula.ts
@@ -21,7 +21,11 @@ export class ToddleFormula<Handler> {
    * Traverse all formulas in the formula.
    * @returns An iterable that yields the path and formula.
    */
-  *formulasInFormula(): Generator<[(string | number)[], Formula]> {
+  *formulasInFormula(): Generator<{
+    path: (string | number)[]
+    formula: Formula
+    packageName?: string
+  }> {
     yield* getFormulasInFormula({
       formula: this.formula,
       globalFormulas: this.globalFormulas,

--- a/packages/core/src/formula/formula.ts
+++ b/packages/core/src/formula/formula.ts
@@ -203,6 +203,7 @@ export function applyFormula(
           ctx.toddle ?? ((globalThis as any).toddle as Toddle<unknown, unknown>)
         ).getFormula(formula.name)
         if (isDefined(newFunc)) {
+          ctx.package = packageName
           const args = formula.arguments.reduce<Record<string, unknown>>(
             (args, arg, i) => ({
               ...args,

--- a/packages/search/src/rules/apis/noReferenceApiInputRule.ts
+++ b/packages/search/src/rules/apis/noReferenceApiInputRule.ts
@@ -26,7 +26,7 @@ export const noReferenceApiInputRule: Rule<{ inputName: string }> = {
       () => {
         const apiFormulaReferences = apiV2.formulasInApi()
         const referencedApiInputs = new Set<string>()
-        for (const [, formula] of apiFormulaReferences) {
+        for (const { formula } of apiFormulaReferences) {
           if (formula.type === 'path' && formula.path[0] === 'Args') {
             referencedApiInputs.add(formula.path[1])
           }

--- a/packages/search/src/rules/apis/noReferenceApiRule.ts
+++ b/packages/search/src/rules/apis/noReferenceApiRule.ts
@@ -17,7 +17,7 @@ export const noReferenceApiRule: Rule<void> = {
       `componentApiReferences/${component.name}]`,
       () => {
         const usedApis = new Set<string>()
-        for (const [, formula] of component.formulasInComponent()) {
+        for (const { formula } of component.formulasInComponent()) {
           if (
             formula.type === 'path' &&
             formula.path[0] === 'Apis' &&

--- a/packages/search/src/rules/attributes/noReferenceAttributeRule.ts
+++ b/packages/search/src/rules/attributes/noReferenceAttributeRule.ts
@@ -15,7 +15,7 @@ export const noReferenceAttributeRule: Rule<void> = {
     }
     const attrs = memo(`${component.name}-attrs`, () => {
       const attrs = new Set<string>()
-      for (const [, formula] of component.formulasInComponent()) {
+      for (const { formula } of component.formulasInComponent()) {
         if (formula.type === 'path' && formula.path[0] === 'Attributes') {
           attrs.add(formula.path[1])
         }

--- a/packages/search/src/rules/formulas/noReferenceComponentFormulaRule.ts
+++ b/packages/search/src/rules/formulas/noReferenceComponentFormulaRule.ts
@@ -15,7 +15,10 @@ export const noReferenceComponentFormulaRule: Rule<{
 
     const { path, files, value, component } = args
     const [, componentName, , formulaKey] = path
-    for (const [formulaPath, formula] of component.formulasInComponent()) {
+    for (const {
+      path: formulaPath,
+      formula,
+    } of component.formulasInComponent()) {
       if (
         formula.type === 'apply' &&
         formula.name === formulaKey &&
@@ -52,7 +55,7 @@ export const noReferenceComponentFormulaRule: Rule<{
                 packages: files.packages,
               },
             })
-            for (const [, formula] of contextComponent.formulasInComponent()) {
+            for (const { formula } of contextComponent.formulasInComponent()) {
               if (
                 formula.type === 'path' &&
                 formula.path[0] === 'Contexts' &&

--- a/packages/search/src/rules/formulas/noReferenceProjectFormulaRule.ts
+++ b/packages/search/src/rules/formulas/noReferenceProjectFormulaRule.ts
@@ -21,7 +21,7 @@ export const noReferenceProjectFormulaRule: Rule<void> = {
         globalFormulas: { formulas: files.formulas, packages: files.packages },
       })
       const formulas = service.formulasInService()
-      for (const [_formulaPath, formula] of formulas) {
+      for (const { path: _formulaPath, formula } of formulas) {
         // Check if the formula is used in the formula
         if (checkFormula(formula, value.name)) {
           return
@@ -36,7 +36,7 @@ export const noReferenceProjectFormulaRule: Rule<void> = {
         globalFormulas: { formulas: files.formulas, packages: files.packages },
       })
       const formulas = route.formulasInRoute()
-      for (const [_formulaPath, formula] of formulas) {
+      for (const { path: _formulaPath, formula } of formulas) {
         // Check if the formula is used in the formula
         if (checkFormula(formula, value.name)) {
           return
@@ -59,7 +59,7 @@ export const noReferenceProjectFormulaRule: Rule<void> = {
               packages: files.packages,
             },
           })
-          for (const [, formula] of c.formulasInComponent()) {
+          for (const { formula } of c.formulasInComponent()) {
             if (formula.type === 'function') {
               usedFormulas.add(formula.name)
             }

--- a/packages/search/src/rules/variables/noReferenceVariableRule.ts
+++ b/packages/search/src/rules/variables/noReferenceVariableRule.ts
@@ -18,12 +18,12 @@ export const noReferenceVariableRule: Rule<void> = {
         new Set(
           Array.from(component.formulasInComponent())
             .filter(
-              ([, formula]) =>
+              ({ formula }) =>
                 formula.type === 'path' &&
                 formula.path[0] === 'Variables' &&
                 formula.path[1],
             )
-            .map<string | number>(([, formula]) => (formula as any).path[1]),
+            .map<string | number>(({ formula }) => (formula as any).path[1]),
         ),
     )
 

--- a/packages/search/src/searchProject.ts
+++ b/packages/search/src/searchProject.ts
@@ -347,7 +347,10 @@ function* visitNode(
         )
       }
 
-      for (const [formulaPath, formula] of component.formulasInComponent()) {
+      for (const {
+        path: formulaPath,
+        formula,
+      } of component.formulasInComponent()) {
         yield* visitNode(
           {
             nodeType: 'formula',
@@ -391,7 +394,10 @@ function* visitNode(
           },
         })
         formula.formulasInFormula()
-        for (const [formulaPath, f] of formula.formulasInFormula()) {
+        for (const {
+          path: formulaPath,
+          formula: f,
+        } of formula.formulasInFormula()) {
           yield* visitNode(
             {
               nodeType: 'formula',
@@ -439,7 +445,10 @@ function* visitNode(
           packages: files.packages,
         },
       })
-      for (const [formulaPath, formula] of apiService.formulasInService()) {
+      for (const {
+        path: formulaPath,
+        formula,
+      } of apiService.formulasInService()) {
         yield* visitNode(
           {
             nodeType: 'formula',
@@ -464,7 +473,10 @@ function* visitNode(
           packages: files.packages,
         },
       })
-      for (const [formulaPath, formula] of projectRoute.formulasInRoute()) {
+      for (const {
+        path: formulaPath,
+        formula,
+      } of projectRoute.formulasInRoute()) {
         yield* visitNode(
           {
             nodeType: 'formula',

--- a/packages/ssr/src/ToddleApiService.ts
+++ b/packages/ssr/src/ToddleApiService.ts
@@ -22,7 +22,11 @@ export class ToddleApiService<Handler> {
    * Traverse all formulas in the API Service.
    * @returns An iterable that yields the path and formula.
    */
-  *formulasInService(): Generator<[(string | number)[], Formula]> {
+  *formulasInService(): Generator<{
+    path: (string | number)[]
+    formula: Formula
+    packageName?: string
+  }> {
     const globalFormulas = this.globalFormulas
 
     yield* getFormulasInFormula({

--- a/packages/ssr/src/ToddleRoute.ts
+++ b/packages/ssr/src/ToddleRoute.ts
@@ -22,7 +22,11 @@ export class ToddleRoute<Handler> {
    * Traverse all formulas in the route
    * @returns An iterable that yields the path and formula.
    */
-  *formulasInRoute(): Generator<[(string | number)[], Formula]> {
+  *formulasInRoute(): Generator<{
+    path: (string | number)[]
+    formula: Formula
+    packageName?: string
+  }> {
     const globalFormulas = this.globalFormulas
 
     yield* getFormulasInFormula({


### PR DESCRIPTION
Using a global formula inside another global formula for packages, would not work as only the first one would have it's package attribute set. Similar to components, we need to keep track of which package we're going through.

You can test here: https://spring.toddle.dev/ease it should show a nice graph when it is working, and not a console error that it cannot find the formula.