### PR TITLE
Improve multipart/form-data API encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -7,6 +7,7 @@ import {
   getRequestPath,
   getRequestQueryParams,
   getUrl,
+  toFormData,
 } from './api'
 import type { ApiRequest } from './apiTypes'
 import { ApiMethod } from './apiTypes'
@@ -416,5 +417,72 @@ describe('getRequestBody', () => {
       method: ApiMethod.POST,
     })
     expect(body).toBeInstanceOf(File)
+  })
+})
+
+describe('toFormData()', () => {
+  it('converts a simple object to FormData', () => {
+    const body = {
+      name: 'John Doe',
+      age: 30,
+      active: true,
+    }
+    const formData = toFormData(body)
+    expect(formData.get('name')).toBe('John Doe')
+    expect(formData.get('age')).toBe('30')
+    expect(formData.get('active')).toBe('true')
+  })
+
+  it('handles arrays by appending multiple values', () => {
+    const body = {
+      tags: ['tag1', 'tag2'],
+    }
+    const formData = toFormData(body)
+    expect(formData.getAll('tags')).toEqual(['tag1', 'tag2'])
+  })
+
+  it('skips null and undefined values', () => {
+    const body = {
+      name: 'John Doe',
+      age: null,
+      active: undefined,
+    }
+    const formData = toFormData(body)
+    expect(formData.get('name')).toBe('John Doe')
+    expect(formData.has('age')).toBe(false)
+    expect(formData.has('active')).toBe(false)
+  })
+
+  it('handles nested objects by stringifying them', () => {
+    const body = {
+      user: { id: 1, name: 'John' },
+    }
+    const formData = toFormData(body)
+    expect(formData.get('user')).toBe(JSON.stringify(body.user))
+  })
+
+  it('handles File and Blob objects', () => {
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' })
+    const blob = new Blob(['blob content'], {
+      type: 'application/octet-stream',
+    })
+    const body = {
+      file,
+      blob,
+    }
+    const formData = toFormData(body)
+    expect(formData.get('file')).toBeInstanceOf(File)
+    expect((formData.get('file') as File).name).toBe('test.txt')
+    expect(formData.get('blob')).toBeInstanceOf(Blob)
+  })
+
+  it('skips unsupported value types', () => {
+    const body = {
+      fn: () => {},
+      valid: 'working',
+    }
+    const formData = toFormData(body)
+    expect(formData.has('fn')).toBe(false)
+    expect(formData.get('valid')).toBe('working')
   })
 })

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -367,13 +367,11 @@ export const getRequestBody = ({
       return ''
     }
     case 'multipart/form-data': {
-      const formData = new FormData()
       if (typeof body === 'object' && body !== null) {
-        Object.entries(body).forEach(([key, value]) => {
-          formData.set(key, value as string | Blob)
-        })
+        return toFormData(body)
+      } else {
+        return new FormData()
       }
-      return formData
     }
     case 'text/plain':
       return String(body)
@@ -381,6 +379,37 @@ export const getRequestBody = ({
       // For other content types, we return the body as is
       return body
   }
+}
+
+/**
+ * Converts a plain object to FormData, supporting nested objects and arrays.
+ */
+export const toFormData = (body: Record<string, unknown>): FormData => {
+  const formData = new FormData()
+  for (const [key, value] of Object.entries(body)) {
+    if (value === null || value === undefined) {
+      continue
+    }
+    const values = Array.isArray(value) ? value : [value]
+    for (const v of values) {
+      if (v === null || v === undefined) {
+        continue
+      }
+      if (v instanceof File) {
+        formData.append(key, v, v.name)
+      } else if (v instanceof Blob) {
+        formData.append(key, v)
+      } else if (['string', 'number', 'boolean'].includes(typeof v)) {
+        formData.append(key, String(v))
+      } else if (typeof v === 'object') {
+        formData.append(key, JSON.stringify(v))
+      } else {
+        // Unsupported value type
+        continue
+      }
+    }
+  }
+  return formData
 }
 
 export const createApiEvent = (


### PR DESCRIPTION

- Support nested arrays
- Support primitive values (string, number, boolean) explicitly
- Use JSON.stringify for nested objects
- Support File and Blob types directly
- Support multiple File/Blob values for the same key (e.g., arrays of files)
  