### PR TITLE
Visit API redirect rule status code formulas

### DIFF
--- a/packages/core/src/api/ToddleApiV2.ts
+++ b/packages/core/src/api/ToddleApiV2.ts
@@ -279,6 +279,11 @@ export class ToddleApiV2<Handler> implements ApiRequest {
         globalFormulas: this.globalFormulas,
         path: ['apis', apiKey, 'redirectRules', rule, 'formula'],
       })
+      yield* getFormulasInFormula({
+        formula: value.statusCode,
+        globalFormulas: this.globalFormulas,
+        path: ['apis', apiKey, 'redirectRules', rule, 'statusCode'],
+      })
     }
     yield* getFormulasInFormula({
       formula: api.isError?.formula,

--- a/packages/search/src/rules/issues/formulas/noReferenceComponentFormulaRule.test.ts
+++ b/packages/search/src/rules/issues/formulas/noReferenceComponentFormulaRule.test.ts
@@ -1,6 +1,9 @@
+import { ApiMethod } from '@nordcraft/core/dist/api/apiTypes'
 import { HeadTagTypes } from '@nordcraft/core/dist/component/component.types'
+import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 import { describe, expect, test } from 'bun:test'
 import { searchProject } from '../../../searchProject'
+import type { IssueResult } from '../../../types'
 import { noReferenceComponentFormulaRule } from './noReferenceComponentFormulaRule'
 
 describe('noReferenceComponentFormulaRule', () => {
@@ -55,9 +58,10 @@ describe('noReferenceComponentFormulaRule', () => {
       }),
     )
 
-    expect(problems).toHaveLength(1)
-    expect(problems[0].code).toBe('no-reference component formula')
-    expect(problems[0].path).toEqual([
+    const issues = problems as IssueResult[]
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe('no-reference component formula')
+    expect(issues[0].path).toEqual([
       'components',
       'page',
       'formulas',
@@ -129,6 +133,101 @@ describe('noReferenceComponentFormulaRule', () => {
                       tag: HeadTagTypes.Script,
                       attrs: {},
                       content: {
+                        type: 'apply',
+                        name: 'my-formula2',
+                        arguments: [],
+                      },
+                    },
+                  },
+                },
+                path: [],
+                query: {},
+              },
+            },
+          },
+        },
+        rules: [noReferenceComponentFormulaRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+  test('should not detect other component formulas with references', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            page: {
+              name: 'my-page',
+              nodes: {},
+              formulas: {
+                'my-formula': {
+                  name: 'my-formula',
+                  formula: {
+                    type: 'function',
+                    name: '@toddle/number',
+                    arguments: [
+                      {
+                        name: 'Input',
+                        formula: { type: 'value', value: 5 },
+                      },
+                    ],
+                  },
+                  arguments: [],
+                  memoize: false,
+                  exposeInContext: true,
+                  '@nordcraft/metadata': {
+                    comments: null,
+                  },
+                },
+                'my-formula2': {
+                  name: 'my-formula2',
+                  formula: {
+                    type: 'function',
+                    name: '@toddle/number',
+                    arguments: [],
+                  },
+                  arguments: [],
+                  memoize: false,
+                  exposeInContext: true,
+                  '@nordcraft/metadata': {
+                    comments: null,
+                  },
+                },
+              },
+              apis: {
+                myApi: {
+                  name: 'myApi',
+                  type: 'http',
+                  version: 2,
+                  url: valueFormula('https://example.com'),
+                  method: ApiMethod.GET,
+                  autoFetch: valueFormula(true),
+                  inputs: {},
+                  queryParams: {},
+                  headers: {},
+                  redirectRules: {
+                    rule1: {
+                      formula: valueFormula(true),
+                      statusCode: {
+                        type: 'apply',
+                        name: 'my-formula',
+                        arguments: [],
+                      },
+                      index: 0,
+                    },
+                  },
+                },
+              },
+              attributes: {},
+              variables: {},
+              route: {
+                info: {
+                  meta: {
+                    xyz: {
+                      tag: HeadTagTypes.Script,
+                      attrs: {},
+                      enabled: {
                         type: 'apply',
                         name: 'my-formula2',
                         arguments: [],
@@ -277,10 +376,11 @@ describe('noReferenceComponentFormulaRule', () => {
         rules: [noReferenceComponentFormulaRule],
       }),
     )
+    const issues = problems as IssueResult[]
 
-    expect(problems).toHaveLength(1)
-    expect(problems[0].code).toBe('no-reference component formula')
-    expect(problems[0].details).toEqual({
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe('no-reference component formula')
+    expect(issues[0].details).toEqual({
       contextSubscribers: ['my-component'],
       name: 'my-formula',
     })
@@ -332,9 +432,10 @@ describe('noReferenceComponentFormulaRule', () => {
       }),
     )
 
-    expect(problems).toHaveLength(1)
-    expect(problems[0].code).toBe('no-reference component formula')
-    expect(problems[0].path).toEqual([
+    const issues = problems as IssueResult[]
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe('no-reference component formula')
+    expect(issues[0].path).toEqual([
       'components',
       'page',
       'formulas',

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -14,7 +14,6 @@
     "strict": true,
     "strictBuiltinIteratorReturn": true,
     "target": "ESNext",
-    "types": ["bun"],
     "verbatimModuleSyntax": true
   },
   "include": ["src"],

--- a/packages/ssr/src/utils/routes.ts
+++ b/packages/ssr/src/utils/routes.ts
@@ -31,6 +31,11 @@ export type ProjectFilesWithCustomCode = ProjectFiles & {
 
 export type Files = Record<string, ProjectFilesWithCustomCode>
 
+export type ProjectWithConfig = {
+  project: ToddleProject
+  config: ProjectFiles['config']
+}
+
 export const splitRoutes = ({
   branchName,
   files,
@@ -40,7 +45,7 @@ export const splitRoutes = ({
   files: ProjectFiles
   project: ToddleProject
 }): {
-  project: { project: ToddleProject; config: ProjectFiles['config'] }
+  project: ProjectWithConfig
   routes: Routes
   files: Files
   styles: Record<string, string>

--- a/packages/ssr/src/utils/routes.ts
+++ b/packages/ssr/src/utils/routes.ts
@@ -20,7 +20,7 @@ import { getServerToddleObject } from '../rendering/formulaContext'
 import { removeTestData } from '../rendering/testData'
 import type { ProjectFiles, Route, ToddleProject } from '../ssr.types'
 
-interface Routes {
+export interface Routes {
   pages: Record<string, { name: string; route: RouteDeclaration }>
   routes: Record<string, Route>
 }


### PR DESCRIPTION

- Ensure formulas for status code for API redirect rules are visited when we find all formula references
- Add tests to ensure this is working correctly
- Also test that the `enabled` formula on meta tags is visited when we find all formula references
- Expose a type
  