### PR TITLE
Ensure workflow events are visited by issue rules

### DIFF
--- a/packages/core/src/component/ToddleComponent.actionReferences.test.ts
+++ b/packages/core/src/component/ToddleComponent.actionReferences.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, test } from 'bun:test'
 import { ToddleComponent } from './ToddleComponent'
 
 describe('ToddleComponent.actionReferences', () => {
@@ -31,6 +32,42 @@ describe('ToddleComponent.actionReferences', () => {
     })
     const actions = Array.from(demo.actionReferences)
     expect(actions).toEqual(['MyCustomAction', 'MyLegacyCustomAction'])
+  })
+  test('it return custom actions referenced in workflow callbacks', () => {
+    const demo = new ToddleComponent({
+      component: {
+        name: 'demo',
+        apis: {},
+        attributes: {},
+        nodes: {},
+        variables: {},
+        onLoad: {
+          trigger: 'onLoad',
+          actions: [
+            {
+              type: 'TriggerWorkflow',
+              callbacks: {
+                'test event': {
+                  actions: [
+                    {
+                      type: 'Custom',
+                      name: 'MyCustomAction',
+                    },
+                  ],
+                },
+              },
+              workflow: 'AsqRCv',
+              parameters: {},
+            },
+          ],
+        },
+      },
+      getComponent: () => undefined,
+      packageName: 'demo',
+      globalFormulas: { formulas: {}, packages: {} },
+    })
+    const actions = Array.from(demo.actionReferences)
+    expect(actions).toEqual(['MyCustomAction'])
   })
   test('it should not include non-custom actions', () => {
     const demo = new ToddleComponent({

--- a/packages/core/src/component/actionUtils.ts
+++ b/packages/core/src/component/actionUtils.ts
@@ -17,8 +17,24 @@ export function* getActionsInAction(
     case 'SetURLParameters':
     case 'SetVariable':
     case 'TriggerEvent':
-    case 'TriggerWorkflow':
     case 'TriggerWorkflowCallback':
+      break
+    case 'TriggerWorkflow':
+      for (const [key, callback] of Object.entries(action.callbacks ?? {})) {
+        if (callback) {
+          for (const [aKey, a] of Object.entries(callback.actions ?? {})) {
+            if (a) {
+              yield* getActionsInAction(a, [
+                ...path,
+                'callbacks',
+                key,
+                'actions',
+                aKey,
+              ])
+            }
+          }
+        }
+      }
       break
     case 'Fetch':
       for (const [key, a] of Object.entries(action.onSuccess?.actions ?? {})) {

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -372,7 +372,9 @@ export interface WorkflowActionModel {
   type: 'TriggerWorkflow'
   workflow: string
   parameters: Record<string, { formula?: Nullable<Formula> }>
-  callbacks?: Nullable<Record<string, { actions?: Nullable<ActionModel[]> }>>
+  callbacks?: Nullable<
+    Partial<Record<string, { actions?: Nullable<Partial<ActionModel[]>> }>>
+  >
   contextProvider?: Nullable<string>
 }
 

--- a/packages/core/src/formula/formulaUtils.ts
+++ b/packages/core/src/formula/formulaUtils.ts
@@ -319,6 +319,23 @@ export function* getFormulasInAction<Handler>({
           })
         }
       }
+      for (const [callbackKey, callback] of Object.entries(
+        action.callbacks ?? {},
+      )) {
+        if (isDefined(callback?.actions)) {
+          for (const [key, a] of Object.entries(callback.actions)) {
+            if (isDefined(a)) {
+              yield* getFormulasInAction({
+                action: a,
+                globalFormulas,
+                path: [...path, 'callbacks', callbackKey, 'actions', key],
+                visitedFormulas,
+                packageName,
+              })
+            }
+          }
+        }
+      }
       break
     case 'Switch':
       if (isDefined(action.data) && isFormula(action.data)) {

--- a/packages/runtime/src/events/handleAction.ts
+++ b/packages/runtime/src/events/handleAction.ts
@@ -424,19 +424,21 @@ export function handleAction(
               event,
               (callbackName, callbackData) => {
                 const callback = callbacks?.[callbackName]
-                callback?.actions?.forEach((action) =>
-                  handleAction(
-                    action,
-                    {
-                      ...data,
-                      ...ctx.dataSignal.get(),
-                      Parameters: parameters,
-                      Event: callbackData,
-                    },
-                    ctx,
-                    event,
-                    workflowCallback,
-                  ),
+                callback?.actions?.forEach(
+                  (action) =>
+                    action &&
+                    handleAction(
+                      action,
+                      {
+                        ...data,
+                        ...ctx.dataSignal.get(),
+                        Parameters: parameters,
+                        Event: callbackData,
+                      },
+                      ctx,
+                      event,
+                      workflowCallback,
+                    ),
                 )
               },
             ),
@@ -464,19 +466,21 @@ export function handleAction(
             event,
             (callbackName, callbackData) => {
               const callback = callbacks?.[callbackName]
-              callback?.actions?.forEach((action) =>
-                handleAction(
-                  action,
-                  {
-                    ...data,
-                    ...ctx.dataSignal.get(),
-                    Parameters: parameters,
-                    Event: callbackData,
-                  },
-                  ctx,
-                  event,
-                  workflowCallback,
-                ),
+              callback?.actions?.forEach(
+                (action) =>
+                  action &&
+                  handleAction(
+                    action,
+                    {
+                      ...data,
+                      ...ctx.dataSignal.get(),
+                      Parameters: parameters,
+                      Event: callbackData,
+                    },
+                    ctx,
+                    event,
+                    workflowCallback,
+                  ),
               )
             },
           ),

--- a/packages/search/src/rules/issues/variables/unknownVariableRule.test.ts
+++ b/packages/search/src/rules/issues/variables/unknownVariableRule.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { searchProject } from '../../../searchProject'
-import { IssueResult } from '../../../types'
+import type { IssueResult } from '../../../types'
 import { unknownVariableRule } from './unknownVariableRule'
 
 describe('unknownVariable', () => {

--- a/packages/search/src/rules/issues/variables/unknownVariableRule.test.ts
+++ b/packages/search/src/rules/issues/variables/unknownVariableRule.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { searchProject } from '../../../searchProject'
+import { IssueResult } from '../../../types'
 import { unknownVariableRule } from './unknownVariableRule'
 
 describe('unknownVariable', () => {
@@ -40,8 +41,64 @@ describe('unknownVariable', () => {
     )
 
     expect(problems).toHaveLength(1)
-    expect(problems[0].code).toBe('unknown variable')
+    expect((problems[0] as IssueResult).code).toBe('unknown variable')
     expect(problems[0].details).toEqual({ name: 'unknown' })
+  })
+
+  test('should report references to unknown variables in workflow events/callbacks', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              onLoad: {
+                trigger: 'onLoad',
+                actions: [
+                  {
+                    type: 'TriggerWorkflow',
+                    callbacks: {
+                      'test event': {
+                        actions: [
+                          {
+                            name: '@toddle/logToConsole',
+                            arguments: [
+                              {
+                                name: 'Label',
+                                formula: { type: 'value', value: '' },
+                              },
+                              {
+                                name: 'Data',
+                                formula: {
+                                  type: 'path',
+                                  path: ['Variables', 'test'],
+                                },
+                              },
+                            ],
+                            label: 'Log to console',
+                          },
+                        ],
+                      },
+                    },
+                    workflow: 'AsqRCv',
+                    parameters: {},
+                  },
+                ],
+              },
+            },
+          },
+        },
+        rules: [unknownVariableRule],
+      }),
+    )
+    expect(problems).toHaveLength(1)
+    expect((problems[0] as IssueResult).code).toBe('unknown variable')
+    expect(problems[0].details).toEqual({ name: 'test' })
   })
 
   test('should not report variables that exist', () => {

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -249,7 +249,10 @@ const removeActionTestData = (action: ActionModel): ActionModel => {
                 key,
                 {
                   ...value,
-                  actions: value.actions?.map(removeActionTestData) ?? [],
+                  actions:
+                    value?.actions?.map((a) =>
+                      a ? removeActionTestData(a) : a,
+                    ) ?? [],
                 },
               ]),
             }


### PR DESCRIPTION
Actions/formulas defined in workflow event callbacks were not visited by issue/search rules. This PR:

- Ensures we visit workflow event callbacks when running issue/search rules
- Relaxes types for workflow callbacks to safeguard agains nullish values
  
Closes https://github.com/nordcraftengine/nordcraft-internal/issues/4158