### PR TITLE
Change API redirect statusCode type to formula

### DIFF
--- a/packages/backend/src/utils/api.test.ts
+++ b/packages/backend/src/utils/api.test.ts
@@ -6,7 +6,7 @@ import type {
 } from '@nordcraft/core/dist/formula/formula'
 import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 import { beforeEach, describe, expect, it, spyOn } from 'bun:test'
-import { evaluateComponentApis } from './api'
+import { evaluateComponentApis, RedirectError } from './api'
 
 const spyFetch = spyOn(globalThis, 'fetch')
 
@@ -319,5 +319,237 @@ describe('evaluateComponentApis', () => {
       receivedToken: 'my-session-id',
     })
     expect(spyFetch).toHaveBeenCalled()
+  })
+
+  it('should trigger redirect if redirectRule returns a string', async () => {
+    const mockApi = new ToddleApiV2(
+      {
+        name: 'testApi',
+        version: 2,
+        type: 'http',
+        url: { type: 'value', value: 'https://example.com/api' },
+        method: ApiMethod.GET,
+        inputs: {},
+        autoFetch: { type: 'value', value: true },
+        server: {
+          ssr: { enabled: { formula: valueFormula(true) } },
+        },
+        redirectRules: {
+          rule1: {
+            formula: { type: 'value', value: '/login' },
+            index: 0,
+          },
+        },
+      },
+      'testApi',
+      {},
+    )
+
+    const formulaContext: FormulaContext = {
+      component: { name: 'TestComponent' },
+      data: { Apis: {}, Variables: {}, Attributes: {}, Contexts: {} },
+      package: null,
+      toddle: {
+        getFormula: () => undefined,
+        getCustomFormula: () => undefined,
+        errors: [],
+      },
+      env: {
+        branchName: 'main',
+        isServer: true,
+        request: {
+          headers: {},
+          cookies: {},
+          url: 'http://localhost:3000/page',
+        },
+        logErrors: false,
+      } as ToddleServerEnv,
+    }
+
+    const mockResponse = async () =>
+      new Response(JSON.stringify({ redirect: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }) as any
+
+    spyFetch.mockImplementation(mockResponse as any)
+
+    try {
+      await evaluateComponentApis({
+        component: {
+          name: 'TestComponent',
+          apis: { testApi: mockApi },
+        } as any,
+        formulaContext,
+        req: new Request('http://localhost:3000/page'),
+        apiCache: {},
+        updateApiCache: () => {},
+      })
+      throw new Error('Should have thrown RedirectError')
+    } catch (e) {
+      expect(e).toBeInstanceOf(RedirectError)
+      const redirectError = e as RedirectError
+      expect(redirectError.redirect.url.href).toBe(
+        'http://localhost:3000/login',
+      )
+      expect(redirectError.redirect.statusCode).toBe(302)
+    }
+  })
+
+  it('should use numeric status code in redirectRule', async () => {
+    const mockApi = new ToddleApiV2(
+      {
+        name: 'testApi',
+        version: 2,
+        type: 'http',
+        url: { type: 'value', value: 'https://example.com/api' },
+        method: ApiMethod.GET,
+        inputs: {},
+        autoFetch: { type: 'value', value: true },
+        server: {
+          ssr: { enabled: { formula: valueFormula(true) } },
+        },
+        redirectRules: {
+          rule1: {
+            formula: { type: 'value', value: '/login' },
+            index: 0,
+            statusCode: valueFormula(301),
+          },
+        },
+      },
+      'testApi',
+      {},
+    )
+
+    const formulaContext: FormulaContext = {
+      component: { name: 'TestComponent' },
+      data: { Apis: {}, Variables: {}, Attributes: {}, Contexts: {} },
+      package: null,
+      toddle: {
+        getFormula: () => undefined,
+        getCustomFormula: () => undefined,
+        errors: [],
+      },
+      env: {
+        branchName: 'main',
+        isServer: true,
+        request: {
+          headers: {},
+          cookies: {},
+          url: 'http://localhost:3000/page',
+        },
+        logErrors: false,
+      } as ToddleServerEnv,
+    }
+
+    const mockResponse = async () =>
+      new Response(JSON.stringify({ redirect: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }) as any
+
+    spyFetch.mockImplementation(mockResponse as any)
+
+    try {
+      await evaluateComponentApis({
+        component: {
+          name: 'TestComponent',
+          apis: { testApi: mockApi },
+        } as any,
+        formulaContext,
+        req: new Request('http://localhost:3000/page'),
+        apiCache: {},
+        updateApiCache: () => {},
+      })
+      throw new Error('Should have thrown RedirectError')
+    } catch (e) {
+      expect(e).toBeInstanceOf(RedirectError)
+      const redirectError = e as RedirectError
+      expect(redirectError.redirect.url.href).toBe(
+        'http://localhost:3000/login',
+      )
+      expect(redirectError.redirect.statusCode).toBe(301)
+    }
+  })
+
+  it('should support formula for redirectRule status code', async () => {
+    const mockApi = new ToddleApiV2(
+      {
+        name: 'testApi',
+        version: 2,
+        type: 'http',
+        url: { type: 'value', value: 'https://example.com/api' },
+        method: ApiMethod.GET,
+        inputs: {},
+        autoFetch: { type: 'value', value: true },
+        server: {
+          ssr: { enabled: { formula: valueFormula(true) } },
+        },
+        redirectRules: {
+          rule1: {
+            formula: { type: 'value', value: '/login' },
+            index: 0,
+            statusCode: {
+              type: 'path',
+              path: ['Apis', 'testApi', 'response', 'status'],
+            } as any,
+          },
+        },
+      },
+      'testApi',
+      {},
+    )
+
+    const formulaContext: FormulaContext = {
+      component: { name: 'TestComponent' },
+      data: { Apis: {}, Variables: {}, Attributes: {}, Contexts: {} },
+      package: null,
+      toddle: {
+        getFormula: () => undefined,
+        getCustomFormula: () => undefined,
+        errors: [],
+      },
+      env: {
+        branchName: 'main',
+        isServer: true,
+        request: {
+          headers: {},
+          cookies: {},
+          url: 'http://localhost:3000/page',
+        },
+        logErrors: false,
+      } as ToddleServerEnv,
+    }
+
+    const mockResponse = async () =>
+      new Response(JSON.stringify({ redirect: true }), {
+        status: 307,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }) as any
+
+    spyFetch.mockImplementation(mockResponse as any)
+
+    try {
+      await evaluateComponentApis({
+        component: {
+          name: 'TestComponent',
+          apis: { testApi: mockApi },
+        } as any,
+        formulaContext,
+        req: new Request('http://localhost:3000/page'),
+        apiCache: {},
+        updateApiCache: () => {},
+      })
+      throw new Error('Should have thrown RedirectError')
+    } catch (e) {
+      expect(e).toBeInstanceOf(RedirectError)
+      const redirectError = e as RedirectError
+      expect(redirectError.redirect.url.href).toBe(
+        'http://localhost:3000/login',
+      )
+      expect(redirectError.redirect.statusCode).toBe(307)
+    }
   })
 })

--- a/packages/backend/src/utils/api.ts
+++ b/packages/backend/src/utils/api.ts
@@ -5,13 +5,14 @@ import {
   requestHash,
   sortApiEntries,
 } from '@nordcraft/core/dist/api/api'
-import type {
-  ApiMethod,
-  ApiParserMode,
-  ApiPerformance,
-  ApiStatus,
-  LegacyApiStatus,
-  RedirectStatusCode,
+import {
+  REDIRECT_STATUS_CODES,
+  type ApiMethod,
+  type ApiParserMode,
+  type ApiPerformance,
+  type ApiStatus,
+  type LegacyApiStatus,
+  type RedirectStatusCode,
 } from '@nordcraft/core/dist/api/apiTypes'
 import {
   isJsonHeader,
@@ -137,9 +138,7 @@ const fetchApi = async ({
   }
 
   const ssrEnabled = isDefined(api.server?.ssr?.enabled)
-    ? toBoolean(
-        applyFormula(api.server?.ssr?.enabled.formula, newFormulaContext),
-      )
+    ? toBoolean(applyFormula(api.server.ssr.enabled.formula, newFormulaContext))
     : false
 
   const autoFetch = isDefined(api.autoFetch)
@@ -297,7 +296,7 @@ const fetchApiV2 = async ({
     Object.values(api.redirectRules ?? {}),
     (rule) => rule.index,
   ).forEach((rule) => {
-    const location = applyFormula(rule.formula, {
+    const ruleContext: FormulaContext = {
       ...formulaContext,
       data: {
         ...formulaContext.data,
@@ -305,7 +304,8 @@ const fetchApiV2 = async ({
           [api.name]: apiStatus,
         },
       },
-    })
+    }
+    const location = applyFormula(rule.formula, ruleContext)
     if (typeof location === 'string') {
       const url = validateUrl({
         path: location,
@@ -313,10 +313,15 @@ const fetchApiV2 = async ({
       })
       if (url) {
         // Opt out early to avoid additional API requests/rendering
+        let statusCode = applyFormula(rule.statusCode, ruleContext)
+        statusCode =
+          typeof statusCode === 'number' &&
+          REDIRECT_STATUS_CODES.includes(statusCode as RedirectStatusCode)
+            ? statusCode
+            : 302
         throw new RedirectError({
           url,
-          statusCode:
-            typeof rule.statusCode === 'number' ? rule.statusCode : undefined,
+          statusCode,
           componentName,
           apiName: api.name,
         })

--- a/packages/backend/src/utils/api.ts
+++ b/packages/backend/src/utils/api.ts
@@ -313,12 +313,18 @@ const fetchApiV2 = async ({
       })
       if (url) {
         // Opt out early to avoid additional API requests/rendering
-        let statusCode = applyFormula(rule.statusCode, ruleContext)
-        statusCode =
-          typeof statusCode === 'number' &&
-          REDIRECT_STATUS_CODES.includes(statusCode as RedirectStatusCode)
-            ? statusCode
-            : 302
+        let statusCode = 302 as RedirectStatusCode
+        if (isDefined(rule.statusCode)) {
+          const statusCodeResult = applyFormula(rule.statusCode, ruleContext)
+          if (
+            typeof statusCodeResult === 'number' &&
+            REDIRECT_STATUS_CODES.includes(
+              statusCodeResult as RedirectStatusCode,
+            )
+          ) {
+            statusCode = statusCodeResult as RedirectStatusCode
+          }
+        }
         throw new RedirectError({
           url,
           statusCode,

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -42,7 +42,10 @@ export enum ApiMethod {
   OPTIONS = 'OPTIONS',
 }
 
-export type RedirectStatusCode = 300 | 301 | 302 | 303 | 304 | 307 | 308
+
+export const REDIRECT_STATUS_CODES = [300, 301, 302, 303, 304, 307, 308] as const
+
+export type RedirectStatusCode = typeof REDIRECT_STATUS_CODES[number]
 
 export type ApiParserMode =
   | 'auto'
@@ -122,7 +125,7 @@ export interface ApiRequest extends ApiBase {
         // A redirect response will be returned if the formula returns a valid url
         formula: Formula
         // The status code used in the redirect response. Only relevant server side
-        statusCode?: Nullable<RedirectStatusCode>
+        statusCode?: Nullable<Formula>
         index: number
       }
     >

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -42,10 +42,11 @@ export enum ApiMethod {
   OPTIONS = 'OPTIONS',
 }
 
+export const REDIRECT_STATUS_CODES = [
+  300, 301, 302, 303, 304, 307, 308,
+] as const
 
-export const REDIRECT_STATUS_CODES = [300, 301, 302, 303, 304, 307, 308] as const
-
-export type RedirectStatusCode = typeof REDIRECT_STATUS_CODES[number]
+export type RedirectStatusCode = (typeof REDIRECT_STATUS_CODES)[number]
 
 export type ApiParserMode =
   | 'auto'


### PR DESCRIPTION
To allow more flexibility, the redirect status code should be a formula instead of a number. Since the `statusCode` property has never been used, it should be safe to change its type. Also - even if it had previously been set to a `number`, `applyFormula` would still return a number.