### PR TITLE
Add issue rule for unknown component attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/search/src/problems.worker.ts
+++ b/packages/search/src/problems.worker.ts
@@ -12,6 +12,7 @@ import { unknownApiInputRule } from './rules/apis/unknownApiInputRule'
 import { unknownApiRule } from './rules/apis/unknownApiRule'
 import { noReferenceAttributeRule } from './rules/attributes/noReferenceAttributeRule'
 import { unknownAttributeRule } from './rules/attributes/unknownAttributeRule'
+import { unknownComponentAttributeRule } from './rules/attributes/unknownComponentAttributeRule'
 import { noReferenceComponentRule } from './rules/components/noReferenceComponentRule'
 import { unknownComponentRule } from './rules/components/unknownComponentRule'
 import { noContextConsumersRule } from './rules/context/noContextConsumersRule'
@@ -180,6 +181,7 @@ const RULES = [
   unknownContextProviderWorkflowRule,
   unknownContextWorkflowRule,
   unknownCookieRule,
+  unknownComponentAttributeRule,
   unknownEventRule,
   unknownFormulaRule,
   unknownProjectActionRule,

--- a/packages/search/src/rules/attributes/unknownComponentAttributeRule.test.ts
+++ b/packages/search/src/rules/attributes/unknownComponentAttributeRule.test.ts
@@ -1,0 +1,156 @@
+import type { ComponentNodeModel } from '@nordcraft/core/dist/component/component.types'
+import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { fixProject } from '../../fixProject'
+import { searchProject } from '../../searchProject'
+import { unknownComponentAttributeRule } from './unknownComponentAttributeRule'
+
+describe('find unknownComponentAttribute', () => {
+  test('should report unknown component attributes', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            referenced: {
+              name: 'referenced',
+              nodes: {},
+              attributes: {
+                first: {
+                  name: 'first',
+                  testValue: valueFormula(null),
+                },
+                second: {
+                  name: 'second',
+                  testValue: valueFormula(null),
+                },
+              },
+              apis: {},
+              formulas: {},
+              variables: {},
+            },
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'component',
+                  name: 'referenced',
+                  events: {},
+                  children: [],
+                  style: {},
+                  attrs: {
+                    first: valueFormula('exists'),
+                    third: valueFormula('does not exist'),
+                  },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [unknownComponentAttributeRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('unknown component attribute')
+    expect(problems[0].details).toEqual({ name: 'third' })
+  })
+
+  test('should not report component attributes that exist', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  attrs: {
+                    known: valueFormula('exists'),
+                  },
+                  classes: {},
+                  events: {},
+                  tag: 'div',
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              variables: {},
+              attributes: {
+                known: {
+                  name: 'known',
+                  testValue: { type: 'value', value: null },
+                },
+              },
+            },
+          },
+        },
+        rules: [unknownComponentAttributeRule],
+      }),
+    )
+    expect(problems).toEqual([])
+  })
+})
+
+describe('fix unknownComponentAttribute', () => {
+  test('should remove unknown component attributes', () => {
+    const files: ProjectFiles = {
+      components: {
+        referenced: {
+          name: 'referenced',
+          nodes: {},
+          attributes: {
+            first: {
+              name: 'first',
+              testValue: valueFormula(null),
+            },
+            second: {
+              name: 'second',
+              testValue: valueFormula(null),
+            },
+          },
+          apis: {},
+          formulas: {},
+          variables: {},
+        },
+        test: {
+          name: 'test',
+          nodes: {
+            root: {
+              type: 'component',
+              name: 'referenced',
+              events: {},
+              children: [],
+              style: {},
+              attrs: {
+                first: valueFormula('exists'),
+                third: valueFormula('does not exist'),
+              },
+            },
+          },
+          formulas: {},
+          apis: {},
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedProject = fixProject({
+      files,
+      rule: unknownComponentAttributeRule,
+      fixType: 'delete-component-attribute',
+    })
+    expect(
+      (fixedProject.components.test!.nodes.root as ComponentNodeModel).attrs,
+    ).toEqual({
+      first: valueFormula('exists'),
+    })
+  })
+})

--- a/packages/search/src/rules/attributes/unknownComponentAttributeRule.ts
+++ b/packages/search/src/rules/attributes/unknownComponentAttributeRule.ts
@@ -1,0 +1,40 @@
+import { isDefined } from '@nordcraft/core/dist/utils/util'
+import type { Rule } from '../../types'
+import { removeFromPathFix } from '../../util/removeUnused.fix'
+
+export const unknownComponentAttributeRule: Rule<{
+  name: string
+}> = {
+  code: 'unknown component attribute',
+  level: 'error',
+  category: 'Unknown Reference',
+  visit: (report, { path, files, value, nodeType }) => {
+    if (
+      nodeType !== 'component-node' ||
+      value.type !== 'component' ||
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      Object.keys(value.attrs ?? {}).length === 0
+    ) {
+      return
+    }
+    const component = value.package
+      ? files.packages?.[value.package].components?.[value.name]
+      : files.components[value.name]
+    if (!component) {
+      return
+    }
+    for (const attrKey of Object.keys(value.attrs)) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!isDefined(component.attributes?.[attrKey])) {
+        report([...path, 'attrs', attrKey], { name: attrKey }, [
+          'delete-component-attribute',
+        ])
+      }
+    }
+  },
+  fixes: {
+    'delete-component-attribute': removeFromPathFix,
+  },
+}
+
+export type UnknownComponentAttributeRuleFix = 'delete-component-attribute'

--- a/packages/search/src/types.d.ts
+++ b/packages/search/src/types.d.ts
@@ -25,6 +25,7 @@ import type { LegacyActionRuleFix } from './rules/actions/legacyActionRule'
 import type { NoReferenceProjectActionRuleFix } from './rules/actions/noReferenceProjectActionRule'
 import type { NoReferenceApiRuleFix } from './rules/apis/noReferenceApiRule'
 import type { NoReferenceAttributeRuleFix } from './rules/attributes/noReferenceAttributeRule'
+import type { UnknownComponentAttributeRuleFix } from './rules/attributes/unknownComponentAttributeRule'
 import type { NoReferenceComponentRuleFix } from './rules/components/noReferenceComponentRule'
 import type { NoReferenceEventRuleFix } from './rules/events/noReferenceEventRule'
 import type { LegacyFormulaRuleFix } from './rules/formulas/legacyFormulaRule'
@@ -76,6 +77,7 @@ type Code =
   | 'unknown api'
   | 'unknown attribute'
   | 'unknown classname'
+  | 'unknown component attribute'
   | 'unknown component formula input'
   | 'unknown component slot'
   | 'unknown context formula'
@@ -352,6 +354,7 @@ type FixType =
   | InvalidStyleSyntaxRuleFix
   | NoStaticNodeConditionRuleFix
   | NoPostNavigateActionRuleFix
+  | UnknownComponentAttributeRuleFix
 
 export interface Rule<T = unknown, V = NodeType> {
   category: Category

--- a/packages/search/src/util/helpers.test.ts
+++ b/packages/search/src/util/helpers.test.ts
@@ -53,7 +53,7 @@ describe('shouldSearchPath', () => {
 })
 
 describe('shouldSearchExactPath', () => {
-  test.only('should only return true for exact matches', () => {
+  test('should only return true for exact matches', () => {
     const pathsToVisit = [
       ['components', 'Button'],
       ['components', 'Input'],


### PR DESCRIPTION
This detects (and potentially fixes) uses of attributes in nodes on components that are not defined in the target component.