### PR TITLE
Allow relative proxies

### DIFF
--- a/packages/backend/hono.d.ts
+++ b/packages/backend/hono.d.ts
@@ -2,8 +2,8 @@ import type { ProjectFiles, ToddleProject } from '@nordcraft/ssr/dist/ssr.types'
 import type { DurableObject } from 'cloudflare:workers'
 import type { Routes } from './src/middleware/routesLoader'
 
-export interface HonoEnv<T = never> {
-  Variables: T
+export interface HonoEnv<T = unknown> {
+  Variables: T & { app: Hono<HonoEnv<T>, BlankSchema> }
 }
 
 export interface PreviewHonoEnv<T = never> extends HonoEnv<T> {

--- a/packages/backend/hono.d.ts
+++ b/packages/backend/hono.d.ts
@@ -3,7 +3,7 @@ import type { DurableObject } from 'cloudflare:workers'
 import type { Routes } from './src/middleware/routesLoader'
 
 export interface HonoEnv<T = unknown> {
-  Variables: T & { app: Hono<HonoEnv<T>, BlankSchema> }
+  Variables: T & { app: Hono<HonoEnv<T>, BlankSchema, '/'> }
 }
 
 export interface PreviewHonoEnv<T = never> extends HonoEnv<T> {

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -35,6 +35,11 @@ export const getApp = <T extends Record<string, any>>(options: {
 
   const app = new Hono<HonoEnv<T>>({ strict: false })
 
+  app.use(async (c, next) => {
+    c.set('app', app)
+    await next()
+  })
+
   app.use(
     timing({
       // Potentially only enable detailed timing in development mode

--- a/packages/backend/src/routes/routeHandler.test.ts
+++ b/packages/backend/src/routes/routeHandler.test.ts
@@ -1,0 +1,152 @@
+import { REWRITE_HEADER } from '@nordcraft/core/dist/utils/url'
+import * as routing from '@nordcraft/ssr/dist/routing/routing'
+import { REDIRECT_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers'
+import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import { Hono } from 'hono'
+import type { HonoEnv } from '../../hono'
+import { routeHandler } from './routeHandler'
+
+const spyFetch = spyOn(globalThis, 'fetch')
+const spyMatchRoute = spyOn(routing, 'matchRouteForUrl')
+const spyGetRouteDestination = spyOn(routing, 'getRouteDestination')
+
+describe('routeHandler', () => {
+  beforeEach(() => {
+    spyFetch.mockReset()
+    spyMatchRoute.mockReset()
+    spyGetRouteDestination.mockReset()
+  })
+
+  afterAll(() => {
+    spyFetch.mockRestore()
+    spyMatchRoute.mockRestore()
+    spyGetRouteDestination.mockRestore()
+  })
+
+  it('should call next() if no route matches', async () => {
+    spyMatchRoute.mockReturnValue(undefined)
+    let nextCalled = false
+    const app = new Hono()
+    app.use('*', routeHandler)
+    app.get('*', (c) => {
+      nextCalled = true
+      return c.text('next')
+    })
+
+    const res = await app.request('http://localhost/no-match')
+    expect(res.status).toBe(200)
+    expect(nextCalled).toBe(true)
+  })
+
+  it('should return 500 if destination is invalid', async () => {
+    spyMatchRoute.mockReturnValue({
+      route: { type: 'page', path: '/test' } as any,
+      name: 'test-route',
+    })
+    spyGetRouteDestination.mockReturnValue(undefined)
+
+    const app = new Hono()
+    app.use('*', routeHandler)
+
+    const res = await app.request('http://localhost/test')
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe('Invalid destination')
+  })
+
+  it('should handle redirect routes', async () => {
+    spyMatchRoute.mockReturnValue({
+      route: { type: 'redirect', path: '/old', status: 301 } as any,
+      name: 'old-route',
+    })
+    const destination = new URL('http://localhost/new')
+    spyGetRouteDestination.mockReturnValue(destination)
+
+    const app = new Hono()
+    app.use('*', routeHandler)
+
+    const res = await app.request('http://localhost/old')
+    expect(res.status).toBe(301)
+    expect(res.headers.get('Location')).toBe('http://localhost/new')
+    expect(res.headers.get(REDIRECT_NAME_HEADER)).toBe('old-route')
+  })
+
+  it('should prevent recursive rewrites', async () => {
+    spyMatchRoute.mockReturnValue({
+      route: { type: 'proxy', path: '/proxy' } as any,
+      name: 'proxy-route',
+    })
+    spyGetRouteDestination.mockReturnValue(new URL('http://localhost/proxy'))
+
+    const app = new Hono()
+    app.use('*', routeHandler)
+
+    const res = await app.request('http://localhost/proxy', {
+      headers: {
+        [REWRITE_HEADER]: 'true',
+      },
+    })
+    expect(res.status).toBe(500)
+    expect(await res.text()).toBe(
+      'Nordcraft rewrites are not allowed to be recursive',
+    )
+  })
+
+  it('should proxy request to external destination', async () => {
+    spyMatchRoute.mockReturnValue({
+      route: { type: 'proxy', path: '/proxy' } as any,
+      name: 'proxy-route',
+    })
+    const destinationUrl = 'https://external.com/api'
+    spyGetRouteDestination.mockReturnValue(new URL(destinationUrl))
+
+    spyFetch.mockResolvedValue(
+      new Response('external content', {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+      }),
+    )
+
+    const app = new Hono()
+    app.use('*', routeHandler)
+
+    const res = await app.request('http://localhost/proxy')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('external content')
+    expect(spyFetch).toHaveBeenCalled()
+    const fetchArgs = spyFetch.mock.calls[0]
+    expect(fetchArgs?.[0].toString()).toBe(destinationUrl)
+    expect((fetchArgs?.[1]?.headers as Headers).get(REWRITE_HEADER)).toBe(
+      'true',
+    )
+  })
+
+  it('should handle internal proxying via app.fetch', async () => {
+    spyMatchRoute.mockReturnValue({
+      route: { type: 'proxy', path: '/internal' } as any,
+      name: 'internal-route',
+    })
+    const internalUrl = 'http://localhost/internal-resource'
+    spyGetRouteDestination.mockReturnValue(new URL(internalUrl))
+
+    const innerApp = {
+      fetch: async (req: Request, _env: any, _executionCtx: any) => {
+        const url = typeof req === 'string' ? req : req.url
+        if (url?.endsWith('/internal-resource')) {
+          return new Response('internal content')
+        }
+        return new Response('Not Found', { status: 404 })
+      },
+    }
+
+    const app = new Hono<HonoEnv>()
+    app.use('*', async (c, next) => {
+      c.set('app', innerApp)
+      await next()
+    })
+    app.use('*', routeHandler)
+
+    const res = await app.request('http://localhost/internal')
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('internal content')
+  })
+})

--- a/packages/backend/src/routes/routeHandler.ts
+++ b/packages/backend/src/routes/routeHandler.ts
@@ -18,8 +18,9 @@ import {
   skipCookieHeader,
   skipHopByHopHeaders,
 } from '@nordcraft/ssr/src/utils/headers'
-import type { ExecutionContext, Handler } from 'hono'
+import type { ExecutionContext, Handler, Hono } from 'hono'
 import { endTime, startTime } from 'hono/timing'
+import type { BlankSchema } from 'hono/types'
 import type { StatusCode } from 'hono/utils/http-status'
 import type { HonoEnv, HonoProject, HonoRoutes } from '../../hono'
 
@@ -89,7 +90,8 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
     startTime(c, timingKey)
     let response: Response
     if (destination.origin === url.origin) {
-      const hono = c.get('app')
+      // hono.fetch below is treated as any if we don't specify the type of hono explicitly here
+      const hono: Hono<HonoEnv<unknown>, BlankSchema, '/'> = c.get('app')
       let executionCtx: ExecutionContext | undefined
       try {
         executionCtx = c.executionCtx

--- a/packages/backend/src/routes/routeHandler.ts
+++ b/packages/backend/src/routes/routeHandler.ts
@@ -18,7 +18,7 @@ import {
   skipCookieHeader,
   skipHopByHopHeaders,
 } from '@nordcraft/ssr/src/utils/headers'
-import type { Handler } from 'hono'
+import type { ExecutionContext, Handler } from 'hono'
 import { endTime, startTime } from 'hono/timing'
 import type { StatusCode } from 'hono/utils/http-status'
 import type { HonoEnv, HonoProject, HonoRoutes } from '../../hono'
@@ -87,13 +87,37 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
 
     const timingKey = 'proxyRequest'
     startTime(c, timingKey)
-    const response = await fetch(destination, {
-      headers,
-      method: c.req.raw.method,
-      body: HttpMethodsWithAllowedBody.includes(c.req.raw.method as ApiMethod)
-        ? c.req.raw.body
-        : undefined,
-    })
+    let response: Response
+    if (destination.origin === url.origin) {
+      const hono = c.get('app')
+      let executionCtx: ExecutionContext | undefined
+      try {
+        executionCtx = c.executionCtx
+      } catch {
+        // In tests, the execution context might not be available
+      }
+      response = hono.fetch(
+        new Request(destination, {
+          method: c.req.raw.method,
+          body: HttpMethodsWithAllowedBody.includes(
+            c.req.raw.method as ApiMethod,
+          )
+            ? c.req.raw.body
+            : undefined,
+          headers,
+        }),
+        c.env,
+        executionCtx,
+      )
+    } else {
+      response = await fetch(destination, {
+        headers,
+        method: c.req.raw.method,
+        body: HttpMethodsWithAllowedBody.includes(c.req.raw.method as ApiMethod)
+          ? c.req.raw.body
+          : undefined,
+      })
+    }
     endTime(c, timingKey)
     // Pass the stream into a new response so we can write the headers
     const body = NON_BODY_RESPONSE_CODES.includes(response.status)

--- a/packages/backend/src/routes/routeHandler.ts
+++ b/packages/backend/src/routes/routeHandler.ts
@@ -96,7 +96,7 @@ export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
       } catch {
         // In tests, the execution context might not be available
       }
-      response = hono.fetch(
+      response = await hono.fetch(
         new Request(destination, {
           method: c.req.raw.method,
           body: HttpMethodsWithAllowedBody.includes(

--- a/packages/ssr/src/rendering/testData.test.ts
+++ b/packages/ssr/src/rendering/testData.test.ts
@@ -241,7 +241,7 @@ describe('removeTestData', () => {
             inputs: {},
           },
         },
-      }).apis['a'],
+      }).apis?.['a'],
     ).toEqual({
       name: 'foo',
       url: valueFormula('https://example.com'),

--- a/packages/ssr/src/routing/routing.test.ts
+++ b/packages/ssr/src/routing/routing.test.ts
@@ -1,9 +1,13 @@
 import type { PageComponent } from '@nordcraft/core/dist/component/component.types'
 import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 import { describe, expect, test } from 'bun:test'
-import { serverEnv } from '../rendering/formulaContext'
+import { getServerToddleObject, serverEnv } from '../rendering/formulaContext'
 import type { Route } from '../ssr.types'
-import { matchPageForUrl, matchRouteForUrl } from './routing'
+import {
+  getRouteDestination,
+  matchPageForUrl,
+  matchRouteForUrl,
+} from './routing'
 
 describe('matchPageForUrl', () => {
   test('it finds the correct page for a url', () => {
@@ -206,7 +210,7 @@ describe('matchRouteForUrl', () => {
           getFormula: () => undefined,
           getCustomFormula: () => undefined,
         },
-      }),
+      }) as any,
     ).toEqual({ name: 'docsRedirect', route: routes['docsRedirect'] })
   })
   test('it ignores disabled routes', () => {
@@ -269,7 +273,164 @@ describe('matchRouteForUrl', () => {
           getFormula: () => undefined,
           getCustomFormula: () => undefined,
         },
-      }),
+      }) as any,
     ).toEqual({ name: 'docsRedirect', route: routes['docsRedirect'] })
+  })
+})
+describe('getRouteDestination', () => {
+  const getEnv = (req: Request) =>
+    serverEnv({
+      branchName: 'main',
+      req,
+      logErrors: false,
+    })
+
+  test('it returns the destination for a rewrite route', () => {
+    const route: Route = {
+      type: 'rewrite',
+      source: { path: [{ type: 'static', name: 'search' }], query: {} },
+      destination: {
+        url: valueFormula('results'),
+      },
+    }
+    const req = new Request('http://localhost:3000/search')
+    const url = getRouteDestination({
+      serverContext: getServerToddleObject({}),
+      req,
+      route,
+      env: getEnv(req),
+    })
+    expect(url?.toString()).toEqual('http://localhost:3000/results')
+  })
+
+  test('it returns the destination for a redirect route', () => {
+    const route: Route = {
+      type: 'redirect',
+      source: { path: [{ type: 'static', name: 'old' }], query: {} },
+      destination: {
+        url: valueFormula('new'),
+      },
+    }
+    const req = new Request('http://localhost:3000/old')
+    const url = getRouteDestination({
+      serverContext: getServerToddleObject({}),
+      req,
+      route,
+      env: getEnv(req),
+    })
+    expect(url?.toString()).toEqual('http://localhost:3000/new')
+  })
+
+  test('it returns undefined if a redirect points to the same URL', () => {
+    const route: Route = {
+      type: 'redirect',
+      source: { path: [{ type: 'static', name: 'same' }], query: {} },
+      destination: {
+        url: valueFormula('same'),
+      },
+    }
+    const req = new Request('http://localhost:3000/same')
+    const url = getRouteDestination({
+      serverContext: getServerToddleObject({}),
+      req,
+      route,
+      env: getEnv(req),
+    })
+    expect(url).toBeUndefined()
+  })
+
+  test('it allows a rewrite to point to the same URL', () => {
+    const route: Route = {
+      type: 'rewrite',
+      source: { path: [{ type: 'static', name: 'same' }], query: {} },
+      destination: {
+        url: valueFormula('same'),
+      },
+    }
+    const req = new Request('http://localhost:3000/same')
+    const url = getRouteDestination({
+      serverContext: getServerToddleObject({}),
+      req,
+      route,
+      env: getEnv(req),
+    })
+    expect(url?.toString()).toEqual('http://localhost:3000/same')
+  })
+
+  test('it handles dynamic parameters in the destination', () => {
+    const route: Route = {
+      type: 'rewrite',
+      source: {
+        path: [
+          { type: 'static', name: 'user' },
+          { type: 'param', name: 'id', testValue: '123' },
+        ],
+        query: {},
+      },
+      destination: {
+        path: {
+          profile: {
+            index: 0,
+            formula: valueFormula('profile'),
+          },
+          id: {
+            index: 1,
+            formula: {
+              path: ['Route parameters', 'path', 'id'],
+              type: 'path',
+            },
+          },
+        },
+      },
+    }
+    const req = new Request('http://localhost:3000/user/456')
+    const url = getRouteDestination({
+      serverContext: getServerToddleObject({}),
+      req,
+      route,
+      env: getEnv(req),
+    })
+    expect(url?.toString()).toEqual('http://localhost:3000/profile/456')
+  })
+
+  test('it handles relative URLs in the destination', () => {
+    const route: Route = {
+      type: 'redirect',
+      source: { path: [{ type: 'static', name: 'old' }], query: {} },
+      destination: {
+        url: valueFormula('/new-relative'),
+      },
+    }
+    const req = new Request('http://localhost:3000/old')
+    const url = getRouteDestination({
+      serverContext: getServerToddleObject({}),
+      req,
+      route,
+      env: getEnv(req),
+    })
+    expect(url?.toString()).toEqual('http://localhost:3000/new-relative')
+  })
+
+  test('it handles query parameters in the destination', () => {
+    const route: Route = {
+      type: 'rewrite',
+      source: { path: [{ type: 'static', name: 'search' }], query: {} },
+      destination: {
+        url: valueFormula('results'),
+        queryParams: {
+          q: {
+            formula: valueFormula('toddle'),
+          },
+        },
+      },
+    }
+    const req = new Request('http://localhost:3000/search')
+    const url = getRouteDestination({
+      serverContext: getServerToddleObject({}),
+      req,
+      route,
+      env: getEnv(req),
+    })
+    expect(url?.toString()).toEqual('http://localhost:3000/results?q=toddle')
   })
 })

--- a/packages/ssr/src/routing/routing.ts
+++ b/packages/ssr/src/routing/routing.ts
@@ -127,23 +127,13 @@ export const getRouteDestination = ({
       serverContext,
     })
 
-    const url = getUrl(
-      route.destination,
-      formulaContext,
-      // Redirects can redirect to relative URLs - rewrites can't
-      route.type === 'redirect' ? requestUrl.origin : undefined,
-    )
+    const url = getUrl(route.destination, formulaContext, requestUrl.origin)
     if (
       route.type === 'redirect' &&
       requestUrl.origin === url.origin &&
       requestUrl.pathname === url.pathname
     ) {
       // Redirects are not allowed to redirect to the same URL as their source
-      return
-    }
-    if (route.type === 'rewrite' && requestUrl.origin === url.origin) {
-      // Rewrites are not allowed from the same origin as the source
-      // This prevents potential recursive fetch calls from the server to itself
       return
     }
     return url

--- a/packages/ssr/src/utils/media.test.ts
+++ b/packages/ssr/src/utils/media.test.ts
@@ -67,7 +67,7 @@ describe('transformRelativePaths()', () => {
           },
         },
       },
-    })
+    } as any)
   })
   test('it keeps absolute urls', () => {
     expect(
@@ -96,7 +96,7 @@ describe('transformRelativePaths()', () => {
           },
         },
       },
-    })
+    } as any)
   })
   test('it does not transform non-src attributes', () => {
     expect(
@@ -125,6 +125,6 @@ describe('transformRelativePaths()', () => {
           },
         },
       },
-    })
+    } as any)
   })
 })

--- a/packages/ssr/tsconfig.json
+++ b/packages/ssr/tsconfig.json
@@ -19,5 +19,5 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- Consider proxies to relative URLs valid
- Use the Hono app internally to handle relative proxied URLs
- Add tests

Relative proxies can essentially be used to create URL aliases and serve the same page from multiple URLs. It does come with a drawback though if the number of path parameters in the source and destination are not the same since the client code will not receive the correct parameters in the expected positions (indices).