### PR TITLE
More accurately display text when editing in canvas

### DIFF
--- a/packages/core/src/utils/getNodeSelector.test.ts
+++ b/packages/core/src/utils/getNodeSelector.test.ts
@@ -54,4 +54,13 @@ describe('getNodeSelector', () => {
     const selector = getNodeSelector(path)
     expect(selector).toBe('[data-id="0.1\\/2"]')
   })
+
+  test('should prefix selector with an underscore if it starts with a number', () => {
+    const path = '0.1\\/2'
+    const selector = getNodeSelector(path, {
+      componentName: '404',
+      nodeId: 'test-node',
+    })
+    expect(selector).toBe('[data-id="0.1\\/2"]._404\\:test-node')
+  })
 })

--- a/packages/core/src/utils/getNodeSelector.ts
+++ b/packages/core/src/utils/getNodeSelector.ts
@@ -19,7 +19,10 @@ export function getNodeSelector(
 ): string {
   let selector = `[data-id="${path}"]`
   if (componentName) {
-    selector += `.${componentName}`
+    // Do not allow classes to start with a number, for example a page named "404" would result in a selector starting with a number which is invalid in CSS.
+    selector += startsWithNumber(componentName)
+      ? `._${componentName}`
+      : `.${componentName}`
   }
   if (nodeId) {
     selector += `\\:${nodeId}`
@@ -31,4 +34,10 @@ export function getNodeSelector(
   }
 
   return selector
+}
+
+function startsWithNumber(str: string): boolean {
+  if (!str) return false
+  const code = str.charCodeAt(0)
+  return code >= 48 && code <= 57
 }

--- a/packages/core/src/utils/measure.test.ts
+++ b/packages/core/src/utils/measure.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, spyOn, beforeEach, afterEach } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
 import { measure } from './measure'
 
 const globalScope = globalThis as any
@@ -11,7 +11,7 @@ describe('measure', () => {
     // Reset global state
     globalScope.__nc_measure_enabled = false
     globalScope.__nc_measure_max_depth = 10
-    
+
     // Mock performance
     originalPerformanceMeasure = performance.measure
     originalPerformanceNow = performance.now
@@ -22,7 +22,7 @@ describe('measure', () => {
     globalScope.sessionStorage = {
       getItem: () => null,
       setItem: () => {},
-      removeItem: () => {}
+      removeItem: () => {},
     }
   })
 
@@ -36,47 +36,50 @@ describe('measure', () => {
     const measureSpy = spyOn(performance, 'measure')
     const key = 'test-key'
     const stop = measure(key, { arg: 1 })
-    
+
     expect(stop).toBeDefined()
     stop()
-    
+
     expect(measureSpy).not.toHaveBeenCalled()
   })
 
   test('should call performance.measure when enabled', () => {
     globalScope.__nc_measure_enabled = true
     const measureSpy = spyOn(performance, 'measure')
-    
+
     let now = 0
     performance.now = () => now++
 
     const key = 'test-performance'
     const stop = measure(key, { arg: 1 })
-    
+
     stop({ extra: 2 })
-    
-    expect(measureSpy).toHaveBeenCalledWith(key, expect.objectContaining({
-      start: 0,
-      end: 1,
-      detail: expect.objectContaining({
-        devtools: expect.objectContaining({
-          track: 'Nordcraft devtools',
-          tooltipText: expect.stringContaining(key)
-        })
-      })
-    }))
+
+    expect(measureSpy).toHaveBeenCalledWith(
+      key,
+      expect.objectContaining({
+        start: 0,
+        end: 1,
+        detail: expect.objectContaining({
+          devtools: expect.objectContaining({
+            track: 'Nordcraft devtools',
+            tooltipText: expect.stringContaining(key),
+          }),
+        }),
+      }),
+    )
   })
 
   test('should merge details and extraDetails', () => {
     globalScope.__nc_measure_enabled = true
     const measureSpy = spyOn(performance, 'measure')
-    
+
     const stop = measure('key', { original: 'value' })
     stop({ extra: 'value' })
-    
+
     const lastCall = measureSpy.mock.calls[0]
     const properties = lastCall[1].detail.devtools.properties
-    
+
     const propsMap = new Map(properties)
     expect(propsMap.get('original')).toBe('value')
     expect(propsMap.get('extra')).toBe('value')
@@ -96,7 +99,7 @@ describe('measure', () => {
 
     stop2()
     expect(measureSpy).toHaveBeenCalledTimes(1)
-    
+
     stop1()
     expect(measureSpy).toHaveBeenCalledTimes(2)
   })
@@ -110,33 +113,37 @@ describe('measure', () => {
 
     stop2()
     const childCall = measureSpy.mock.calls[0]
-    const childStack = new Map(childCall[1].detail.devtools.properties).get('Stack')
+    const childStack = new Map(childCall[1].detail.devtools.properties).get(
+      'Stack',
+    )
     expect(childStack).toBe('parent > child')
 
     stop1()
     const parentCall = measureSpy.mock.calls[1]
-    const parentStack = new Map(parentCall[1].detail.devtools.properties).get('Stack')
+    const parentStack = new Map(parentCall[1].detail.devtools.properties).get(
+      'Stack',
+    )
     expect(parentStack).toBe('parent')
   })
 
   test('should only call finish once', () => {
-     globalScope.__nc_measure_enabled = true
-     const measureSpy = spyOn(performance, 'measure')
-     
-     const stop = measure('once', {})
-     stop()
-     stop()
-     
-     expect(measureSpy).toHaveBeenCalledTimes(1)
+    globalScope.__nc_measure_enabled = true
+    const measureSpy = spyOn(performance, 'measure')
+
+    const stop = measure('once', {})
+    stop()
+    stop()
+
+    expect(measureSpy).toHaveBeenCalledTimes(1)
   })
 
   test('global __nc_enableMeasure should update state', () => {
     // We need to trigger the globalScope mock logic if we want to test the helper function
     // But since it's defined in the module scope of measure.ts, it might already be there
     if (typeof globalScope.__nc_enableMeasure === 'function') {
-        globalScope.__nc_enableMeasure(true, 5)
-        expect(globalScope.__nc_measure_enabled).toBe(true)
-        expect(globalScope.__nc_measure_max_depth).toBe(5)
+      globalScope.__nc_enableMeasure(true, 5)
+      expect(globalScope.__nc_measure_enabled).toBe(true)
+      expect(globalScope.__nc_measure_max_depth).toBe(5)
     }
   })
 })

--- a/packages/core/src/utils/measure.test.ts
+++ b/packages/core/src/utils/measure.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test, spyOn, beforeEach, afterEach } from 'bun:test'
+import { measure } from './measure'
+
+const globalScope = globalThis as any
+
+describe('measure', () => {
+  let originalPerformanceMeasure: any
+  let originalPerformanceNow: any
+
+  beforeEach(() => {
+    // Reset global state
+    globalScope.__nc_measure_enabled = false
+    globalScope.__nc_measure_max_depth = 10
+    
+    // Mock performance
+    originalPerformanceMeasure = performance.measure
+    originalPerformanceNow = performance.now
+    performance.measure = () => ({}) as any
+    performance.now = () => 0
+
+    // Mock sessionStorage
+    globalScope.sessionStorage = {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {}
+    }
+  })
+
+  afterEach(() => {
+    performance.measure = originalPerformanceMeasure
+    performance.now = originalPerformanceNow
+    delete globalScope.sessionStorage
+  })
+
+  test('should do nothing if NOT enabled', () => {
+    const measureSpy = spyOn(performance, 'measure')
+    const key = 'test-key'
+    const stop = measure(key, { arg: 1 })
+    
+    expect(stop).toBeDefined()
+    stop()
+    
+    expect(measureSpy).not.toHaveBeenCalled()
+  })
+
+  test('should call performance.measure when enabled', () => {
+    globalScope.__nc_measure_enabled = true
+    const measureSpy = spyOn(performance, 'measure')
+    
+    let now = 0
+    performance.now = () => now++
+
+    const key = 'test-performance'
+    const stop = measure(key, { arg: 1 })
+    
+    stop({ extra: 2 })
+    
+    expect(measureSpy).toHaveBeenCalledWith(key, expect.objectContaining({
+      start: 0,
+      end: 1,
+      detail: expect.objectContaining({
+        devtools: expect.objectContaining({
+          track: 'Nordcraft devtools',
+          tooltipText: expect.stringContaining(key)
+        })
+      })
+    }))
+  })
+
+  test('should merge details and extraDetails', () => {
+    globalScope.__nc_measure_enabled = true
+    const measureSpy = spyOn(performance, 'measure')
+    
+    const stop = measure('key', { original: 'value' })
+    stop({ extra: 'value' })
+    
+    const lastCall = measureSpy.mock.calls[0]
+    const properties = lastCall[1].detail.devtools.properties
+    
+    const propsMap = new Map(properties)
+    expect(propsMap.get('original')).toBe('value')
+    expect(propsMap.get('extra')).toBe('value')
+  })
+
+  test('should respect max depth', () => {
+    globalScope.__nc_measure_enabled = true
+    globalScope.__nc_measure_max_depth = 2
+    const measureSpy = spyOn(performance, 'measure')
+
+    const stop1 = measure('depth-1', {})
+    const stop2 = measure('depth-2', {})
+    const stop3 = measure('depth-3', {}) // Should be NOOP
+
+    stop3()
+    expect(measureSpy).not.toHaveBeenCalled()
+
+    stop2()
+    expect(measureSpy).toHaveBeenCalledTimes(1)
+    
+    stop1()
+    expect(measureSpy).toHaveBeenCalledTimes(2)
+  })
+
+  test('should handle nested measures and display stack', () => {
+    globalScope.__nc_measure_enabled = true
+    const measureSpy = spyOn(performance, 'measure')
+
+    const stop1 = measure('parent', {})
+    const stop2 = measure('child', {})
+
+    stop2()
+    const childCall = measureSpy.mock.calls[0]
+    const childStack = new Map(childCall[1].detail.devtools.properties).get('Stack')
+    expect(childStack).toBe('parent > child')
+
+    stop1()
+    const parentCall = measureSpy.mock.calls[1]
+    const parentStack = new Map(parentCall[1].detail.devtools.properties).get('Stack')
+    expect(parentStack).toBe('parent')
+  })
+
+  test('should only call finish once', () => {
+     globalScope.__nc_measure_enabled = true
+     const measureSpy = spyOn(performance, 'measure')
+     
+     const stop = measure('once', {})
+     stop()
+     stop()
+     
+     expect(measureSpy).toHaveBeenCalledTimes(1)
+  })
+
+  test('global __nc_enableMeasure should update state', () => {
+    // We need to trigger the globalScope mock logic if we want to test the helper function
+    // But since it's defined in the module scope of measure.ts, it might already be there
+    if (typeof globalScope.__nc_enableMeasure === 'function') {
+        globalScope.__nc_enableMeasure(true, 5)
+        expect(globalScope.__nc_measure_enabled).toBe(true)
+        expect(globalScope.__nc_measure_max_depth).toBe(5)
+    }
+  })
+})

--- a/packages/core/src/utils/measure.ts
+++ b/packages/core/src/utils/measure.ts
@@ -1,5 +1,9 @@
 const globalScope: any = typeof globalThis !== 'undefined' ? globalThis : window
-globalScope.__nc_measure_max_depth = 10
+globalScope.__nc_measure_max_depth =
+  typeof sessionStorage !== 'undefined' &&
+  sessionStorage.getItem('__nc_measure_max_depth')
+    ? parseInt(sessionStorage.getItem('__nc_measure_max_depth')!)
+    : 10
 globalScope.__nc_measure_enabled =
   typeof sessionStorage !== 'undefined' &&
   sessionStorage.getItem('__nc_measure') === 'true'
@@ -7,8 +11,10 @@ globalScope.__nc_measure_enabled =
 globalScope.__nc_enableMeasure = (enabled = true, maxDepth = 10) => {
   if (enabled) {
     sessionStorage.setItem('__nc_measure', 'true')
+    sessionStorage.setItem('__nc_measure_max_depth', String(maxDepth))
   } else {
     sessionStorage.removeItem('__nc_measure')
+    sessionStorage.removeItem('__nc_measure_max_depth')
   }
   globalScope.__nc_measure_enabled = enabled
   globalScope.__nc_measure_max_depth = maxDepth
@@ -18,17 +24,25 @@ let measureCount = 0
 const STACK: string[] = []
 const NOOP = () => {}
 
-export const measure = (key: string, details: Record<string, unknown>) => {
+export const measure = (
+  key: string,
+  details: Record<string, unknown>,
+  type?: 'component',
+) => {
   if (!globalScope.__nc_measure_enabled) {
     return NOOP
   }
 
   const selfIndex = measureCount++
+  const selfStackSize = STACK.length
+  if (selfStackSize >= globalScope.__nc_measure_max_depth) {
+    return NOOP
+  }
   if (STACK.length >= globalScope.__nc_measure_max_depth) {
     return NOOP
   }
 
-  const start = performance.now()
+  const start = performance.now() + selfStackSize * 0.001
   STACK.push(key)
 
   let _stopped = false
@@ -38,7 +52,7 @@ export const measure = (key: string, details: Record<string, unknown>) => {
     }
 
     _stopped = true
-    const end = performance.now()
+    const end = performance.now() + selfStackSize * 0.001
     const mergedDetails = extraDetails
       ? { ...details, ...extraDetails }
       : details
@@ -50,6 +64,7 @@ export const measure = (key: string, details: Record<string, unknown>) => {
         devtools: {
           dataType: 'track-entry',
           track: 'Nordcraft devtools',
+          color: COLOR_MAP[type as keyof typeof COLOR_MAP],
           properties: [
             ...Object.entries(mergedDetails).map(([k, v]) => [k, String(v)]),
             ['Stack', STACK.join(' > ')],
@@ -62,4 +77,8 @@ export const measure = (key: string, details: Record<string, unknown>) => {
     })
     STACK.pop()
   }
+}
+
+const COLOR_MAP = {
+  component: 'secondary',
 }

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -79,10 +79,14 @@ export function renderComponent({
   jsonPath,
   reportFormulaEvaluation,
 }: RenderComponentProps): ReadonlyArray<Element | Text> {
-  const stopMeasure = measure(`Render component: ${component.name}`, {
-    component: component.name,
-    path,
-  })
+  const stopMeasure = measure(
+    `Render component: ${component.name}`,
+    {
+      component: component.name,
+      path,
+    },
+    'component',
+  )
   const ctx: ComponentContext = {
     triggerEvent: onEvent,
     component,

--- a/packages/runtime/src/editor/overlay.ts
+++ b/packages/runtime/src/editor/overlay.ts
@@ -3,8 +3,16 @@ export function getRectData(selectedNode: Element | null | undefined) {
     return null
   }
 
-  const { borderRadius, rotate } = window.getComputedStyle(selectedNode)
-  const rect: DOMRect = selectedNode.getBoundingClientRect()
+  const { borderRadius, rotate, padding, margin, gap } =
+    window.getComputedStyle(selectedNode)
+  let rect: DOMRect
+  if (selectedNode.getAttribute('data-node-type') === 'text') {
+    selectedNode.classList.add('__nc-text-node-measure')
+    rect = selectedNode.getBoundingClientRect()
+    selectedNode.classList.remove('__nc-text-node-measure')
+  } else {
+    rect = selectedNode.getBoundingClientRect()
+  }
 
   return {
     left: rect.left,
@@ -17,5 +25,8 @@ export function getRectData(selectedNode: Element | null | undefined) {
     y: rect.y,
     borderRadius: borderRadius.split(' '),
     rotate,
+    padding: padding.split(' '),
+    margin: margin.split(' '),
+    gap: gap.split(' '),
   }
 }


### PR DESCRIPTION
Also fix an issue where setting component instance styling on a page or component that starts with a number (most commonly page `404`) would not work.

Also improve the performance measurer with colors to differentiate renders and formulas.