### PR TITLE
Use MDN's element descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/editor/elements/html/a.json
+++ b/packages/editor/elements/html/a.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "a",
     "categories": ["semantic"],
-    "description": "Defines a hyperlink to link to another page or resource",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a",
+    "description": "The <a> HTML element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a",
     "aliases": ["link", "anchor"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/abbr.json
+++ b/packages/editor/elements/html/abbr.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "abbr",
     "categories": ["typography"],
-    "description": "Represents an abbreviation or acronym, with an optional title for expansion",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr",
+    "description": "The <abbr> HTML element represents an abbreviation or acronym.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/abbr",
     "aliases": ["abbreviation"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/address.json
+++ b/packages/editor/elements/html/address.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "address",
     "categories": ["semantic"],
-    "description": "Provides contact information for a person, organization, or author",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address",
+    "description": "The <address> HTML element indicates that the enclosed HTML provides contact information for a person or people, or for an organization.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/address",
     "aliases": ["contact-info"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/area.json
+++ b/packages/editor/elements/html/area.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "area",
     "categories": ["media"],
-    "description": "Defines a clickable area inside an image map",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area",
+    "description": "The <area> HTML element defines an area inside an image map that has predefined clickable areas. An image map allows geometric areas on an image to be associated with hypertext links.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/area",
     "aliases": ["imagemap-area"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/article.json
+++ b/packages/editor/elements/html/article.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "article",
     "categories": ["semantic"],
-    "description": "Represents a self-contained, independent piece of content",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article",
+    "description": "The <article> HTML element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). Examples include: a forum post, a magazine or newspaper article, or a blog entry, a product card, a user-submitted comment, an interactive widget or gadget, or any other independent item of content.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/article",
     "aliases": ["blog-post", "news-article"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/aside.json
+++ b/packages/editor/elements/html/aside.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "aside",
     "categories": ["semantic"],
-    "description": "Contains content tangentially related to the main content, like a sidebar",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside",
+    "description": "The <aside> HTML element represents a portion of a document whose content is only indirectly related to the document's main content. Asides are frequently presented as sidebars or call-out boxes.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/aside",
     "aliases": ["sidebar"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/audio.json
+++ b/packages/editor/elements/html/audio.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "audio",
     "categories": ["media"],
-    "description": "Embeds sound content such as music or audio streams",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio",
+    "description": "The <audio> HTML element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element: the browser will choose the most suitable one.\nIt can also be the destination for streamed media, using a MediaStream.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/audio",
     "aliases": ["sound", "music"],
     "interfaces": [
       "HTMLAudioElement",

--- a/packages/editor/elements/html/b.json
+++ b/packages/editor/elements/html/b.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "b",
     "categories": ["typography"],
-    "description": "Renders text in bold for emphasis without conveying extra importance",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b",
+    "description": "The <b> HTML element is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance. This was formerly known as the Boldface element, and most browsers still draw the text in boldface. However, you should not use <b> for styling text or granting importance. If you wish to create boldface text, you should use the CSS font-weight property. If you wish to indicate an element is of special importance, you should use the <strong> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/b",
     "aliases": ["bold"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/bdi.json
+++ b/packages/editor/elements/html/bdi.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "bdi",
     "categories": ["typography"],
-    "description": "Isolates a span of text that might have a different text direction",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi",
+    "description": "The <bdi> HTML element tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text. It's particularly useful when a website dynamically inserts some text and doesn't know the directionality of the text being inserted.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdi",
     "aliases": ["bidirectional-isolation"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/bdo.json
+++ b/packages/editor/elements/html/bdo.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "bdo",
     "categories": ["typography"],
-    "description": "Overrides the current text direction for its children",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo",
+    "description": "The <bdo> HTML element overrides the current directionality of text, so that the text within is rendered in a different direction.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/bdo",
     "aliases": ["bidirectional-override"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/blockquote.json
+++ b/packages/editor/elements/html/blockquote.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "blockquote",
     "categories": ["typography"],
-    "description": "Indicates a section quoted from another source",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote",
+    "description": "The <blockquote> HTML element indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the <cite> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/blockquote",
     "aliases": ["quote", "quotation"],
     "interfaces": [
       "HTMLQuoteElement",

--- a/packages/editor/elements/html/br.json
+++ b/packages/editor/elements/html/br.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "br",
     "categories": ["typography"],
-    "description": "Produces a single line break in text",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br",
+    "description": "The <br> HTML element produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/br",
     "aliases": ["line-break"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/button.json
+++ b/packages/editor/elements/html/button.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "button",
     "categories": ["form"],
-    "description": "Creates a clickable button for user interaction",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button",
+    "description": "The <button> HTML element is an interactive element activated by a user with a mouse, keyboard, finger, voice command, or other assistive technology. Once activated, it then performs an action, such as submitting a form or opening a dialog.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button",
     "aliases": ["form-button", "action-button", "submit-button"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/canvas.json
+++ b/packages/editor/elements/html/canvas.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "canvas",
     "categories": ["media"],
-    "description": "Provides an area for drawing graphics via scripting",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas",
+    "description": "Use the HTML <canvas> element with either the canvas scripting API or the WebGL API to draw graphics and animations.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/canvas",
     "aliases": ["drawing", "graphics"],
     "interfaces": [
       "HTMLCanvasElement",

--- a/packages/editor/elements/html/caption.json
+++ b/packages/editor/elements/html/caption.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "caption",
     "categories": ["semantic"],
-    "description": "Specifies the caption or title for a table",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption",
+    "description": "The <caption> HTML element specifies the caption (or title) of a table, providing the table an accessible name or accessible description.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/caption",
     "aliases": ["table-caption"],
     "interfaces": [
       "HTMLTableCaptionElement",

--- a/packages/editor/elements/html/cite.json
+++ b/packages/editor/elements/html/cite.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "cite",
     "categories": ["typography"],
-    "description": "Cites the title of a creative work",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite",
+    "description": "The <cite> HTML element is used to mark up the title of a creative work. The reference may be in an abbreviated form according to context-appropriate conventions related to citation metadata.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/cite",
     "aliases": ["citation", "reference"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/code.json
+++ b/packages/editor/elements/html/code.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "code",
     "categories": ["typography"],
-    "description": "Displays a fragment of computer code",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code",
+    "description": "The <code> HTML element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/code",
     "aliases": ["inline-code", "source-code"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/col.json
+++ b/packages/editor/elements/html/col.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "col",
     "categories": ["semantic"],
-    "description": "Specifies column properties for each column within a colgroup in a table",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col",
+    "description": "The <col> HTML element defines one or more columns in a column group represented by its parent <colgroup> element. The <col> element is only valid as a child of a <colgroup> element that has no span attribute defined.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/col",
     "aliases": ["table-column"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/colgroup.json
+++ b/packages/editor/elements/html/colgroup.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "colgroup",
     "categories": ["semantic"],
-    "description": "Groups one or more columns in a table for formatting",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup",
+    "description": "The <colgroup> HTML element defines a group of columns within a table.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/colgroup",
     "aliases": ["table-column-group"],
     "interfaces": [
       "HTMLTableColElement",

--- a/packages/editor/elements/html/data.json
+++ b/packages/editor/elements/html/data.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "data",
     "categories": ["semantic"],
-    "description": "Associates a machine-readable value with its human-readable content",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data",
+    "description": "The <data> HTML element links a given piece of content with a machine-readable translation. If the content is time- or date-related, the <time> element must be used.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/data",
     "aliases": ["machine-readable"],
     "interfaces": [
       "HTMLDataElement",

--- a/packages/editor/elements/html/datalist.json
+++ b/packages/editor/elements/html/datalist.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "datalist",
     "categories": ["form"],
-    "description": "Contains a set of option elements for input suggestions",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist",
+    "description": "The <datalist> HTML element contains a set of <option> elements that represent the permissible or recommended options available to choose from within other controls.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/datalist",
     "aliases": ["input-suggestions"],
     "interfaces": [
       "HTMLDataListElement",

--- a/packages/editor/elements/html/dd.json
+++ b/packages/editor/elements/html/dd.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "dd",
     "categories": ["semantic"],
-    "description": "Provides the description or value for a term in a description list",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd",
+    "description": "The <dd> HTML element provides the description, definition, or value for the preceding term (<dt>) in a description list (<dl>).",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dd",
     "aliases": ["description-details"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/del.json
+++ b/packages/editor/elements/html/del.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "del",
     "categories": ["typography"],
-    "description": "Represents deleted or removed text",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del",
+    "description": "The <del> HTML element represents a range of text that has been deleted from a document. This can be used when rendering \"track changes\" or source code diff information, for example. The <ins> element can be used for the opposite purpose: to indicate text that has been added to the document.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/del",
     "aliases": ["deleted-text", "remove"],
     "interfaces": [
       "HTMLModElement",

--- a/packages/editor/elements/html/details.json
+++ b/packages/editor/elements/html/details.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "details",
     "categories": ["semantic"],
-    "description": "Creates a disclosure widget for additional information",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details",
+    "description": "The <details> HTML element creates a disclosure widget in which information is visible only when the widget is toggled into an open state. A summary or label must be provided using the <summary> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/details",
     "aliases": ["disclosure", "expandable"],
     "interfaces": ["HTMLDetailsElement", "global"]
   },

--- a/packages/editor/elements/html/dfn.json
+++ b/packages/editor/elements/html/dfn.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "dfn",
     "categories": ["typography"],
-    "description": "Indicates the defining instance of a term",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn",
+    "description": "The <dfn> HTML element indicates a term to be defined. The <dfn> element should be used in a complete definition statement, where the full definition of the term can be one of the following:",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dfn",
     "aliases": ["definition"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/dialog.json
+++ b/packages/editor/elements/html/dialog.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "dialog",
     "categories": ["semantic"],
-    "description": "Represents a dialog box or other interactive component",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog",
+    "description": "The <dialog> HTML element represents a modal or non-modal dialog box or other interactive component, such as a dismissible alert, inspector, or subwindow.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog",
     "aliases": ["modal", "popup"],
     "interfaces": ["HTMLDialogElement", "global"]
   },

--- a/packages/editor/elements/html/div.json
+++ b/packages/editor/elements/html/div.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "div",
     "categories": ["semantic"],
-    "description": "Generic container for content, used for layout and styling",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div",
+    "description": "The <div> HTML element is the generic container for flow content. It has no effect on the content or layout until styled in some way using CSS (e.g., styling is directly applied to it, or some kind of layout model like Flexbox is applied to its parent element).",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/div",
     "aliases": ["container", "division"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/dl.json
+++ b/packages/editor/elements/html/dl.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "dl",
     "categories": ["semantic"],
-    "description": "Represents a description list of terms and their descriptions",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl",
+    "description": "The <dl> HTML element represents a description list. The element encloses a list of groups of terms (specified using the <dt> element) and descriptions (provided by <dd> elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs).",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl",
     "aliases": ["description-list"],
     "interfaces": [
       "HTMLDListElement",

--- a/packages/editor/elements/html/dt.json
+++ b/packages/editor/elements/html/dt.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "dt",
     "categories": ["semantic"],
-    "description": "Specifies a term or name in a description list",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt",
+    "description": "The <dt> HTML element specifies a term in a description or definition list, and as such must be used inside a <dl> element. It is usually followed by a <dd> element; however, multiple <dt> elements in a row indicate several terms that are all defined by the immediate next <dd> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dt",
     "aliases": ["description-term"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/em.json
+++ b/packages/editor/elements/html/em.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "em",
     "categories": ["typography"],
-    "description": "Stresses emphasis of its contents, typically rendered in italics",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em",
+    "description": "The <em> HTML element marks text that has stress emphasis. The <em> element can be nested, with each level of nesting indicating a greater degree of emphasis.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/em",
     "aliases": ["emphasis", "italic"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/embed.json
+++ b/packages/editor/elements/html/embed.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "embed",
     "categories": ["media"],
-    "description": "Embeds external content, like a plugin or interactive resource",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed",
+    "description": "The <embed> HTML element embeds external content at the specified point in the document. This content is provided by an external application or other source of interactive content such as a browser plug-in.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/embed",
     "aliases": ["external-content", "plugin"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/fieldset.json
+++ b/packages/editor/elements/html/fieldset.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "fieldset",
     "categories": ["form"],
-    "description": "Groups related elements in a form",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset",
+    "description": "The <fieldset> HTML element is used to group several controls as well as labels (<label>) within a web form.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/fieldset",
     "aliases": ["form-group"],
     "interfaces": [
       "HTMLFieldSetElement",

--- a/packages/editor/elements/html/figcaption.json
+++ b/packages/editor/elements/html/figcaption.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "figcaption",
     "categories": ["media"],
-    "description": "Provides a caption or legend for a figure element",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption",
+    "description": "The <figcaption> HTML element represents a caption or legend describing the rest of the contents of its parent <figure> element, providing the <figure> an accessible name.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/figcaption",
     "aliases": ["figure-caption"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"],
     "permittedParents": ["figure"]

--- a/packages/editor/elements/html/figure.json
+++ b/packages/editor/elements/html/figure.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "figure",
     "categories": ["media"],
-    "description": "Represents self-contained content, like images or diagrams",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure",
+    "description": "The <figure> HTML element represents self-contained content, potentially with an optional caption, which is specified using the <figcaption> element. The figure, its caption, and its contents are referenced as a single unit.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/figure",
     "aliases": ["illustration", "media"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/footer.json
+++ b/packages/editor/elements/html/footer.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "footer",
     "categories": ["semantic"],
-    "description": "Defines a footer for a section or page",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer",
+    "description": "The <footer> HTML element represents a footer for its nearest ancestor sectioning content or sectioning root element. A <footer> typically contains information about the author of the section, copyright data or links to related documents.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/footer",
     "aliases": ["page-footer", "section-footer"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/form.json
+++ b/packages/editor/elements/html/form.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "form",
     "categories": ["form"],
-    "description": "Collects user input via interactive controls",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form",
+    "description": "The <form> HTML element represents a document section containing interactive controls for submitting information.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/form",
     "aliases": ["input-form", "user-input"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/h1.json
+++ b/packages/editor/elements/html/h1.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "h1",
     "categories": ["typography"],
-    "description": "Represents a top-level heading",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1",
+    "description": "The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. By default, all heading elements create a block-level box in the layout, starting on a new line and taking up the full width available in their containing block.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements",
     "aliases": ["heading-1", "main-heading"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/h2.json
+++ b/packages/editor/elements/html/h2.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "h2",
     "categories": ["typography"],
-    "description": "Represents a second-level heading",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2",
+    "description": "The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. By default, all heading elements create a block-level box in the layout, starting on a new line and taking up the full width available in their containing block.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements",
     "aliases": ["heading-2", "heading", "sub-heading"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/h3.json
+++ b/packages/editor/elements/html/h3.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "h3",
     "categories": ["typography"],
-    "description": "Represents a third-level heading",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3",
+    "description": "The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. By default, all heading elements create a block-level box in the layout, starting on a new line and taking up the full width available in their containing block.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements",
     "aliases": ["heading-3", "heading", "sub-heading"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/h4.json
+++ b/packages/editor/elements/html/h4.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "h4",
     "categories": ["typography"],
-    "description": "Represents a fourth-level heading",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4",
+    "description": "The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. By default, all heading elements create a block-level box in the layout, starting on a new line and taking up the full width available in their containing block.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements",
     "aliases": ["heading-4", "heading", "sub-heading"],
     "interfaces": [
       "HTMLHeadingElement",

--- a/packages/editor/elements/html/h5.json
+++ b/packages/editor/elements/html/h5.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "h5",
     "categories": ["typography"],
-    "description": "Represents a fifth-level heading",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5",
+    "description": "The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. By default, all heading elements create a block-level box in the layout, starting on a new line and taking up the full width available in their containing block.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements",
     "aliases": ["heading-5", "heading", "sub-heading"],
     "interfaces": [
       "HTMLHeadingElement",

--- a/packages/editor/elements/html/h6.json
+++ b/packages/editor/elements/html/h6.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "h6",
     "categories": ["typography"],
-    "description": "Represents a sixth-level heading",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6",
+    "description": "The <h1> to <h6> HTML elements represent six levels of section headings. <h1> is the highest section level and <h6> is the lowest. By default, all heading elements create a block-level box in the layout, starting on a new line and taking up the full width available in their containing block.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/Heading_Elements",
     "aliases": ["heading-6", "heading", "sub-heading"],
     "interfaces": [
       "HTMLHeadingElement",

--- a/packages/editor/elements/html/header.json
+++ b/packages/editor/elements/html/header.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "header",
     "categories": ["semantic"],
-    "description": "Specifies introductory content or navigational links",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header",
+    "description": "The <header> HTML element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/header",
     "aliases": ["page-header", "section-header"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/hgroup.json
+++ b/packages/editor/elements/html/hgroup.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "hgroup",
     "categories": ["typography"],
-    "description": "Groups a set of heading elements",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup",
+    "description": "The <hgroup> HTML element represents a heading and related content. It groups a single <h1>–<h6> element with one or more <p>.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hgroup",
     "aliases": ["heading-group"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/hr.json
+++ b/packages/editor/elements/html/hr.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "hr",
     "categories": ["typography"],
-    "description": "Creates a thematic break with a horizontal rule",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr",
+    "description": "The <hr> HTML element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/hr",
     "aliases": ["horizontal-rule", "divider"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/i.json
+++ b/packages/editor/elements/html/i.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "i",
     "categories": ["typography"],
-    "description": "Renders text in italic for alternate voice or mood",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i",
+    "description": "The <i> HTML element represents a range of text that is set off from the normal text for some reason, such as idiomatic text, technical terms, taxonomical designations, among others. Historically, these have been presented using italicized type, which is the original source of the <i> naming of this element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/i",
     "aliases": ["italic", "alternate-voice"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/iframe.json
+++ b/packages/editor/elements/html/iframe.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "iframe",
     "categories": ["media"],
-    "description": "Embeds another HTML page within the current page",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe",
+    "description": "The <iframe> HTML element represents a nested browsing context, embedding another HTML page into the current one.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe",
     "aliases": ["inline-frame", "embed-page", "frame"],
     "interfaces": [
       "HTMLIFrameElement",

--- a/packages/editor/elements/html/img.json
+++ b/packages/editor/elements/html/img.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "img",
     "categories": ["media"],
-    "description": "Embeds an image into the document",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img",
+    "description": "The <img> HTML element embeds an image into the document.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img",
     "aliases": ["image", "picture"],
     "isVoid": true,
     "isPopular": true,

--- a/packages/editor/elements/html/input.json
+++ b/packages/editor/elements/html/input.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "input",
     "categories": ["form"],
-    "description": "Accepts user input in a form",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input",
+    "description": "The <input> HTML element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent. The <input> element is one of the most powerful and complex in all of HTML due to the sheer number of combinations of input types and attributes.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input",
     "aliases": ["form-input", "user-input"],
     "isVoid": true,
     "isPopular": true,

--- a/packages/editor/elements/html/ins.json
+++ b/packages/editor/elements/html/ins.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "ins",
     "categories": ["typography"],
-    "description": "Indicates inserted or added text",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins",
+    "description": "The <ins> HTML element represents a range of text that has been added to a document. You can use the <del> element to similarly represent a range of text that has been deleted from the document.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ins",
     "aliases": ["inserted-text", "addition"],
     "interfaces": [
       "HTMLModElement",

--- a/packages/editor/elements/html/kbd.json
+++ b/packages/editor/elements/html/kbd.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "kbd",
     "categories": ["typography"],
-    "description": "Represents user input, typically keyboard input",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd",
+    "description": "The <kbd> HTML element represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <kbd> element using its default monospace font, although this is not mandated by the HTML standard.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/kbd",
     "aliases": ["keyboard-input"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/label.json
+++ b/packages/editor/elements/html/label.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "label",
     "categories": ["form"],
-    "description": "Defines a label for a form input",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label",
+    "description": "The <label> HTML element represents a caption for an item in a user interface.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label",
     "aliases": ["form-label"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/legend.json
+++ b/packages/editor/elements/html/legend.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "legend",
     "categories": ["form"],
-    "description": "Provides a caption for a fieldset",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend",
+    "description": "The <legend> HTML element represents a caption for the content of its parent <fieldset>.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/legend",
     "aliases": ["fieldset-caption"],
     "interfaces": [
       "HTMLLegendElement",

--- a/packages/editor/elements/html/li.json
+++ b/packages/editor/elements/html/li.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "li",
     "categories": ["semantic"],
-    "description": "Represents an item in a list",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li",
+    "description": "The <li> HTML element is used to represent an item in a list. It must be contained in a parent element: an ordered list (<ol>), an unordered list (<ul>), or a menu (<menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/li",
     "aliases": ["list-item"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/link.json
+++ b/packages/editor/elements/html/link.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "link",
     "categories": ["semantic"],
-    "description": "Specifies relationships between the current document and external resources",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link",
+    "description": "The <link> HTML element specifies relationships between the current document and an external resource.\nThis element is most commonly used to link to stylesheets, but is also used to establish site icons (both \"favicon\" style icons and icons for the home screen and apps on mobile devices) among other things.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link",
     "aliases": ["stylesheet-link", "external-resource"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/main.json
+++ b/packages/editor/elements/html/main.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "main",
     "categories": ["semantic"],
-    "description": "Represents the main content of a document",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main",
+    "description": "The <main> HTML element represents the dominant content of the <body> of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/main",
     "aliases": ["main-content"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/map.json
+++ b/packages/editor/elements/html/map.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "map",
     "categories": ["media"],
-    "description": "Defines an image map with clickable areas",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map",
+    "description": "The <map> HTML element is used with <area> elements to define an image map (a clickable link area).",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/map",
     "aliases": ["imagemap"],
     "interfaces": [
       "HTMLMapElement",

--- a/packages/editor/elements/html/mark.json
+++ b/packages/editor/elements/html/mark.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "mark",
     "categories": ["typography"],
-    "description": "Highlights text for reference or relevance",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark",
+    "description": "The <mark> HTML element represents text which is marked or highlighted for reference or notation purposes due to the marked passage's relevance in the enclosing context.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/mark",
     "aliases": ["highlight"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/menu.json
+++ b/packages/editor/elements/html/menu.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "menu",
     "categories": ["semantic"],
-    "description": "Represents a list of commands or menu options",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu",
+    "description": "The <menu> HTML element is described in the HTML specification as a semantic alternative to <ul>, but treated by browsers (and exposed through the accessibility tree) as no different than <ul>. It represents an unordered list of items (which are represented by <li> elements).",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/menu",
     "aliases": ["context-menu", "list-menu"],
     "interfaces": [
       "HTMLMenuElement",

--- a/packages/editor/elements/html/meta.json
+++ b/packages/editor/elements/html/meta.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "meta",
     "categories": ["semantic"],
-    "description": "Provides metadata about the HTML document",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta",
+    "description": "The <meta> HTML element represents metadata that cannot be represented by other meta-related elements, such as <base>, <link>, <script>, <style>, or <title>.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta",
     "aliases": ["metadata"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/meter.json
+++ b/packages/editor/elements/html/meter.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "meter",
     "categories": ["form"],
-    "description": "Displays a scalar measurement within a known range",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter",
+    "description": "The <meter> HTML element represents either a scalar value within a known range or a fractional value.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meter",
     "aliases": ["gauge", "measurement"],
     "interfaces": [
       "HTMLMeterElement",

--- a/packages/editor/elements/html/nav.json
+++ b/packages/editor/elements/html/nav.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "nav",
     "categories": ["semantic"],
-    "description": "Defines navigation links for the site or section",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav",
+    "description": "The <nav> HTML element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/nav",
     "aliases": ["navigation", "menu"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/noscript.json
+++ b/packages/editor/elements/html/noscript.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "noscript",
     "categories": ["semantic"],
-    "description": "Provides alternate content for users without JavaScript",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript",
+    "description": "The <noscript> HTML element defines a section of HTML to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/noscript",
     "aliases": ["no-javascript"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/object.json
+++ b/packages/editor/elements/html/object.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "object",
     "categories": ["media"],
-    "description": "Embeds external resources like images, audio, or plugins",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object",
+    "description": "The <object> HTML element represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/object",
     "aliases": ["embedded-object", "plugin"],
     "interfaces": [
       "HTMLObjectElement",

--- a/packages/editor/elements/html/ol.json
+++ b/packages/editor/elements/html/ol.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "ol",
     "categories": ["semantic"],
-    "description": "Represents an ordered list of items",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol",
+    "description": "The <ol> HTML element represents an ordered list of items — typically rendered as a numbered list.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ol",
     "aliases": ["ordered-list", "numbered-list", "list"],
     "interfaces": [
       "HTMLOListElement",

--- a/packages/editor/elements/html/optgroup.json
+++ b/packages/editor/elements/html/optgroup.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "optgroup",
     "categories": ["form"],
-    "description": "Groups related options in a dropdown list",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup",
+    "description": "The <optgroup> HTML element creates a grouping of options within a <select> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/optgroup",
     "aliases": ["option-group"],
     "interfaces": [
       "HTMLOptGroupElement",

--- a/packages/editor/elements/html/option.json
+++ b/packages/editor/elements/html/option.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "option",
     "categories": ["form"],
-    "description": "Defines an option in a select, datalist, or optgroup",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option",
+    "description": "The <option> HTML element is used to define an item contained in a <select>, an <optgroup>, or a <datalist> element. As such, <option> can represent menu items in popups and other lists of items in an HTML document.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option",
     "aliases": ["select-option"],
     "interfaces": [
       "HTMLOptionElement",

--- a/packages/editor/elements/html/output.json
+++ b/packages/editor/elements/html/output.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "output",
     "categories": ["form"],
-    "description": "Displays the result of a calculation or user action",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output",
+    "description": "The <output> HTML element is a container element into which a site or app can inject the results of a calculation or the outcome of a user action.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/output",
     "aliases": ["calculation-result"],
     "interfaces": [
       "HTMLOutputElement",

--- a/packages/editor/elements/html/p.json
+++ b/packages/editor/elements/html/p.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "p",
     "categories": ["typography"],
-    "description": "Represents a paragraph of text",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p",
+    "description": "The <p> HTML element represents a paragraph. Paragraphs are usually represented in visual media as blocks of text separated from adjacent blocks by blank lines and/or first-line indentation, but HTML paragraphs can be any structural grouping of related content, such as images or form fields.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/p",
     "aliases": ["paragraph", "text-block", "text"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/picture.json
+++ b/packages/editor/elements/html/picture.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "picture",
     "categories": ["media"],
-    "description": "Provides multiple sources for responsive images",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture",
+    "description": "The <picture> HTML element contains zero or more <source> elements and one <img> element to offer alternative versions of an image for different display/device scenarios.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/picture",
     "aliases": ["responsive-image", "image"],
     "interfaces": [
       "HTMLPictureElement",

--- a/packages/editor/elements/html/pre.json
+++ b/packages/editor/elements/html/pre.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "pre",
     "categories": ["typography"],
-    "description": "Displays preformatted text, preserving whitespace and line breaks",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre",
+    "description": "The <pre> HTML element represents preformatted text which is to be presented exactly as written in the HTML file. The text is typically rendered using a non-proportional, or monospaced font.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/pre",
     "aliases": ["preformatted", "code-block"],
     "interfaces": [
       "HTMLPreElement",

--- a/packages/editor/elements/html/progress.json
+++ b/packages/editor/elements/html/progress.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "progress",
     "categories": ["form"],
-    "description": "Shows the progress of a task or operation",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress",
+    "description": "The <progress> HTML element displays an indicator showing the completion progress of a task, typically displayed as a progress bar.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/progress",
     "aliases": ["progress-bar", "loading"],
     "interfaces": [
       "HTMLProgressElement",

--- a/packages/editor/elements/html/q.json
+++ b/packages/editor/elements/html/q.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "q",
     "categories": ["typography"],
-    "description": "Indicates a short inline quotation",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q",
+    "description": "The <q> HTML element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks. This element is intended for short quotations that don't require paragraph breaks; for long quotations use the <blockquote> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/q",
     "aliases": ["inline-quote"],
     "interfaces": [
       "HTMLQuoteElement",

--- a/packages/editor/elements/html/rp.json
+++ b/packages/editor/elements/html/rp.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "rp",
     "categories": ["typography"],
-    "description": "Provides fallback text for browsers that do not support ruby annotations",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp",
+    "description": "The <rp> HTML element is used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the <ruby> element. One <rp> element should enclose each of the opening and closing parentheses that wrap the <rt> element that contains the annotation's text.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rp",
     "aliases": ["ruby-parenthesis"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/rt.json
+++ b/packages/editor/elements/html/rt.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "rt",
     "categories": ["typography"],
-    "description": "Specifies the pronunciation of characters in ruby annotations",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt",
+    "description": "The <rt> HTML element specifies the ruby text component of a ruby annotation, which is used to provide pronunciation, translation, or transliteration information for East Asian typography. The <rt> element must always be contained within a <ruby> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/rt",
     "aliases": ["ruby-text"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/ruby.json
+++ b/packages/editor/elements/html/ruby.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "ruby",
     "categories": ["typography"],
-    "description": "Represents ruby annotation for East Asian typography",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby",
+    "description": "The <ruby> HTML element represents small annotations that are rendered above, below, or next to base text, usually used for showing the pronunciation of East Asian characters. It can also be used for annotating other kinds of text, but this usage is less common.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ruby",
     "aliases": ["ruby-annotation"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/s.json
+++ b/packages/editor/elements/html/s.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "s",
     "categories": ["typography"],
-    "description": "Renders text with a strikethrough, indicating inaccuracy or removal",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s",
+    "description": "The <s> HTML element renders text with a strikethrough, or a line through it. Use the <s> element to represent things that are no longer relevant or no longer accurate. However, <s> is not appropriate when indicating document edits; for that, use the <del> and <ins> elements, as appropriate.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/s",
     "aliases": ["strikethrough", "deleted"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/samp.json
+++ b/packages/editor/elements/html/samp.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "samp",
     "categories": ["typography"],
-    "description": "Represents sample output from a computer program",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp",
+    "description": "The <samp> HTML element is used to enclose inline text which represents sample (or quoted) output from a computer program. Its contents are typically rendered using the browser's default monospaced font (such as Courier or Lucida Console).",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/samp",
     "aliases": ["sample-output"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/script.json
+++ b/packages/editor/elements/html/script.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "script",
     "categories": ["semantic"],
-    "description": "Embeds or references executable JavaScript code",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script",
+    "description": "The <script> HTML element is used to embed executable code or data; this is typically used to embed or refer to JavaScript code. The <script> element can also be used with other languages, such as WebGL's GLSL shader programming language and JSON.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script",
     "aliases": ["javascript", "client-script"],
     "interfaces": [
       "HTMLScriptElement",

--- a/packages/editor/elements/html/search.json
+++ b/packages/editor/elements/html/search.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "search",
     "categories": ["form"],
-    "description": "Represents a search section within a document",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search",
+    "description": "The <search> HTML element is a container representing the parts of the document or application with form controls or other content related to performing a search or filtering operation. The <search> element semantically identifies the purpose of the element's contents as having search or filtering capabilities. The search or filtering functionality can be for the website or application, the current web page or document, or the entire Internet or subsection thereof.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/search",
     "aliases": ["search-region"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/section.json
+++ b/packages/editor/elements/html/section.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "section",
     "categories": ["semantic"],
-    "description": "Defines a standalone section of content",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section",
+    "description": "The <section> HTML element represents a generic standalone section of a document, which doesn't have a more specific semantic element to represent it. Sections should always have a heading, with very few exceptions.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/section",
     "aliases": ["content-section"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/select.json
+++ b/packages/editor/elements/html/select.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "select",
     "categories": ["form"],
-    "description": "Creates a dropdown list for selecting options",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select",
+    "description": "The <select> HTML element represents a control that provides a menu of options.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/select",
     "aliases": ["dropdown", "select-box"],
     "interfaces": [
       "HTMLSelectElement",

--- a/packages/editor/elements/html/small.json
+++ b/packages/editor/elements/html/small.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "small",
     "categories": ["typography"],
-    "description": "Renders text in a smaller font size for side comments or fine print",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small",
+    "description": "The <small> HTML element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/small",
     "aliases": ["fine-print"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/source.json
+++ b/packages/editor/elements/html/source.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "source",
     "categories": ["media"],
-    "description": "Specifies multiple media resources for media elements",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source",
+    "description": "The <source> HTML element specifies one or more media resources for the <picture>, <audio>, and <video> elements. It is a void element, which means that it has no content and does not require a closing tag. This element is commonly used to offer the same media content in multiple file formats in order to provide compatibility with a broad range of browsers given their differing support for image file formats and media file formats.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source",
     "aliases": ["media-source"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/span.json
+++ b/packages/editor/elements/html/span.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "span",
     "categories": ["semantic"],
-    "description": "Generic inline container for text or other elements",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span",
+    "description": "The <span> HTML element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element is appropriate. <span> is very much like a <div> element, but <div> is a block-level element whereas a <span> is an inline-level element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/span",
     "aliases": ["inline-container"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/strong.json
+++ b/packages/editor/elements/html/strong.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "strong",
     "categories": ["typography"],
-    "description": "Indicates strong importance, typically rendered in bold",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong",
+    "description": "The <strong> HTML element indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/strong",
     "aliases": ["bold", "importance"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/style.json
+++ b/packages/editor/elements/html/style.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "style",
     "categories": ["semantic", "svg"],
-    "description": "Embeds CSS styles within the document",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style",
+    "description": "The <style> HTML element contains style information for a document, or part of a document. It contains CSS, which is applied to the contents of the document containing the <style> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style",
     "aliases": ["css", "stylesheet"],
     "interfaces": [
       "HTMLStyleElement",

--- a/packages/editor/elements/html/sub.json
+++ b/packages/editor/elements/html/sub.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "sub",
     "categories": ["typography"],
-    "description": "Renders text as subscript",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub",
+    "description": "The <sub> HTML element specifies inline text which should be displayed as subscript for solely typographical reasons. Subscripts are typically rendered with a lowered baseline using smaller text.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sub",
     "aliases": ["subscript"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/summary.json
+++ b/packages/editor/elements/html/summary.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "summary",
     "categories": ["semantic"],
-    "description": "Provides a summary or heading for a details element",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary",
+    "description": "The <summary> HTML element specifies a summary, caption, or legend for a <details> element's disclosure box. Clicking the <summary> element toggles the state of the parent <details> element open and closed.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/summary",
     "aliases": ["details-summary"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/sup.json
+++ b/packages/editor/elements/html/sup.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "sup",
     "categories": ["typography"],
-    "description": "Renders text as superscript",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup",
+    "description": "The <sup> HTML element specifies inline text which is to be displayed as superscript for solely typographical reasons. Superscripts are usually rendered with a raised baseline using smaller text.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/sup",
     "aliases": ["superscript"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/table.json
+++ b/packages/editor/elements/html/table.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "table",
     "categories": ["semantic"],
-    "description": "Represents tabular data in rows and columns",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table",
+    "description": "The <table> HTML element represents tabular data—that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/table",
     "aliases": ["data-table"],
     "interfaces": [
       "HTMLTableElement",

--- a/packages/editor/elements/html/tbody.json
+++ b/packages/editor/elements/html/tbody.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "tbody",
     "categories": ["semantic"],
-    "description": "Groups the body content in a table",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody",
+    "description": "The <tbody> HTML element encapsulates a set of table rows (<tr> elements), indicating that they comprise the body of a table's (main) data.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tbody",
     "aliases": ["table-body"],
     "interfaces": [
       "HTMLTableSectionElement",

--- a/packages/editor/elements/html/td.json
+++ b/packages/editor/elements/html/td.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "td",
     "categories": ["semantic"],
-    "description": "Defines a cell in a table row",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td",
+    "description": "The <td> HTML element defines a cell of a table that contains data and may be used as a child of the <tr> element.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/td",
     "aliases": ["table-cell"],
     "interfaces": [
       "HTMLTableCellElement",

--- a/packages/editor/elements/html/template.json
+++ b/packages/editor/elements/html/template.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "template",
     "categories": ["semantic"],
-    "description": "Holds client-side content that is not rendered when the page loads",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template",
+    "description": "The <template> HTML element serves as a mechanism for holding HTML fragments, which can either be used later via JavaScript or generated immediately into shadow DOM.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template",
     "aliases": ["html-template"],
     "interfaces": [
       "HTMLTemplateElement",

--- a/packages/editor/elements/html/textarea.json
+++ b/packages/editor/elements/html/textarea.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "textarea",
     "categories": ["form"],
-    "description": "Allows multi-line text input in a form",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea",
+    "description": "The <textarea> HTML element represents a multi-line plain-text editing control, useful when you want to allow users to enter a sizeable amount of free-form text, for example a comment on a review or feedback form.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/textarea",
     "aliases": ["multiline-input"],
     "interfaces": [
       "HTMLTextAreaElement",

--- a/packages/editor/elements/html/tfoot.json
+++ b/packages/editor/elements/html/tfoot.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "tfoot",
     "categories": ["semantic"],
-    "description": "Groups the footer content in a table",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot",
+    "description": "The <tfoot> HTML element encapsulates a set of table rows (<tr> elements), indicating that they comprise the foot of a table with information about the table's columns. This is usually a summary of the columns, e.g., a sum of the given numbers in a column.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tfoot",
     "aliases": ["table-footer"],
     "interfaces": [
       "HTMLTableSectionElement",

--- a/packages/editor/elements/html/th.json
+++ b/packages/editor/elements/html/th.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "th",
     "categories": ["semantic"],
-    "description": "Defines a header cell in a table",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th",
+    "description": "The <th> HTML element defines a cell as the header of a group of table cells and may be used as a child of the <tr> element. The exact nature of this group is defined by the scope and headers attributes.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/th",
     "aliases": ["table-header-cell"],
     "interfaces": [
       "HTMLTableCellElement",

--- a/packages/editor/elements/html/thead.json
+++ b/packages/editor/elements/html/thead.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "thead",
     "categories": ["semantic"],
-    "description": "Groups the header content in a table",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead",
+    "description": "The <thead> HTML element encapsulates a set of table rows (<tr> elements), indicating that they comprise the head of a table with information about the table's columns. This is usually in the form of column headers (<th> elements).",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/thead",
     "aliases": ["table-header"],
     "interfaces": [
       "HTMLTableSectionElement",

--- a/packages/editor/elements/html/time.json
+++ b/packages/editor/elements/html/time.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "time",
     "categories": ["semantic"],
-    "description": "Represents a specific time or date",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time",
+    "description": "The <time> HTML element represents a specific period in time. It may include the datetime attribute to translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time",
     "aliases": ["datetime", "timestamp"],
     "interfaces": [
       "HTMLTimeElement",

--- a/packages/editor/elements/html/tr.json
+++ b/packages/editor/elements/html/tr.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "tr",
     "categories": ["semantic"],
-    "description": "Defines a row in a table",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr",
+    "description": "The <tr> HTML element defines a row of cells in a table. The row's cells can then be established using a mix of <td> (data cell) and <th> (header cell) elements.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/tr",
     "aliases": ["table-row"],
     "interfaces": [
       "HTMLTableRowElement",

--- a/packages/editor/elements/html/track.json
+++ b/packages/editor/elements/html/track.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "track",
     "categories": ["media"],
-    "description": "Provides text tracks for media elements like video or audio",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track",
+    "description": "The <track> HTML element is used as a child of the media elements, <audio> and <video>.\nEach track element lets you specify a timed text track (or time-based data) that can be displayed in parallel with the media element, for example to overlay subtitles or closed captions on top of a video or alongside audio tracks.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/track",
     "aliases": ["media-track", "subtitles"],
     "isVoid": true,
     "interfaces": [

--- a/packages/editor/elements/html/u.json
+++ b/packages/editor/elements/html/u.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "u",
     "categories": ["typography"],
-    "description": "Renders text with an underline",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u",
+    "description": "The <u> HTML element represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation. This is rendered by default as a single solid underline, but may be altered using CSS.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/u",
     "aliases": ["underline"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/ul.json
+++ b/packages/editor/elements/html/ul.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "ul",
     "categories": ["semantic"],
-    "description": "Represents an unordered list of items",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul",
+    "description": "The <ul> HTML element represents an unordered list of items, typically rendered as a bulleted list.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/ul",
     "aliases": ["unordered-list", "bulleted-list", "list"],
     "isPopular": true,
     "interfaces": [

--- a/packages/editor/elements/html/var.json
+++ b/packages/editor/elements/html/var.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "var",
     "categories": ["typography"],
-    "description": "Represents a variable in a mathematical expression or programming context",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var",
+    "description": "The <var> HTML element represents the name of a variable in a mathematical expression or a programming context. It's typically presented using an italicized version of the current typeface, although that behavior is browser-dependent.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/var",
     "aliases": ["variable"],
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]
   },

--- a/packages/editor/elements/html/video.json
+++ b/packages/editor/elements/html/video.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "video",
     "categories": ["media"],
-    "description": "Embeds a video player for video playback",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video",
+    "description": "The <video> HTML element embeds a media player which supports video playback into the document. You can use <video> for audio content as well, but the <audio> element may provide a more appropriate user experience.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video",
     "aliases": ["movie", "media", "film"],
     "interfaces": [
       "HTMLVideoElement",

--- a/packages/editor/elements/html/wbr.json
+++ b/packages/editor/elements/html/wbr.json
@@ -2,8 +2,8 @@
   "metadata": {
     "name": "wbr",
     "categories": ["typography"],
-    "description": "Suggests a line break opportunity within text",
-    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr",
+    "description": "The <wbr> HTML element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location.",
+    "link": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/wbr",
     "aliases": ["word-break"],
     "isVoid": true,
     "interfaces": ["HTMLElement", "Element", "Node", "EventTarget", "global"]

--- a/packages/editor/elements/svg/animate.json
+++ b/packages/editor/elements/svg/animate.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "animate",
     "categories": ["svg"],
-    "description": "Animates an attribute of an SVG element over time",
+    "description": "The <animate> SVG element provides a way to animate an attribute of an element over time.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animate",
     "aliases": ["animation", "svg-animate"],
     "interfaces": [

--- a/packages/editor/elements/svg/animateMotion.json
+++ b/packages/editor/elements/svg/animateMotion.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "animateMotion",
     "categories": ["svg"],
-    "description": "Animates an element along a motion path",
+    "description": "The <animateMotion> SVG element provides a way to define how an element moves along a motion path.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateMotion",
     "aliases": ["motion-animation", "svg-motion"],
     "interfaces": [

--- a/packages/editor/elements/svg/animateTransform.json
+++ b/packages/editor/elements/svg/animateTransform.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "animateTransform",
     "categories": ["svg"],
-    "description": "Animates transformations such as scale, rotate, or translate on an element",
+    "description": "The <animateTransform> SVG element animates a transformation attribute on its target element, thereby allowing animations to control translation, scaling, rotation, and/or skewing.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/animateTransform",
     "aliases": ["transform-animation", "svg-transform"],
     "interfaces": [

--- a/packages/editor/elements/svg/circle.json
+++ b/packages/editor/elements/svg/circle.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "circle",
     "categories": ["svg"],
-    "description": "Draws a circle based on a center point and radius",
+    "description": "The <circle> SVG element is an SVG basic shape, used to draw circles based on a center point and a radius.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/circle",
     "aliases": ["ellipse", "svg-circle", "round"],
     "interfaces": [

--- a/packages/editor/elements/svg/clipPath.json
+++ b/packages/editor/elements/svg/clipPath.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "clipPath",
     "categories": ["svg"],
-    "description": "Defines a clipping path to restrict the visible region of elements",
+    "description": "The <clipPath> SVG element defines a clipping path, to be used by the clip-path property.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/clipPath",
     "aliases": ["clipping", "svg-clip", "masking"],
     "interfaces": [

--- a/packages/editor/elements/svg/defs.json
+++ b/packages/editor/elements/svg/defs.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "defs",
     "categories": ["svg"],
-    "description": "Container for elements that can be referenced later, such as gradients or filters",
+    "description": "The <defs> SVG element is used to store graphical objects that will be used at a later time. Objects created inside a <defs> element are not rendered directly. To display them you have to reference them (with a <use> element for example).",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/defs",
     "aliases": ["definitions", "svg-defs"],
     "interfaces": [

--- a/packages/editor/elements/svg/desc.json
+++ b/packages/editor/elements/svg/desc.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "desc",
     "categories": ["svg"],
-    "description": "Provides a description of the SVG content for accessibility",
+    "description": "The <desc> SVG element provides an accessible, long-text description of any SVG container element or graphics element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/desc",
     "aliases": ["description", "svg-desc"],
     "interfaces": [

--- a/packages/editor/elements/svg/ellipse.json
+++ b/packages/editor/elements/svg/ellipse.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "ellipse",
     "categories": ["svg"],
-    "description": "Draws an ellipse based on a center point and radii",
+    "description": "The <ellipse> SVG element is an SVG basic shape, used to create ellipses based on a center coordinate, and both their x and y radius.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/ellipse",
     "aliases": ["oval", "svg-ellipse"],
     "interfaces": [

--- a/packages/editor/elements/svg/feBlend.json
+++ b/packages/editor/elements/svg/feBlend.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feBlend",
     "categories": ["svg"],
-    "description": "Blends two images together using a specified blending mode",
+    "description": "The <feBlend> SVG filter primitive composes two objects together ruled by a certain blending mode. This is similar to what is known from image editing software when blending two layers. The mode is defined by the mode attribute.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feBlend",
     "aliases": ["blend-filter", "svg-blend"],
     "interfaces": [

--- a/packages/editor/elements/svg/feColorMatrix.json
+++ b/packages/editor/elements/svg/feColorMatrix.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feColorMatrix",
     "categories": ["svg"],
-    "description": "Applies a matrix transformation to the colors of the input image, enabling effects like grayscale or sepia",
+    "description": "The <feColorMatrix> SVG filter element changes colors based on a transformation matrix. Every pixel's color value [R,G,B,A] is matrix multiplied by a 5 by 5 color matrix to create new color [R',G',B',A'].",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feColorMatrix",
     "aliases": ["color-matrix", "svg-color"],
     "interfaces": [

--- a/packages/editor/elements/svg/feComponentTransfer.json
+++ b/packages/editor/elements/svg/feComponentTransfer.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feComponentTransfer",
     "categories": ["svg"],
-    "description": "Allows per-channel color manipulation using component transfer functions",
+    "description": "The <feComponentTransfer> SVG filter primitive performs color-component-wise remapping of data for each pixel. It allows operations like brightness adjustment, contrast adjustment, color balance or thresholding.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feComponentTransfer",
     "aliases": ["component-transfer", "svg-component"],
     "interfaces": [

--- a/packages/editor/elements/svg/feComposite.json
+++ b/packages/editor/elements/svg/feComposite.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feComposite",
     "categories": ["svg"],
-    "description": "Combines images using arithmetic or compositing operations",
+    "description": "The <feComposite> SVG filter primitive performs the combination of two input images pixel-wise in image space using one of the Porter-Duff compositing operations: over, in, atop, out, xor, lighter, or arithmetic.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feComposite",
     "aliases": ["composite-filter", "svg-composite"],
     "interfaces": [

--- a/packages/editor/elements/svg/feConvolveMatrix.json
+++ b/packages/editor/elements/svg/feConvolveMatrix.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feConvolveMatrix",
     "categories": ["svg"],
-    "description": "Applies a matrix convolution filter for effects like edge detection or blurring",
+    "description": "The <feConvolveMatrix> SVG filter primitive applies a matrix convolution filter effect. A convolution combines pixels in the input image with neighboring pixels to produce a resulting image. A wide variety of imaging operations can be achieved through convolutions, including blurring, edge detection, sharpening, embossing and beveling.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feConvolveMatrix",
     "aliases": ["convolve-matrix", "svg-convolve"],
     "interfaces": [

--- a/packages/editor/elements/svg/feDiffuseLighting.json
+++ b/packages/editor/elements/svg/feDiffuseLighting.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feDiffuseLighting",
     "categories": ["svg"],
-    "description": "Simulates diffuse lighting on an image for a 3D effect",
+    "description": "The <feDiffuseLighting> SVG filter primitive lights an image using the alpha channel as a bump map. The resulting image, which is an RGBA opaque image, depends on the light color, light position and surface geometry of the input bump map.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDiffuseLighting",
     "aliases": ["diffuse-light", "svg-lighting"],
     "interfaces": [

--- a/packages/editor/elements/svg/feDisplacementMap.json
+++ b/packages/editor/elements/svg/feDisplacementMap.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feDisplacementMap",
     "categories": ["svg"],
-    "description": "Distorts an image using another image as a displacement map",
+    "description": "The <feDisplacementMap> SVG filter primitive uses the pixel values from the image from in2 to spatially displace the image from in.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDisplacementMap",
     "aliases": ["displacement-map", "svg-displacement"],
     "interfaces": [

--- a/packages/editor/elements/svg/feDistantLight.json
+++ b/packages/editor/elements/svg/feDistantLight.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feDistantLight",
     "categories": ["svg"],
-    "description": "Defines a distant light source for lighting effects",
+    "description": "The <feDistantLight> SVG element defines a distant light source that can be used within a lighting filter primitive: <feDiffuseLighting> or <feSpecularLighting>.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDistantLight",
     "aliases": ["distant-light", "svg-light"],
     "interfaces": [

--- a/packages/editor/elements/svg/feDropShadow.json
+++ b/packages/editor/elements/svg/feDropShadow.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feDropShadow",
     "categories": ["svg"],
-    "description": "Applies a drop shadow effect to the input image, allowing control over color, blur, and offset",
+    "description": "The <feDropShadow> SVG filter primitive creates a drop shadow of the input image. It can only be used inside a <filter> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feDropShadow",
     "aliases": ["drop-shadow", "svg-shadow"],
     "interfaces": [

--- a/packages/editor/elements/svg/feFlood.json
+++ b/packages/editor/elements/svg/feFlood.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feFlood",
     "categories": ["svg"],
-    "description": "Fills the filter region with a solid color",
+    "description": "The <feFlood> SVG filter primitive fills the filter subregion with the color and opacity defined by flood-color and flood-opacity.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFlood",
     "aliases": ["flood-filter", "svg-flood"],
     "interfaces": [

--- a/packages/editor/elements/svg/feFuncA.json
+++ b/packages/editor/elements/svg/feFuncA.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feFuncA",
     "categories": ["svg"],
-    "description": "Defines the transfer function for the alpha (opacity) channel in feComponentTransfer",
+    "description": "The <feFuncA> SVG filter primitive defines the transfer function for the alpha component of the input graphic of its parent <feComponentTransfer> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncA",
     "aliases": ["function-a", "svg-func-a"],
     "interfaces": [

--- a/packages/editor/elements/svg/feFuncB.json
+++ b/packages/editor/elements/svg/feFuncB.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feFuncB",
     "categories": ["svg"],
-    "description": "Defines the transfer function for the blue channel in feComponentTransfer",
+    "description": "The <feFuncB> SVG filter primitive defines the transfer function for the blue component of the input graphic of its parent <feComponentTransfer> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncB",
     "aliases": ["function-b", "svg-func-b"],
     "interfaces": [

--- a/packages/editor/elements/svg/feFuncG.json
+++ b/packages/editor/elements/svg/feFuncG.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feFuncG",
     "categories": ["svg"],
-    "description": "Defines the transfer function for the green channel in feComponentTransfer",
+    "description": "The <feFuncG> SVG filter primitive defines the transfer function for the green component of the input graphic of its parent <feComponentTransfer> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncG",
     "aliases": ["function-g", "svg-func-g"],
     "interfaces": [

--- a/packages/editor/elements/svg/feFuncR.json
+++ b/packages/editor/elements/svg/feFuncR.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feFuncR",
     "categories": ["svg"],
-    "description": "Defines the transfer function for the red channel in feComponentTransfer",
+    "description": "The <feFuncR> SVG filter primitive defines the transfer function for the red component of the input graphic of its parent <feComponentTransfer> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feFuncR",
     "aliases": ["function-r", "svg-func-r"],
     "interfaces": [

--- a/packages/editor/elements/svg/feGaussianBlur.json
+++ b/packages/editor/elements/svg/feGaussianBlur.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feGaussianBlur",
     "categories": ["svg"],
-    "description": "Applies a Gaussian blur effect to the input image",
+    "description": "The <feGaussianBlur> SVG filter primitive blurs the input image by the amount specified in stdDeviation, which defines the bell-curve.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feGaussianBlur",
     "aliases": ["gaussian-blur", "svg-blur"],
     "interfaces": [

--- a/packages/editor/elements/svg/feImage.json
+++ b/packages/editor/elements/svg/feImage.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feImage",
     "categories": ["svg"],
-    "description": "Uses an external image as input for a filter effect",
+    "description": "The <feImage> SVG filter primitive fetches image data from an external source and provides the pixel data as output (meaning if the external source is an SVG image, it is rasterized.)",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feImage",
     "aliases": ["image-filter", "svg-image"],
     "interfaces": [

--- a/packages/editor/elements/svg/feMerge.json
+++ b/packages/editor/elements/svg/feMerge.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feMerge",
     "categories": ["svg"],
-    "description": "Combines multiple filter effects into a single output",
+    "description": "The <feMerge> SVG element allows filter effects to be applied concurrently instead of sequentially. This is achieved by other filters storing their output via the result attribute and then accessing it in a <feMergeNode> child.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMerge",
     "aliases": ["merge-filter", "svg-merge"],
     "interfaces": [

--- a/packages/editor/elements/svg/feMergeNode.json
+++ b/packages/editor/elements/svg/feMergeNode.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feMergeNode",
     "categories": ["svg"],
-    "description": "Specifies an input image to be merged in a feMerge filter",
+    "description": "The <feMergeNode> SVG takes the result of another filter to be processed by its parent <feMerge>.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMergeNode",
     "aliases": ["merge-node", "svg-merge-node"],
     "interfaces": [

--- a/packages/editor/elements/svg/feMorphology.json
+++ b/packages/editor/elements/svg/feMorphology.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feMorphology",
     "categories": ["svg"],
-    "description": "Applies erosion or dilation to the input image",
+    "description": "The <feMorphology> SVG filter primitive is used to erode or dilate the input image. Its usefulness lies especially in fattening or thinning effects.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feMorphology",
     "aliases": ["morphology-filter", "svg-morphology"],
     "interfaces": [

--- a/packages/editor/elements/svg/feOffset.json
+++ b/packages/editor/elements/svg/feOffset.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feOffset",
     "categories": ["svg"],
-    "description": "Offsets the input image by a specified amount",
+    "description": "The <feOffset> SVG filter primitive enables offsetting an input image relative to its current position. The input image as a whole is offset by the values specified in the dx and dy attributes.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feOffset",
     "aliases": ["offset-filter", "svg-offset"],
     "interfaces": [

--- a/packages/editor/elements/svg/fePointLight.json
+++ b/packages/editor/elements/svg/fePointLight.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "fePointLight",
     "categories": ["svg"],
-    "description": "Defines a point light source for lighting effects",
+    "description": "The <fePointLight> SVG element defines a light source which allows to create a point light effect. It can be used within a lighting filter primitive: <feDiffuseLighting> or <feSpecularLighting>.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/fePointLight",
     "aliases": ["point-light", "svg-point"],
     "interfaces": [

--- a/packages/editor/elements/svg/feSpecularLighting.json
+++ b/packages/editor/elements/svg/feSpecularLighting.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feSpecularLighting",
     "categories": ["svg"],
-    "description": "Simulates specular lighting on an image for shiny highlights",
+    "description": "The <feSpecularLighting> SVG filter primitive lights a source graphic using the alpha channel as a bump map. The resulting image is an RGBA image based on the light color. The lighting calculation follows the standard specular component of the Phong lighting model. The resulting image depends on the light color, light position and surface geometry of the input bump map. The result of the lighting calculation is added. The filter primitive assumes that the viewer is at infinity in the z direction.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feSpecularLighting",
     "aliases": ["specular-light", "svg-specular"],
     "interfaces": [

--- a/packages/editor/elements/svg/feSpotLight.json
+++ b/packages/editor/elements/svg/feSpotLight.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feSpotLight",
     "categories": ["svg"],
-    "description": "Defines a spotlight source for lighting effects",
+    "description": "The <feSpotLight> SVG element defines a light source that can be used to create a spotlight effect.\nIt is used within a lighting filter primitive: <feDiffuseLighting> or <feSpecularLighting>.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feSpotLight",
     "aliases": ["spot-light", "svg-spot"],
     "interfaces": [

--- a/packages/editor/elements/svg/feTile.json
+++ b/packages/editor/elements/svg/feTile.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feTile",
     "categories": ["svg"],
-    "description": "Repeats the input image to fill the filter region",
+    "description": "The <feTile> SVG filter primitive allows to fill a target rectangle with a repeated, tiled pattern of an input image. The effect is similar to the one of a <pattern>.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feTile",
     "aliases": ["tile-filter", "svg-tile"],
     "interfaces": [

--- a/packages/editor/elements/svg/feTurbulence.json
+++ b/packages/editor/elements/svg/feTurbulence.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "feTurbulence",
     "categories": ["svg"],
-    "description": "Generates a noise or turbulence pattern for texture effects",
+    "description": "The <feTurbulence> SVG filter primitive creates an image using the Perlin turbulence function. It allows the synthesis of artificial textures like clouds or marble. The resulting image will fill the entire filter primitive subregion.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/feTurbulence",
     "aliases": ["turbulence-filter", "svg-turbulence"],
     "interfaces": [

--- a/packages/editor/elements/svg/filter.json
+++ b/packages/editor/elements/svg/filter.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "filter",
     "categories": ["svg"],
-    "description": "Defines graphical effects like blurring or color shifting to be applied to elements",
+    "description": "The <filter> SVG element defines a custom filter effect by grouping atomic filter primitives. It is never rendered itself, but must be used by the filter attribute on SVG elements, or the filter CSS property for SVG/HTML elements.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/filter",
     "aliases": ["svg-filter", "effect"],
     "interfaces": [

--- a/packages/editor/elements/svg/foreignObject.json
+++ b/packages/editor/elements/svg/foreignObject.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "foreignObject",
     "categories": ["svg"],
-    "description": "Allows inclusion of non-SVG content, such as HTML, within an SVG",
+    "description": "The <foreignObject> SVG element includes elements from a different XML namespace. In the context of a browser, it is most likely (X)HTML.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/foreignObject",
     "aliases": ["foreign-object", "svg-foreign"],
     "interfaces": [

--- a/packages/editor/elements/svg/g.json
+++ b/packages/editor/elements/svg/g.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "g",
     "categories": ["svg"],
-    "description": "Groups SVG shapes together so they can be transformed or styled as a unit",
+    "description": "The <g> SVG element is a container used to group other SVG elements.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/g",
     "aliases": ["group", "svg-group"],
     "interfaces": [

--- a/packages/editor/elements/svg/image.json
+++ b/packages/editor/elements/svg/image.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "image",
     "categories": ["svg"],
-    "description": "Embeds an external image within the SVG",
+    "description": "The <image> SVG element includes images inside SVG documents. It can display raster image files or other SVG files.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/image",
     "aliases": ["svg-image", "bitmap"],
     "interfaces": [

--- a/packages/editor/elements/svg/line.json
+++ b/packages/editor/elements/svg/line.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "line",
     "categories": ["svg"],
-    "description": "Draws a straight line between two points",
+    "description": "The <line> SVG element is an SVG basic shape used to create a line connecting two points.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/line",
     "aliases": ["svg-line", "segment"],
     "isPopular": true,

--- a/packages/editor/elements/svg/linearGradient.json
+++ b/packages/editor/elements/svg/linearGradient.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "linearGradient",
     "categories": ["svg"],
-    "description": "Defines a linear color gradient for filling shapes",
+    "description": "The <linearGradient> SVG element lets authors define linear gradients to apply to other SVG elements.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/linearGradient",
     "aliases": ["linear-gradient", "svg-gradient", "gradient"],
     "interfaces": [

--- a/packages/editor/elements/svg/marker.json
+++ b/packages/editor/elements/svg/marker.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "marker",
     "categories": ["svg"],
-    "description": "Defines shapes to be drawn at the start, middle, or end of lines or paths",
+    "description": "The <marker> SVG element defines a graphic used for drawing arrowheads or polymarkers on a given <path>, <line>, <polyline> or <polygon> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/marker",
     "aliases": ["svg-marker", "arrowhead"],
     "interfaces": [

--- a/packages/editor/elements/svg/mask.json
+++ b/packages/editor/elements/svg/mask.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "mask",
     "categories": ["svg"],
-    "description": "Defines a mask to control the visibility of parts of an element",
+    "description": "The <mask> SVG element defines a mask for compositing the current object into the background. A mask is used/referenced using the mask property and CSS mask-image property.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mask",
     "aliases": ["svg-mask", "masking"],
     "interfaces": [

--- a/packages/editor/elements/svg/metadata.json
+++ b/packages/editor/elements/svg/metadata.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "metadata",
     "categories": ["svg"],
-    "description": "Embeds metadata within the SVG, such as licensing or author information",
+    "description": "The <metadata> SVG element adds metadata to SVG content. Metadata is structured information about data. The contents of <metadata> should be elements from other XML namespaces such as RDF, FOAF, etc.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/metadata",
     "aliases": ["svg-metadata", "meta"],
     "interfaces": [

--- a/packages/editor/elements/svg/mpath.json
+++ b/packages/editor/elements/svg/mpath.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "mpath",
     "categories": ["svg"],
-    "description": "Defines a motion path for animateMotion",
+    "description": "The <mpath> SVG sub-element for the <animateMotion> element provides the ability to reference an external <path> element as the definition of a motion path.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mpath",
     "aliases": ["motion-path", "svg-mpath"],
     "interfaces": [

--- a/packages/editor/elements/svg/path.json
+++ b/packages/editor/elements/svg/path.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "path",
     "categories": ["svg"],
-    "description": "Draws complex shapes using a series of commands and coordinates",
+    "description": "The <path> SVG element is the generic element to define a shape. All the basic shapes can be created with a path element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/path",
     "aliases": ["svg-path", "bezier"],
     "isPopular": true,

--- a/packages/editor/elements/svg/pattern.json
+++ b/packages/editor/elements/svg/pattern.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "pattern",
     "categories": ["svg"],
-    "description": "Defines a repeating graphic pattern for filling shapes",
+    "description": "The <pattern> SVG element defines a graphics object which can be redrawn at repeated x- and y-coordinate intervals (\"tiled\") to cover an area.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/pattern",
     "aliases": ["svg-pattern", "fill-pattern"],
     "interfaces": [

--- a/packages/editor/elements/svg/polygon.json
+++ b/packages/editor/elements/svg/polygon.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "polygon",
     "categories": ["svg"],
-    "description": "Draws a closed shape defined by a series of points",
+    "description": "The <polygon> SVG element defines a closed shape consisting of a set of connected straight line segments. The last point is connected to the first point.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/polygon",
     "aliases": ["svg-polygon", "shape"],
     "interfaces": [

--- a/packages/editor/elements/svg/polyline.json
+++ b/packages/editor/elements/svg/polyline.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "polyline",
     "categories": ["svg"],
-    "description": "Draws a series of connected straight lines",
+    "description": "The <polyline> SVG element is an SVG basic shape that creates straight lines connecting several points. Typically a polyline is used to create open shapes as the last point doesn't have to be connected to the first point. For closed shapes see the <polygon> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/polyline",
     "aliases": ["svg-polyline", "line-sequence"],
     "interfaces": [

--- a/packages/editor/elements/svg/radialGradient.json
+++ b/packages/editor/elements/svg/radialGradient.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "radialGradient",
     "categories": ["svg"],
-    "description": "Defines a radial color gradient for filling shapes",
+    "description": "The <radialGradient> SVG element lets authors define radial gradients that can be applied to fill or stroke of graphical elements.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/radialGradient",
     "aliases": ["radial-gradient", "svg-gradient", "gradient"],
     "interfaces": [

--- a/packages/editor/elements/svg/rect.json
+++ b/packages/editor/elements/svg/rect.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "rect",
     "categories": ["svg"],
-    "description": "Draws a rectangle, optionally with rounded corners",
+    "description": "The <rect> SVG element is a basic SVG shape that draws rectangles, defined by their position, width, and height. The rectangles may have their corners rounded.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/rect",
     "aliases": ["rectangle", "svg-rect", "box"],
     "isPopular": true,

--- a/packages/editor/elements/svg/script.json
+++ b/packages/editor/elements/svg/script.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "script",
     "categories": ["svg"],
-    "description": "Embeds or references scripting code, such as JavaScript",
+    "description": "The <script> SVG element allows to add scripts to an SVG document.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/script",
     "aliases": ["svg-script", "js"],
     "interfaces": [

--- a/packages/editor/elements/svg/set.json
+++ b/packages/editor/elements/svg/set.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "set",
     "categories": ["svg"],
-    "description": "Sets an attribute to a value for a specified duration",
+    "description": "The <set> SVG element provides a method of setting the value of an attribute for a specified duration.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/set",
     "aliases": ["svg-set", "attribute-set"],
     "interfaces": [

--- a/packages/editor/elements/svg/stop.json
+++ b/packages/editor/elements/svg/stop.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "stop",
     "categories": ["svg"],
-    "description": "Specifies a color and position in a gradient",
+    "description": "The <stop> SVG element defines a color and its position to use on a gradient. This element is always a child of a <linearGradient> or <radialGradient> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/stop",
     "aliases": ["gradient-stop", "svg-stop", "gradient"],
     "interfaces": [

--- a/packages/editor/elements/svg/svg.json
+++ b/packages/editor/elements/svg/svg.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "svg",
     "categories": ["semantic", "svg"],
-    "description": "Container element for SVG graphics, defining the coordinate system and viewport",
+    "description": "The <svg> SVG element is a container that defines a new coordinate system and viewport. It is used as the outermost element of SVG documents, but it can also be used to embed an SVG fragment inside an SVG or HTML document.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg",
     "aliases": ["vector", "graphic", "svg-root"],
     "isPopular": true,

--- a/packages/editor/elements/svg/switch.json
+++ b/packages/editor/elements/svg/switch.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "switch",
     "categories": ["svg"],
-    "description": "Renders the first child element that matches certain conditions",
+    "description": "The <switch> SVG element evaluates any requiredFeatures, requiredExtensions and systemLanguage attributes on its direct child elements in order, and then renders the first child where these attributes evaluate to true.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/switch",
     "aliases": ["svg-switch", "conditional"],
     "interfaces": [

--- a/packages/editor/elements/svg/symbol.json
+++ b/packages/editor/elements/svg/symbol.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "symbol",
     "categories": ["svg"],
-    "description": "Defines reusable graphical objects that are not rendered directly",
+    "description": "The <symbol> SVG element is used to define graphical template objects which can be instantiated by a <use> element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/symbol",
     "aliases": ["svg-symbol", "icon"],
     "interfaces": [

--- a/packages/editor/elements/svg/text.json
+++ b/packages/editor/elements/svg/text.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "text",
     "categories": ["svg"],
-    "description": "Renders text within the SVG canvas",
+    "description": "The <text> SVG element draws a graphics element consisting of text. It's possible to apply a gradient, pattern, clipping path, mask, or filter to <text>, like any other SVG graphics element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/text",
     "aliases": ["svg-text", "label"],
     "interfaces": [

--- a/packages/editor/elements/svg/textPath.json
+++ b/packages/editor/elements/svg/textPath.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "textPath",
     "categories": ["svg"],
-    "description": "Renders text along the shape of a path",
+    "description": "The <textPath> SVG element is used to render text along the shape of a <path> element.\nThe text must be enclosed in the <textPath> element and its href attribute is used to reference the desired <path>.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/textPath",
     "aliases": ["text-path", "svg-textpath"],
     "interfaces": [

--- a/packages/editor/elements/svg/title.json
+++ b/packages/editor/elements/svg/title.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "title",
     "categories": ["svg"],
-    "description": "Provides a title for the SVG content, often shown as a tooltip",
+    "description": "The <title> SVG element provides an accessible, short-text description of any SVG container element or graphics element.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/title",
     "aliases": ["svg-title", "caption"],
     "interfaces": [

--- a/packages/editor/elements/svg/tspan.json
+++ b/packages/editor/elements/svg/tspan.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "tspan",
     "categories": ["svg"],
-    "description": "Allows for styling or positioning parts of text within a text element",
+    "description": "The <tspan> SVG element defines a subtext within a <text> element or another <tspan> element. It allows for adjustment of the style and/or position of that subtext as needed.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/tspan",
     "aliases": ["text-span", "svg-tspan"],
     "interfaces": [

--- a/packages/editor/elements/svg/use.json
+++ b/packages/editor/elements/svg/use.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "use",
     "categories": ["svg"],
-    "description": "References and reuses an existing SVG element defined elsewhere",
+    "description": "The <use> element takes nodes from within an SVG document, and duplicates them somewhere else.\nThe effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the <use> element is, much like cloned <template> elements.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/use",
     "aliases": ["svg-use", "reference"],
     "interfaces": [

--- a/packages/editor/elements/svg/view.json
+++ b/packages/editor/elements/svg/view.json
@@ -2,7 +2,7 @@
   "metadata": {
     "name": "view",
     "categories": ["svg"],
-    "description": "Defines a view for the SVG, specifying a viewport and transformation",
+    "description": "The <view> SVG element defines a particular view of an SVG document. A specific view can be displayed by referencing the <view> element's id as the target fragment of a URL.",
     "link": "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/view",
     "aliases": ["svg-view", "viewport"],
     "interfaces": [

--- a/packages/editor/elements/utils.ts
+++ b/packages/editor/elements/utils.ts
@@ -153,6 +153,8 @@ export const initMdnMetadata = async () => {
         'svg-attribute',
         'web-api-instance-property',
         'web-api-event',
+        'html-element',
+        'svg-element',
       ].includes(entry.pageType) &&
       entry.summary.includes('read-only property') === false,
   )
@@ -212,6 +214,45 @@ export const getEventInfo = ({
       entry.pageType === 'web-api-event' &&
       entry.mdn_url ===
         `/en-US/docs/Web/API/${interfaceName}/${eventName}_event`,
+  )
+  return entry
+}
+
+export const getHtmlElementInfo = ({
+  elementName,
+}: {
+  elementName: string
+}) => {
+  if (mdnMetadata === undefined) {
+    throw new Error('MDN metadata not initialized')
+  }
+  const elementNameMap: Record<string, string> = {
+    h1: 'Heading_Elements',
+    h2: 'Heading_Elements',
+    h3: 'Heading_Elements',
+    h4: 'Heading_Elements',
+    h5: 'Heading_Elements',
+    h6: 'Heading_Elements',
+  }
+  const entry = mdnMetadata.find(
+    (entry) =>
+      entry.pageType === 'html-element' &&
+      entry.mdn_url ===
+        `/en-US/docs/Web/HTML/Reference/Elements/${elementNameMap[elementName] ?? elementName}`,
+  )
+  return entry
+}
+
+export const getSvgElementInfo = ({ elementName }: { elementName: string }) => {
+  if (mdnMetadata === undefined) {
+    throw new Error('MDN metadata not initialized')
+  }
+  const elementNameMap: Record<string, string> = {}
+  const entry = mdnMetadata.find(
+    (entry) =>
+      entry.pageType === 'svg-element' &&
+      entry.mdn_url ===
+        `/en-US/docs/Web/SVG/Reference/Element/${elementNameMap[elementName] ?? elementName}`,
   )
   return entry
 }


### PR DESCRIPTION
Rather than using our AI generated element descriptions, we should use the descriptions from MDN, which are more accurate and reliable. These descriptions will be used in the element catalog in the editor.