### PR TITLE
Better handle multiple custom-elements on the same page, when using the new theming system

### DIFF
--- a/packages/runtime/src/components/createNode.test.ts
+++ b/packages/runtime/src/components/createNode.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from 'bun:test'
 import '../happydom'
 import { signal } from '../signal/signal'
 import type { ComponentContext } from '../types'
-import { customPropertiesStylesheet } from '../utils/subscribeCustomProperty'
+import { customPropertiesStylesheets } from '../utils/subscribeCustomProperty'
 import { createNode } from './createNode'
 
 describe('createNode()', () => {
@@ -114,7 +114,7 @@ describe('createNode()', () => {
     })
 
     // Custom properties stylesheet should be created and have the custom property from the node
-    const sheet = customPropertiesStylesheet?.getStyleSheet()
+    const sheet = customPropertiesStylesheets.get(document)?.getStyleSheet()
     expect(sheet).toBeTruthy()
     expect(sheet?.cssRules.length).toBe(3)
     expect(sheet?.cssRules[0].cssText).toBe(
@@ -675,7 +675,7 @@ describe('createNode()', () => {
       instance: {},
     })
 
-    const sheet = customPropertiesStylesheet?.getStyleSheet()
+    const sheet = customPropertiesStylesheets.get(ctx.root)?.getStyleSheet()
     // Test that the order makes sense
     expect(Array.from(sheet?.cssRules ?? []).map((r) => r.cssText)).toEqual([
       `[data-id="0"] { --color: ${innermostColor}; }`,

--- a/packages/runtime/src/utils/subscribeCustomProperty.test.ts
+++ b/packages/runtime/src/utils/subscribeCustomProperty.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import '../happydom'
+import { Signal } from '../signal/signal'
+import { subscribeCustomProperty } from './subscribeCustomProperty'
+
+describe('subscribeCustomProperty - multiple roots', () => {
+  afterEach(() => {
+    // Note: We can't easily clear the WeakMap, but each test uses new elements
+  })
+
+  test('it works with multiple shadow roots independently', () => {
+    const div1 = document.createElement('div')
+    const shadow1 = div1.attachShadow({ mode: 'open' })
+    const div2 = document.createElement('div')
+    const shadow2 = div2.attachShadow({ mode: 'open' })
+
+    const signal1 = new Signal('red')
+    const signal2 = new Signal('blue')
+
+    subscribeCustomProperty({
+      root: shadow1,
+      selector: '.test',
+      customPropertyName: '--color',
+      signal: signal1,
+    })
+
+    subscribeCustomProperty({
+      root: shadow2,
+      selector: '.test',
+      customPropertyName: '--color',
+      signal: signal2,
+    })
+
+    // Check that each shadow root has its own stylesheet
+    expect(shadow1.adoptedStyleSheets).toHaveLength(1)
+    expect(shadow2.adoptedStyleSheets).toHaveLength(1)
+    expect(shadow1.adoptedStyleSheets[0]).not.toBe(
+      shadow2.adoptedStyleSheets[0],
+    )
+
+    const sheet1 = shadow1.adoptedStyleSheets[0]
+    const sheet2 = shadow2.adoptedStyleSheets[0]
+
+    expect(sheet1.cssRules[0].cssText).toContain('--color: red')
+    expect(sheet2.cssRules[0].cssText).toContain('--color: blue')
+
+    // Update signal1
+    signal1.set('green')
+    expect(sheet1.cssRules[0].cssText).toContain('--color: green')
+    expect(sheet2.cssRules[0].cssText).toContain('--color: blue') // Should remain blue
+  })
+
+  test('it fetches the same stylesheet for the same root', () => {
+    const div = document.createElement('div')
+    const shadow = div.attachShadow({ mode: 'open' })
+
+    const signal1 = new Signal('red')
+    const signal2 = new Signal('blue')
+
+    subscribeCustomProperty({
+      root: shadow,
+      selector: '.test1',
+      customPropertyName: '--color1',
+      signal: signal1,
+    })
+
+    subscribeCustomProperty({
+      root: shadow,
+      selector: '.test2',
+      customPropertyName: '--color2',
+      signal: signal2,
+    })
+
+    expect(shadow.adoptedStyleSheets).toHaveLength(1)
+    const sheet = shadow.adoptedStyleSheets[0]
+    expect(sheet.cssRules).toHaveLength(2)
+  })
+})

--- a/packages/runtime/src/utils/subscribeCustomProperty.ts
+++ b/packages/runtime/src/utils/subscribeCustomProperty.ts
@@ -4,7 +4,10 @@ import { CUSTOM_PROPERTIES_STYLESHEET_ID } from '@nordcraft/core/dist/styling/th
 import type { StyleVariant } from '@nordcraft/core/dist/styling/variantSelector'
 import { CustomPropertyStyleSheet } from '../styles/CustomPropertyStyleSheet'
 
-export let customPropertiesStylesheet: CustomPropertyStyleSheet | undefined
+export const customPropertiesStylesheets = new WeakMap<
+  Document | ShadowRoot,
+  CustomPropertyStyleSheet
+>()
 
 export function subscribeCustomProperty({
   selector,
@@ -19,31 +22,27 @@ export function subscribeCustomProperty({
   variant?: StyleVariant
   root: Document | ShadowRoot
 }) {
-  customPropertiesStylesheet ??= new CustomPropertyStyleSheet(
-    root,
-    (
-      root.getElementById(CUSTOM_PROPERTIES_STYLESHEET_ID) as
-        | HTMLStyleElement
-        | undefined
-    )?.sheet,
-  )
+  let stylesheet = customPropertiesStylesheets.get(root)
+  if (!stylesheet) {
+    stylesheet = new CustomPropertyStyleSheet(
+      root,
+      (
+        root.getElementById(CUSTOM_PROPERTIES_STYLESHEET_ID) as
+          | HTMLStyleElement
+          | undefined
+      )?.sheet,
+    )
+    customPropertiesStylesheets.set(root, stylesheet)
+  }
 
   signal.subscribe(
-    customPropertiesStylesheet.registerProperty(
-      selector,
-      customPropertyName,
-      variant,
-    ),
+    stylesheet.registerProperty(selector, customPropertyName, variant),
     {
       destroy: () => {
-        customPropertiesStylesheet?.unregisterProperty(
-          selector,
-          customPropertyName,
-          {
-            mediaQuery: variant?.mediaQuery,
-            startingStyle: variant?.startingStyle,
-          },
-        )
+        stylesheet?.unregisterProperty(selector, customPropertyName, {
+          mediaQuery: variant?.mediaQuery,
+          startingStyle: variant?.startingStyle,
+        })
       },
     },
   )


### PR DESCRIPTION
There was an issue where custom elements would reference the wrong stylesheet when multiple web components were used on the same website.