### PR TITLE
Update the parser for the animation property that use variables with a null values

### DIFF
--- a/packages/css-parser/src/parseAnimation.test.ts
+++ b/packages/css-parser/src/parseAnimation.test.ts
@@ -51,6 +51,62 @@ describe('parseAnimation', () => {
     ])
   })
 
+  test('Using variable that has a null value', () => {
+    expect(
+      getParsedAnimation(
+        {
+          animation: '2s ease var(--delay) 1 normal none running',
+        },
+        [
+          {
+            syntax: {
+              type: 'primitive',
+              name: 'time',
+            },
+            formula: { type: 'value', value: null },
+            name: '--delay',
+            description: undefined,
+            unit: 'ms',
+            value: 'ms',
+          } as any,
+        ],
+      ),
+    ).toEqual([
+      {
+        duration: {
+          type: 'time',
+          value: '2',
+          unit: 's',
+        },
+        timing: {
+          type: 'keyword',
+          value: 'ease',
+        },
+        delay: {
+          name: 'var',
+          type: 'function',
+          value: '--delay',
+        },
+        direction: {
+          type: 'keyword',
+          value: 'normal',
+        },
+        iterationCount: {
+          type: 'number',
+          value: '1',
+        },
+        playState: {
+          type: 'keyword',
+          value: 'running',
+        },
+        fillMode: {
+          type: 'keyword',
+          value: 'none',
+        },
+      },
+    ])
+  })
+
   test('Multiple animations are defined', () => {
     expect(
       getParsedAnimation(

--- a/packages/css-parser/src/parseAnimation.ts
+++ b/packages/css-parser/src/parseAnimation.ts
@@ -532,39 +532,44 @@ const parseAnimation = ({
           return
         }
 
+        const valueWithoutUnit = usedVariable.unit
+          ? usedVariable.value.replaceAll(usedVariable.unit, '')
+          : usedVariable.value
+
         const parsedVariable = parseMultipleValues([
           {
             type: 'word',
-            value:
-              usedVariable.unit && usedVariable.unit !== ''
-                ? `${usedVariable.value}${usedVariable.unit}`
-                : usedVariable.value,
+            value: valueWithoutUnit,
           },
         ])
-        const newProp = parseAnimation({
-          valueToCheck: parsedVariable[0],
-          valueToReturn: valueToCheck,
-          durationSet,
-          nameSet,
-          variables,
-        })
 
-        if (newProp.direction) {
-          direction = returnValue
-        } else if (newProp.timing) {
-          timing = returnValue
-        } else if (newProp.playState) {
-          playState = returnValue
-        } else if (newProp.fillMode) {
-          fillMode = returnValue
-        } else if (newProp.iterationCount) {
-          iterationCount = returnValue
-        } else if (newProp.duration) {
-          duration = returnValue
-        } else if (newProp.delay) {
-          delay = returnValue
-        } else if (newProp.name) {
-          name = true
+        if (isDefined(parsedVariable[0])) {
+          const newProp = parseAnimation({
+            valueToCheck: parsedVariable[0],
+            valueToReturn: valueToCheck,
+            durationSet,
+            nameSet,
+            variables,
+          })
+          if (newProp.direction) {
+            direction = returnValue
+          } else if (newProp.timing) {
+            timing = returnValue
+          } else if (newProp.playState) {
+            playState = returnValue
+          } else if (newProp.fillMode) {
+            fillMode = returnValue
+          } else if (newProp.iterationCount) {
+            iterationCount = returnValue
+          } else if (newProp.duration) {
+            duration = returnValue
+          } else if (newProp.delay) {
+            delay = returnValue
+          } else if (newProp.name) {
+            name = returnValue
+          }
+        } else {
+          invalidValue = true
         }
       } else {
         const parsedVariable = parseMultipleValues([
@@ -593,7 +598,7 @@ const parseAnimation = ({
         } else if (newProp.delay) {
           delay = returnValue
         } else if (newProp.name) {
-          name = true
+          name = returnValue
         }
       }
     })


### PR DESCRIPTION
If we use an variable with a null value in the animation property, we will consider that as an invalid value and will add it to the first undefined single animation property.