### PR TITLE
Fix rule: delete actions after a navigate action

### DIFF
--- a/packages/search/src/rules/workflows/noPostNavigateAction.test.ts
+++ b/packages/search/src/rules/workflows/noPostNavigateAction.test.ts
@@ -1,8 +1,11 @@
+import type { ElementNodeModel } from '@nordcraft/core/dist/component/component.types'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
 import { describe, expect, test } from 'bun:test'
+import { fixProject } from '../../fixProject'
 import { searchProject } from '../../searchProject'
 import { noPostNavigateAction } from './noPostNavigateAction'
 
-describe('noPostNavigateAction', () => {
+describe('find noPostNavigateAction', () => {
   test('should detect actions after a url navigate action', () => {
     const problems = Array.from(
       searchProject({
@@ -455,5 +458,112 @@ describe('noPostNavigateAction', () => {
     )
 
     expect(problems).toHaveLength(0)
+  })
+})
+
+describe('fix noPostNavigateAction', () => {
+  test('should remove actions after a url navigate action', () => {
+    const files: ProjectFiles = {
+      formulas: {},
+      components: {
+        nav: {
+          attributes: {},
+          events: [],
+          formulas: {},
+          nodes: {
+            root: {
+              type: 'element',
+              tag: 'div',
+              attrs: {},
+              classes: {},
+              events: {},
+              children: ['wkPXF99C3qdRgZmUcnHO_'],
+              style: {},
+            },
+            wkPXF99C3qdRgZmUcnHO_: {
+              tag: 'button',
+              type: 'element',
+              attrs: {},
+              style: {
+                color: 'var(--grey-200, #E5E5E5)',
+                'border-radius': '6px',
+                'background-color': 'var(--blue-600, #2563EB)',
+                'padding-left': '8px',
+                'padding-right': '8px',
+                'padding-top': '8px',
+                'padding-bottom': '8px',
+                width: 'fit-content',
+                cursor: 'pointer',
+              },
+              events: {
+                click: {
+                  trigger: 'click',
+                  actions: [
+                    {
+                      name: '@toddle/gotToURL',
+                      arguments: [
+                        {
+                          name: 'URL',
+                          formula: {
+                            type: 'value',
+                            value: 'https://example.com',
+                          },
+                        },
+                      ],
+                      label: 'Go to URL',
+                    },
+                    {
+                      name: '@toddle/logToConsole',
+                      arguments: [
+                        {
+                          name: 'Label',
+                          formula: {
+                            type: 'value',
+                            value: '',
+                          },
+                        },
+                        {
+                          name: 'Data',
+                          formula: {
+                            type: 'value',
+                            value: '<Data>',
+                          },
+                        },
+                      ],
+                      label: 'Log to console',
+                    },
+                  ],
+                },
+              },
+              classes: {},
+              children: ['zFhmZR6YnLy089HmlK-Yn'],
+              variants: [],
+            },
+            'zFhmZR6YnLy089HmlK-Yn': {
+              type: 'text',
+              value: {
+                type: 'value',
+                value: 'Button',
+              },
+            },
+          },
+          variables: {},
+          apis: {},
+          name: 'nav',
+        },
+      },
+    }
+    const fixedProject = fixProject({
+      files,
+      rule: noPostNavigateAction,
+      fixType: 'delete-following-actions',
+    })
+    expect(
+      (
+        fixedProject.components.nav?.nodes[
+          'wkPXF99C3qdRgZmUcnHO_'
+        ] as ElementNodeModel
+      )?.events?.click?.actions,
+    ).toHaveLength(1)
   })
 })

--- a/packages/search/src/rules/workflows/noPostNavigateAction.ts
+++ b/packages/search/src/rules/workflows/noPostNavigateAction.ts
@@ -1,5 +1,5 @@
-import { get } from '@nordcraft/core/dist/utils/collections'
-import type { Rule } from '../../types'
+import { get, set } from '@nordcraft/core/dist/utils/collections'
+import type { ActionModelNode, Rule } from '../../types'
 
 export const noPostNavigateAction: Rule<{ parameter: string }> = {
   code: 'no post navigate action',
@@ -25,7 +25,24 @@ export const noPostNavigateAction: Rule<{ parameter: string }> = {
     const actionIndex = Number(_actionIndex)
     if (actionIndex < actions.length - 1) {
       // If the action is not the last one in the array, report it
-      report(path)
+      report(path, undefined, ['delete-following-actions'])
     }
   },
+  fixes: {
+    'delete-following-actions': ({ path, files }: ActionModelNode) => {
+      const actionsArrayPath = path.slice(0, -1).map((p) => String(p))
+      const actions = get(files, actionsArrayPath)
+      const actionIndex = path.at(-1)
+      if (actionIndex === undefined || !Array.isArray(actions)) {
+        return
+      }
+      return set(
+        files,
+        actionsArrayPath,
+        actions.slice(0, Number(actionIndex) + 1),
+      )
+    },
+  },
 }
+
+export type NoPostNavigateActionRuleFix = 'delete-following-actions'

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -30,9 +30,10 @@ import type { NoReferenceEventRuleFix } from './rules/events/noReferenceEventRul
 import type { LegacyFormulaRuleFix } from './rules/formulas/legacyFormulaRule'
 import type { NoReferenceComponentFormulaRuleFix } from './rules/formulas/noReferenceComponentFormulaRule'
 import type { NoReferenceProjectFormulaRuleFix } from './rules/formulas/noReferenceProjectFormulaRule'
-import type { NoStaticNodeConditionRuleFix } from './rules/logic/noStaticNodeConditionRule'
+import type { NoStaticNodeConditionRuleFix } from './rules/logic/noStaticNodeCondition'
 import type { NoReferenceNodeRuleFix } from './rules/noReferenceNodeRule'
 import type { InvalidStyleSyntaxRuleFix } from './rules/style/invalidStyleSyntaxRule'
+import type { NoPostNavigateActionRuleFix } from './rules/workflows/noPostNavigateAction'
 
 type Code =
   | 'duplicate event trigger'
@@ -346,6 +347,7 @@ type FixType =
   | NoReferenceNodeRuleFix
   | InvalidStyleSyntaxRuleFix
   | NoStaticNodeConditionRuleFix
+  | NoPostNavigateActionRuleFix
 
 export interface Rule<T = unknown, V = NodeType> {
   category: Category


### PR DESCRIPTION
Allow auto fixing the `noPostNavigateAction` rule by deleting any actions that come after a navigate action in a workflow.