### PR TITLE
ID formula SSR count stability

### DIFF
--- a/packages/lib/formulas/Id/handler.test.ts
+++ b/packages/lib/formulas/Id/handler.test.ts
@@ -4,11 +4,47 @@ import handler from './handler'
 ;(globalThis as any).toddle = { isEqual }
 
 describe('Formula: Id', () => {
-  test('Should generate a unique number', () => {
-    const ref = handler([], undefined as any)
-    const res = handler([], undefined as any)
+  // This test should run first as there is no way to reset the client side counter at the moment.
+  test('Should generate the same id for client and server when called once', () => {
+    const serverCtx = { env: { isServer: true, request: {} } } as any
+    const clientCtx = { env: { isServer: false, request: {} } } as any
+
+    const serverId = handler([], serverCtx)
+    const clientId = handler([], clientCtx)
+
+    expect(serverId).toBe(clientId)
+  })
+
+  test('Should generate a unique number on client', () => {
+    const ctx = { env: { isServer: false, request: {} } } as any
+    const ref = handler([], ctx)
+    const res = handler([], ctx)
     expect(typeof ref).toBe('string')
     expect(typeof res).toBe('string')
     expect(res).not.toBe(ref)
+  })
+
+  test('Should generate a unique number on server', () => {
+    const ctx = { env: { isServer: true, request: {} } } as any
+    const ref = handler([], ctx)
+    const res = handler([], ctx)
+    expect(typeof ref).toBe('string')
+    expect(typeof res).toBe('string')
+    expect(res).not.toBe(ref)
+  })
+
+  test('Should generate from beginning for each request on server', () => {
+    const request1 = {}
+    const request2 = {}
+    const ctx1 = { env: { isServer: true, request: request1 } } as any
+    const ctx2 = { env: { isServer: true, request: request2 } } as any
+
+    const res1 = handler([], ctx1)
+    const res2 = handler([], ctx1)
+    const res3 = handler([], ctx2)
+
+    expect(res1).toBe('_id_0_')
+    expect(res2).toBe('_id_1_')
+    expect(res3).toBe('_id_0_')
   })
 })

--- a/packages/lib/formulas/Id/handler.ts
+++ b/packages/lib/formulas/Id/handler.ts
@@ -1,8 +1,21 @@
 import type { FormulaHandler } from '@nordcraft/core/dist/types'
 
-let idCounter = 0
-const handler: FormulaHandler<string> = () => {
-  return `_id_${idCounter++}_`
+let localCounter = 0
+const requestCounters = new WeakMap<object, { idCounter: number }>()
+function getRequestCounter(key: object) {
+  if (!requestCounters.has(key)) {
+    requestCounters.set(key, { idCounter: 0 })
+  }
+  return requestCounters.get(key)!
+}
+
+const handler: FormulaHandler<string> = (_, ctx) => {
+  if (ctx.env.isServer) {
+    const counter = getRequestCounter(ctx.env.request)
+    return `_id_${counter.idCounter++}_`
+  }
+
+  return `_id_${localCounter++}_`
 }
 
 export default handler


### PR DESCRIPTION
Bit of a 🤦 as the SSR id counter was in process-state, but should be in request-state. We are not utilising stable IDs for anything yet, but it will be important for when better hydration.