### PR TITLE
Workflow callbacks trigger correctly from API callbacks

### DIFF
--- a/packages/runtime/src/events/handleAction.ts
+++ b/packages/runtime/src/events/handleAction.ts
@@ -281,7 +281,12 @@ export function handleAction(
             onFailed: action.onError?.actions ?? [],
             onMessage: action.onMessage?.actions ?? [],
           }
-          void api.fetch({ actionInputs, actionModels, componentData: data })
+          void api.fetch({
+            actionInputs,
+            actionModels,
+            componentData: data,
+            workflowCallback,
+          })
         } else {
           const triggerActions = (actions: ActionModel[]) => {
             for (const subAction of actions) {

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -107,6 +107,7 @@ export interface ContextApiV2 {
       onMessage: ActionModel[]
     }
     componentData: ComponentData
+    workflowCallback?: (event: string, data: unknown) => void
   }) => Promise<unknown>
   destroy: Function
   update: (newApi: CoreApiRequest, componentData: ComponentData) => void // for updating the dataSignal


### PR DESCRIPTION
From my tests this is the only issue I could find with workflow callbacks: The workflow callback function was not parsed to API requests. It is optional as it is only available when fetch is called from an action and not used on the APIs own events.