### PR TITLE
Add X-Forwarded-For header in proxies

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -84,7 +84,7 @@ export const getApp = <T extends Record<string, any>>(options: {
   }
 
   // Load a route if it matches the URL
-  app.all('/*', routeHandler)
+  app.all('/*', routeHandler(options.getConnInfo))
 
   // Load default resource endpoints
   app.get('/sitemap.xml', sitemap)

--- a/packages/backend/src/routes/apiProxy.test.ts
+++ b/packages/backend/src/routes/apiProxy.test.ts
@@ -6,7 +6,7 @@ import {
 import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test'
 import { Hono } from 'hono'
 import { testClient } from 'hono/testing'
-import { proxyRequestHandler } from './apiProxy'
+import { normalizeIP, proxyRequestHandler } from './apiProxy'
 
 const spyFetch = spyOn(globalThis, 'fetch')
 
@@ -270,5 +270,25 @@ describe('API proxy', () => {
     )
     expect(res.status).toBe(200)
     expect(res.headers.get('Vary')).toBe(`Accept-Encoding, ${PROXY_URL_HEADER}`)
+  })
+
+  describe('normalizeIP', () => {
+    it('should remove ::ffff: prefix from IPv4-mapped IPv6 addresses', () => {
+      expect(normalizeIP('::ffff:127.0.0.1')).toBe('127.0.0.1')
+      expect(normalizeIP('::ffff:192.168.1.1')).toBe('192.168.1.1')
+    })
+
+    it('should return the address unchanged if no prefix is present', () => {
+      expect(normalizeIP('127.0.0.1')).toBe('127.0.0.1')
+      expect(normalizeIP('2001:db8::1')).toBe('2001:db8::1')
+    })
+
+    it('should return undefined if address is undefined', () => {
+      expect(normalizeIP(undefined)).toBe(undefined)
+    })
+
+    it('should return an empty string if address is an empty string', () => {
+      expect(normalizeIP('')).toBe('')
+    })
   })
 })

--- a/packages/backend/src/routes/apiProxy.ts
+++ b/packages/backend/src/routes/apiProxy.ts
@@ -169,7 +169,7 @@ export const proxyRequestHandler =
     }
   }
 
-const normalizeIP = (address?: string) => {
+export const normalizeIP = (address?: string) => {
   // Remove IPv4-mapped IPv6 prefix if present
   if (address?.startsWith('::ffff:')) {
     return address.substring(7)

--- a/packages/backend/src/routes/routeHandler.test.ts
+++ b/packages/backend/src/routes/routeHandler.test.ts
@@ -1,10 +1,10 @@
-import { REWRITE_HEADER } from '@nordcraft/core/dist/utils/url';
-import * as routing from '@nordcraft/ssr/dist/routing/routing';
-import { REDIRECT_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers';
-import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
-import { Hono } from 'hono';
-import type { HonoEnv } from '../../hono';
-import { routeHandler } from './routeHandler';
+import { REWRITE_HEADER } from '@nordcraft/core/dist/utils/url'
+import * as routing from '@nordcraft/ssr/dist/routing/routing'
+import { REDIRECT_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers'
+import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test'
+import { Hono } from 'hono'
+import type { HonoEnv } from '../../hono'
+import { routeHandler } from './routeHandler'
 
 const spyFetch = spyOn(globalThis, 'fetch')
 const spyMatchRoute = spyOn(routing, 'matchRouteForUrl')

--- a/packages/backend/src/routes/routeHandler.test.ts
+++ b/packages/backend/src/routes/routeHandler.test.ts
@@ -1,14 +1,18 @@
-import { REWRITE_HEADER } from '@nordcraft/core/dist/utils/url'
-import * as routing from '@nordcraft/ssr/dist/routing/routing'
-import { REDIRECT_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers'
-import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test'
-import { Hono } from 'hono'
-import type { HonoEnv } from '../../hono'
-import { routeHandler } from './routeHandler'
+import { REWRITE_HEADER } from '@nordcraft/core/dist/utils/url';
+import * as routing from '@nordcraft/ssr/dist/routing/routing';
+import { REDIRECT_NAME_HEADER } from '@nordcraft/ssr/src/utils/headers';
+import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { Hono } from 'hono';
+import type { HonoEnv } from '../../hono';
+import { routeHandler } from './routeHandler';
 
 const spyFetch = spyOn(globalThis, 'fetch')
 const spyMatchRoute = spyOn(routing, 'matchRouteForUrl')
 const spyGetRouteDestination = spyOn(routing, 'getRouteDestination')
+
+const localhostRouteHandler = routeHandler(() => ({
+  remote: { address: '127.0.0.1' },
+}))
 
 describe('routeHandler', () => {
   beforeEach(() => {
@@ -27,7 +31,7 @@ describe('routeHandler', () => {
     spyMatchRoute.mockReturnValue(undefined)
     let nextCalled = false
     const app = new Hono()
-    app.use('*', routeHandler)
+    app.use('*', localhostRouteHandler)
     app.get('*', (c) => {
       nextCalled = true
       return c.text('next')
@@ -46,7 +50,7 @@ describe('routeHandler', () => {
     spyGetRouteDestination.mockReturnValue(undefined)
 
     const app = new Hono()
-    app.use('*', routeHandler)
+    app.use('*', localhostRouteHandler)
 
     const res = await app.request('http://localhost/test')
     expect(res.status).toBe(500)
@@ -62,7 +66,7 @@ describe('routeHandler', () => {
     spyGetRouteDestination.mockReturnValue(destination)
 
     const app = new Hono()
-    app.use('*', routeHandler)
+    app.use('*', localhostRouteHandler)
 
     const res = await app.request('http://localhost/old')
     expect(res.status).toBe(301)
@@ -78,7 +82,7 @@ describe('routeHandler', () => {
     spyGetRouteDestination.mockReturnValue(new URL('http://localhost/proxy'))
 
     const app = new Hono()
-    app.use('*', routeHandler)
+    app.use('*', localhostRouteHandler)
 
     const res = await app.request('http://localhost/proxy', {
       headers: {
@@ -99,15 +103,23 @@ describe('routeHandler', () => {
     const destinationUrl = 'https://external.com/api'
     spyGetRouteDestination.mockReturnValue(new URL(destinationUrl))
 
-    spyFetch.mockResolvedValue(
-      new Response('external content', {
+    const mockFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : input.toString()
+      const headers =
+        input instanceof Request ? input.headers : new Headers(init?.headers)
+
+      expect(url).toBe(destinationUrl)
+      expect(headers.get(REWRITE_HEADER)).toBe('true')
+      expect(headers.get('X-Forwarded-For')).toBe('127.0.0.1')
+      return new Response('external content', {
         status: 200,
         headers: { 'Content-Type': 'text/plain' },
-      }),
-    )
+      })
+    }
+    spyFetch.mockImplementation(mockFetch as any)
 
     const app = new Hono()
-    app.use('*', routeHandler)
+    app.use('*', localhostRouteHandler)
 
     const res = await app.request('http://localhost/proxy')
     expect(res.status).toBe(200)
@@ -143,7 +155,7 @@ describe('routeHandler', () => {
       c.set('app', innerApp)
       await next()
     })
-    app.use('*', routeHandler)
+    app.use('*', localhostRouteHandler)
 
     const res = await app.request('http://localhost/internal')
     expect(res.status).toBe(200)

--- a/packages/backend/src/routes/routeHandler.ts
+++ b/packages/backend/src/routes/routeHandler.ts
@@ -18,128 +18,136 @@ import {
   skipCookieHeader,
   skipHopByHopHeaders,
 } from '@nordcraft/ssr/src/utils/headers'
-import type { ExecutionContext, Handler, Hono } from 'hono'
+import type { Context, ExecutionContext, Handler, Hono } from 'hono'
+import type { ConnInfo } from 'hono/conninfo'
 import { endTime, startTime } from 'hono/timing'
 import type { BlankSchema } from 'hono/types'
 import type { StatusCode } from 'hono/utils/http-status'
 import type { HonoEnv, HonoProject, HonoRoutes } from '../../hono'
+import { normalizeIP } from './apiProxy'
 
-export const routeHandler: Handler<HonoEnv<HonoRoutes & HonoProject>> = async (
-  c,
-  next,
-) => {
-  const url = new URL(c.req.url)
-  const routeMatch = matchRouteForUrl({
-    url,
-    routes: c.var.routes?.routes ?? {},
-    env: serverEnv({ branchName: 'main', req: c.req.raw, logErrors: false }),
-    req: c.req.raw,
-    // TODO: We should pass in global Nordcraft formulas from project + packages here
-    serverContext: getServerToddleObject({} as any),
-  })
-  if (!routeMatch) {
-    return next()
-  }
-  const { route, name: routeName } = routeMatch
-  const destination = getRouteDestination({
-    // might not want to use main branch here
-    env: serverEnv({ branchName: 'main', req: c.req.raw, logErrors: false }),
-    req: c.req.raw,
-    route,
-    // TODO: We should pass in global Nordcraft formulas from project + packages here
-    serverContext: getServerToddleObject({} as any),
-  })
-  if (!destination) {
-    return c.text(`Invalid destination`, {
-      status: 500,
+export const routeHandler: (
+  getConnInfo: (c: Context) => ConnInfo,
+) => Handler<HonoEnv<HonoRoutes & HonoProject>> =
+  (getConnInfo) => async (c, next) => {
+    const url = new URL(c.req.url)
+    const routeMatch = matchRouteForUrl({
+      url,
+      routes: c.var.routes?.routes ?? {},
+      env: serverEnv({ branchName: 'main', req: c.req.raw, logErrors: false }),
+      req: c.req.raw,
+      // TODO: We should pass in global Nordcraft formulas from project + packages here
+      serverContext: getServerToddleObject({} as any),
     })
-  }
-  if (route.type === 'redirect') {
-    if (c.req.raw.method !== 'GET') {
-      return c.text(`Method Not Allowed`, { status: 405 })
+    if (!routeMatch) {
+      return next()
     }
-    // Return a redirect to the destination with the provided status code
-    c.header(REDIRECT_NAME_HEADER, routeName)
-    return c.redirect(destination, route.status ?? 302)
-  }
-
-  // Rewrite handling: fetch the destination and return the response
-  if (c.req.raw.headers.get(REWRITE_HEADER) !== null) {
-    return c.text(`Nordcraft rewrites are not allowed to be recursive`, {
-      status: 500,
+    const { route, name: routeName } = routeMatch
+    const destination = getRouteDestination({
+      // might not want to use main branch here
+      env: serverEnv({ branchName: 'main', req: c.req.raw, logErrors: false }),
+      req: c.req.raw,
+      route,
+      // TODO: We should pass in global Nordcraft formulas from project + packages here
+      serverContext: getServerToddleObject({} as any),
     })
-  }
-  try {
-    const headers = skipCookieHeader(skipHopByHopHeaders(c.req.raw.headers))
-    // Add header to identify that this is a rewrite
-    // This allows us to avoid recursive fetch calls across Nordcraft routes
-    headers.set(REWRITE_HEADER, 'true')
-    // Remove the cf-connecting-ip header if the request is from localhost
-    // This is to prevent cf to throw an error when the requester ip is ::1
-    if ((headers.get('host') ?? '').startsWith('localhost')) {
-      headers.delete('cf-connecting-ip')
-      headers.delete('host')
+    if (!destination) {
+      return c.text(`Invalid destination`, {
+        status: 500,
+      })
     }
-
-    // Override accept + accept-encoding to increase the chance that we can work with the response
-    // from an API fetched during SSR. Many servers don't support br encoding for instance.
-    headers.set('Accept', '*/*')
-    headers.set('Accept-Encoding', 'gzip, deflate')
-
-    const timingKey = 'proxyRequest'
-    startTime(c, timingKey)
-    let response: Response
-    if (destination.origin === url.origin) {
-      // hono.fetch below is treated as any if we don't specify the type of hono explicitly here
-      const hono: Hono<HonoEnv<unknown>, BlankSchema, '/'> = c.get('app')
-      let executionCtx: ExecutionContext | undefined
-      try {
-        executionCtx = c.executionCtx
-      } catch {
-        // In tests, the execution context might not be available
+    if (route.type === 'redirect') {
+      if (c.req.raw.method !== 'GET') {
+        return c.text(`Method Not Allowed`, { status: 405 })
       }
-      response = await hono.fetch(
-        new Request(destination, {
+      // Return a redirect to the destination with the provided status code
+      c.header(REDIRECT_NAME_HEADER, routeName)
+      return c.redirect(destination, route.status ?? 302)
+    }
+
+    // Rewrite handling: fetch the destination and return the response
+    if (c.req.raw.headers.get(REWRITE_HEADER) !== null) {
+      return c.text(`Nordcraft rewrites are not allowed to be recursive`, {
+        status: 500,
+      })
+    }
+    try {
+      const headers = skipCookieHeader(skipHopByHopHeaders(c.req.raw.headers))
+      const ip = normalizeIP(getConnInfo(c).remote.address)
+      if (ip) {
+        headers.set('X-Forwarded-For', ip)
+      }
+      // Add header to identify that this is a rewrite
+      // This allows us to avoid recursive fetch calls across Nordcraft routes
+      headers.set(REWRITE_HEADER, 'true')
+      // Remove the cf-connecting-ip header if the request is from localhost
+      // This is to prevent cf to throw an error when the requester ip is ::1
+      if ((headers.get('host') ?? '').startsWith('localhost')) {
+        headers.delete('cf-connecting-ip')
+        headers.delete('host')
+      }
+
+      // Override accept + accept-encoding to increase the chance that we can work with the response
+      // from an API fetched during SSR. Many servers don't support br encoding for instance.
+      headers.set('Accept', '*/*')
+      headers.set('Accept-Encoding', 'gzip, deflate')
+
+      const timingKey = 'proxyRequest'
+      startTime(c, timingKey)
+      let response: Response
+      if (destination.origin === url.origin) {
+        // hono.fetch below is treated as any if we don't specify the type of hono explicitly here
+        const hono: Hono<HonoEnv<unknown>, BlankSchema, '/'> = c.get('app')
+        let executionCtx: ExecutionContext | undefined
+        try {
+          executionCtx = c.executionCtx
+        } catch {
+          // In tests, the execution context might not be available
+        }
+        response = await hono.fetch(
+          new Request(destination, {
+            method: c.req.raw.method,
+            body: HttpMethodsWithAllowedBody.includes(
+              c.req.raw.method as ApiMethod,
+            )
+              ? c.req.raw.body
+              : undefined,
+            headers,
+          }),
+          c.env,
+          executionCtx,
+        )
+      } else {
+        response = await fetch(destination, {
+          headers,
           method: c.req.raw.method,
           body: HttpMethodsWithAllowedBody.includes(
             c.req.raw.method as ApiMethod,
           )
             ? c.req.raw.body
             : undefined,
-          headers,
-        }),
-        c.env,
-        executionCtx,
+        })
+      }
+      endTime(c, timingKey)
+      // Pass the stream into a new response so we can write the headers
+      const body = NON_BODY_RESPONSE_CODES.includes(response.status)
+        ? undefined
+        : ((response.body ?? new ReadableStream()) as ReadableStream)
+      // Skip hop-by-hop and content-encoding headers. Content-Encoding is handled by compress middleware
+      skipHopByHopHeaders(skipContentEncodingHeader(response.headers))
+        .entries()
+        .forEach(([name, value]) => {
+          c.header(name, value, { append: true })
+        })
+      c.status(response.status as StatusCode)
+      if (body) {
+        return c.body(body)
+      }
+      return c.res
+    } catch {
+      return c.html(
+        `Unable to fetch resource defined in proxy destination: ${destination.href}`,
+        { status: 500 },
       )
-    } else {
-      response = await fetch(destination, {
-        headers,
-        method: c.req.raw.method,
-        body: HttpMethodsWithAllowedBody.includes(c.req.raw.method as ApiMethod)
-          ? c.req.raw.body
-          : undefined,
-      })
     }
-    endTime(c, timingKey)
-    // Pass the stream into a new response so we can write the headers
-    const body = NON_BODY_RESPONSE_CODES.includes(response.status)
-      ? undefined
-      : ((response.body ?? new ReadableStream()) as ReadableStream)
-    // Skip hop-by-hop and content-encoding headers. Content-Encoding is handled by compress middleware
-    skipHopByHopHeaders(skipContentEncodingHeader(response.headers))
-      .entries()
-      .forEach(([name, value]) => {
-        c.header(name, value, { append: true })
-      })
-    c.status(response.status as StatusCode)
-    if (body) {
-      return c.body(body)
-    }
-    return c.res
-  } catch {
-    return c.html(
-      `Unable to fetch resource defined in proxy destination: ${destination.href}`,
-      { status: 500 },
-    )
   }
-}


### PR DESCRIPTION
Include the client's IP address in the X-Forwarded-For header in proxies, similar to how we do for proxied API calls.