### PR TITLE
Report empty/nullish required attributes

### DIFF
--- a/packages/editor/elements/_dev_buildElements.ts
+++ b/packages/editor/elements/_dev_buildElements.ts
@@ -577,7 +577,7 @@ const elements: Record<
     categories: ['media'],
     attrs: {
       src: { type: 'value', value: '' },
-      alt: { type: 'value', value: '' },
+      alt: { type: 'value', value: null },
     },
   },
   input: {

--- a/packages/editor/elements/html/img.json
+++ b/packages/editor/elements/html/img.json
@@ -22,7 +22,7 @@
           },
           "alt": {
             "type": "value",
-            "value": ""
+            "value": null
           }
         },
         "style": {},

--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -84,9 +84,13 @@ export type Options = {
 
 const RULES = [
   createActionNameRule({ name: '@toddle/logToConsole', code: 'no-console' }),
-  createRequiredElementAttributeRule('a', 'href'),
-  createRequiredElementAttributeRule('img', 'alt'),
-  createRequiredElementAttributeRule('img', 'src'),
+  createRequiredElementAttributeRule({ tag: 'a', attribute: 'href' }),
+  createRequiredElementAttributeRule({
+    tag: 'img',
+    attribute: 'alt',
+    allowEmptyString: true,
+  }),
+  createRequiredElementAttributeRule({ tag: 'img', attribute: 'src' }),
   createRequiredMetaTagRule('description'),
   createRequiredMetaTagRule('title'),
   createRequiredDirectChildRule(['ul', 'ol'], ['li', 'script', 'template']),

--- a/packages/search/src/rules/dom/createRequiredElementAttributeRule.test.ts
+++ b/packages/search/src/rules/dom/createRequiredElementAttributeRule.test.ts
@@ -29,7 +29,13 @@ describe('requiredElementAttributeRule', () => {
             },
           },
         },
-        rules: [createRequiredElementAttributeRule('img', 'alt')],
+        rules: [
+          createRequiredElementAttributeRule({
+            tag: 'img',
+            attribute: 'alt',
+            allowEmptyString: true,
+          }),
+        ],
       }),
     )
 
@@ -65,13 +71,55 @@ describe('requiredElementAttributeRule', () => {
             },
           },
         },
-        rules: [createRequiredElementAttributeRule('img', 'alt')],
+        rules: [
+          createRequiredElementAttributeRule({ tag: 'img', attribute: 'src' }),
+        ],
       }),
     )
 
     expect(problems).toHaveLength(1)
     expect(problems[0].code).toBe('required element attribute')
     expect(problems[0].path).toEqual(['components', 'test', 'nodes', 'root'])
+  })
+  test('should not detect issues when elements can have empty attributes', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {
+                    alt: { type: 'value', value: '' },
+                  },
+                  classes: {},
+                  events: {},
+                  tag: 'img',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [
+          createRequiredElementAttributeRule({
+            tag: 'img',
+            attribute: 'alt',
+            allowEmptyString: true,
+          }),
+        ],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
   })
   test('should not detect issues when elements have all required attributes', () => {
     const problems = Array.from(
@@ -101,7 +149,9 @@ describe('requiredElementAttributeRule', () => {
             },
           },
         },
-        rules: [createRequiredElementAttributeRule('img', 'alt')],
+        rules: [
+          createRequiredElementAttributeRule({ tag: 'img', attribute: 'alt' }),
+        ],
       }),
     )
 

--- a/packages/search/src/rules/dom/createRequiredElementAttributeRule.ts
+++ b/packages/search/src/rules/dom/createRequiredElementAttributeRule.ts
@@ -1,11 +1,17 @@
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import type { Level, Rule } from '../../types'
 
-export function createRequiredElementAttributeRule(
-  tag: string,
-  attribute: string,
-  level: Level = 'warning',
-): Rule<{
+export function createRequiredElementAttributeRule({
+  tag,
+  attribute,
+  level = 'warning',
+  allowEmptyString = false,
+}: {
+  tag: string
+  attribute: string
+  level?: Level
+  allowEmptyString?: boolean
+}): Rule<{
   tag: string
   attribute: string
 }> {
@@ -20,13 +26,17 @@ export function createRequiredElementAttributeRule(
         value.tag === tag
       ) {
         const attributeValue = value.attrs[attribute]
-        if (
-          !isDefined(attributeValue) ||
-          (attributeValue.type === 'value' &&
-            (attributeValue.value === '' || !isDefined(attributeValue.value)))
-        ) {
-          // Report the missing attribute if it is not defined or statically empty/nullish
-          report(path, { tag, attribute })
+        // Report the missing attribute if it is not defined or statically empty/nullish
+        if (!isDefined(attributeValue)) {
+          return report(path, { tag, attribute })
+        }
+        if (attributeValue.type === 'value') {
+          if (!isDefined(attributeValue.value)) {
+            return report(path, { tag, attribute })
+          }
+          if (!allowEmptyString && attributeValue.value === '') {
+            return report(path, { tag, attribute })
+          }
         }
       }
     },


### PR DESCRIPTION
Currently this rule is used for:

- img -> alt
- img -> src
- a -> href

All of the above would be considered illegal if they are empty or nullish. These updates will ensure that empty/nullish attributes are also reported as errors for the `createRequiredElementAttributeRule`.