### PR TITLE
Catch infinite loop when looking for element without interactive content when a component includes itself

### DIFF
--- a/packages/search/src/rules/issues/context/unknownContextProviderFormulaRule.ts
+++ b/packages/search/src/rules/issues/context/unknownContextProviderFormulaRule.ts
@@ -23,8 +23,9 @@ export const unknownContextProviderFormulaRule: IssueRule<{
     if (!component) {
       return
     }
-    for (const formulaName of value.formulas) {
-      if (component.formulas?.[formulaName]?.exposeInContext !== true) {
+    for (const key of value.formulas) {
+      if (component.formulas?.[key]?.exposeInContext !== true) {
+        const formulaName = component.formulas?.[key]?.name ?? key
         report({
           path,
           info: {

--- a/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.test.ts
+++ b/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.test.ts
@@ -398,4 +398,44 @@ describe('elementWithoutInteractiveContentRule', () => {
 
     expect(problems).toBeEmpty()
   })
+  test('should handle circular component references without infinite recursion', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            recursive: {
+              name: 'recursive',
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'button',
+                  children: ['child1'],
+                  attrs: {},
+                  classes: {},
+                  events: {},
+                  style: {},
+                },
+                child1: {
+                  type: 'component',
+                  name: 'recursive',
+                  children: [],
+                  attrs: {},
+                  events: {},
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [elementWithoutInteractiveContentRule],
+      }),
+    )
+    // Should not throw and should not find anything as there is no interactive content
+    expect(problems).toBeEmpty()
+  })
 })

--- a/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
+++ b/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
@@ -32,6 +32,7 @@ export const elementWithoutInteractiveContentRule: IssueRule<{
       container: ToddleComponent<Function> | Component,
       children: string[],
       results: Array<InteractiveContent> = [],
+      visitedComponents: Set<string> = new Set(),
     ): Array<InteractiveContent> => {
       return children.reduce((acc, childId) => {
         const child = container.nodes?.[childId]
@@ -48,23 +49,39 @@ export const elementWithoutInteractiveContentRule: IssueRule<{
         }
         const allResults = [...acc]
         if (child.type === 'component') {
+          const componentName = child.package
+            ? `${child.package}/${child.name}`
+            : child.name
+          if (visitedComponents.has(componentName)) {
+            return allResults
+          }
           const component = child.package
             ? files.packages?.[child.package]?.components?.[child.name]
             : files.components?.[child.name]
           if (!component) {
             return results
           }
+
+          const newVisited = new Set(visitedComponents)
+          newVisited.add(componentName)
+
           // Search children in the component's own nodes
           allResults.push(
             ...searchChildren(
               component,
               component.nodes?.['root']?.children ?? [],
-              acc,
+              [],
+              newVisited,
             ),
           )
         }
         // Search children in slot/component/element:
-        return searchChildren(container, child.children, allResults)
+        return searchChildren(
+          container,
+          child.children,
+          allResults,
+          visitedComponents,
+        )
       }, results)
     }
     const childTags = searchChildren(component, value.children)

--- a/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
+++ b/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
@@ -33,6 +33,7 @@ export const elementWithoutInteractiveContentRule: IssueRule<{
       children: string[],
       results: Array<InteractiveContent> = [],
       visitedComponents: Set<string> = new Set(),
+      // eslint-disable-next-line max-params
     ): Array<InteractiveContent> => {
       return children.reduce((acc, childId) => {
         const child = container.nodes?.[childId]

--- a/packages/search/src/rules/issues/workflows/unknownContextProviderWorkflowRule.ts
+++ b/packages/search/src/rules/issues/workflows/unknownContextProviderWorkflowRule.ts
@@ -23,8 +23,9 @@ export const unknownContextProviderWorkflowRule: IssueRule<{
     if (!component) {
       return
     }
-    for (const workflowName of value.workflows) {
-      if (component.workflows?.[workflowName]?.exposeInContext !== true) {
+    for (const key of value.workflows) {
+      if (component.workflows?.[key]?.exposeInContext !== true) {
+        const workflowName = component.workflows?.[key]?.name ?? key
         report({
           path,
           info: {


### PR DESCRIPTION
A component that included itself at any point would statically cause an infinite loop no matter the logical exit condition. This could cause the worker to stack overflow with some weird consequences.

Also fix an issue where we show formula and workflow IDs in some issue rules when we could instead look up the name instead.