### PR TITLE
Include API dependency info in SSR serialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Check runtime file size
         run: |
           FILE=./dist/page.main.esm.js
-          MAX_SIZE=100000
+          MAX_SIZE=102400
           ACTUAL_SIZE=$(stat -c%s "$FILE")
           if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
             echo "Error: $FILE is larger than 100KB ($ACTUAL_SIZE bytes)" >&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,19 +206,19 @@ jobs:
       - name: Check runtime file size
         run: |
           FILE=./dist/page.main.esm.js
-          MAX_SIZE=128000
+          MAX_SIZE=100000
           ACTUAL_SIZE=$(stat -c%s "$FILE")
           if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
-            echo "Error: $FILE is larger than 128KB ($ACTUAL_SIZE bytes)" >&2
+            echo "Error: $FILE is larger than 100KB ($ACTUAL_SIZE bytes)" >&2
             exit 1
           fi
       - name: Check custom element runtime file size
         run: |
           FILE=./dist/custom-element.main.esm.js
-          MAX_SIZE=130000
+          MAX_SIZE=118000
           ACTUAL_SIZE=$(stat -c%s "$FILE")
           if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
-            echo "Error: $FILE is larger than 130KB ($ACTUAL_SIZE bytes)" >&2
+            echo "Error: $FILE is larger than 118KB ($ACTUAL_SIZE bytes)" >&2
             exit 1
           fi
   test-assets-server:

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "8.62.1",
         "@typescript-eslint/parser": "8.62.1",
         "@typescript/native-preview": "7.0.0-dev.20260318.1",
-        "esbuild": "0.27.2",
+        "esbuild": "0.28.1",
         "eslint": "10.6.0",
         "happy-dom": "20.10.6",
         "prettier": "3.8.3",
@@ -127,57 +127,57 @@
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.2", "", { "os": "android", "cpu": "arm64" }, "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.2", "", { "os": "android", "cpu": "x64" }, "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.2", "", { "os": "linux", "cpu": "arm" }, "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.2", "", { "os": "none", "cpu": "x64" }, "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -427,7 +427,7 @@
 
     "es-html-parser": ["es-html-parser@0.3.1", "", {}, "sha512-YTEasG4xt7FEN4b6qJIPbFo/fzQ5kjRMEQ33QMqSXTvfXqAbC2rHxo32x2/1Rhq7Mlu6wI3MIpM5Kf2VHPXrUQ=="],
 
-    "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -659,8 +659,6 @@
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
-    "wrangler/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
     "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
@@ -680,58 +678,6 @@
     "eslint/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "happy-dom/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
-
-    "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
-
-    "wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
-
-    "wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
-
-    "wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
-
-    "wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
-
-    "wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
-
-    "wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
-
-    "wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
-
-    "wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
-
-    "wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
-
-    "wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
-
-    "wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
-
-    "wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
-
-    "wrangler/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
-
-    "wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
-
-    "wrangler/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
-
-    "wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
-
-    "wrangler/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
-
-    "wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
-
-    "wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
-
-    "wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
-
-    "wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/eslint-plugin": "8.62.1",
     "@typescript-eslint/parser": "8.62.1",
     "@typescript/native-preview": "7.0.0-dev.20260318.1",
-    "esbuild": "0.27.2",
+    "esbuild": "0.28.1",
     "eslint": "10.6.0",
     "happy-dom": "20.10.6",
     "prettier-plugin-organize-imports": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/backend/src/routes/nordcraftPage.ts
+++ b/packages/backend/src/routes/nordcraftPage.ts
@@ -1,14 +1,13 @@
 import type { PageComponent } from '@nordcraft/core/dist/component/component.types'
-import { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
-import { type ToddleServerEnv } from '@nordcraft/core/dist/formula/formula'
 import {
   theme as defaultTheme,
   THEME_DATA_ATTRIBUTE,
 } from '@nordcraft/core/dist/styling/theme.const'
 import type { ToddleInternals } from '@nordcraft/core/dist/types'
-import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
+import { toBoolean } from '@nordcraft/core/dist/utils/util'
 import { takeIncludedComponents } from '@nordcraft/ssr/dist/components/utils'
 import type { ApiCache } from '@nordcraft/ssr/dist/rendering/api'
+import { processComponentApis } from '@nordcraft/ssr/dist/rendering/api'
 import { resolveClasses } from '@nordcraft/ssr/dist/rendering/classes'
 import { renderPageBody } from '@nordcraft/ssr/dist/rendering/components'
 import { getPageFormulaContext } from '@nordcraft/ssr/dist/rendering/formulaContext'
@@ -40,7 +39,7 @@ export const nordcraftPage = async ({
   hono,
   project,
   files,
-  page,
+  page: _page,
   status,
   options,
 }: {
@@ -55,6 +54,7 @@ export const nordcraftPage = async ({
   const nordcraftPageTimingKey = 'nordcraftPage'
   startTime(hono, nordcraftPageTimingKey, 'The total render time for a page')
   const url = new URL(hono.req.raw.url)
+  const page = processComponentApis(_page, files)
   const formulaContext = getPageFormulaContext({
     component: page,
     branchName: 'main',
@@ -79,29 +79,7 @@ export const nordcraftPage = async ({
     projectComponents: files.components,
     packages: files.packages,
     includeRoot: true,
-  })
-
-  const toddleComponent = new ToddleComponent<string>({
-    component: page,
-    getComponent: (name, packageName) => {
-      const nodeLookupKey = [packageName, name].filter(isDefined).join('/')
-      const component = packageName
-        ? files.packages?.[packageName]?.components[name]
-        : files.components[name]
-      if (!component) {
-        // eslint-disable-next-line no-console
-        console.warn(`Unable to find component ${nodeLookupKey} in files`)
-        return undefined
-      }
-
-      return component
-    },
-    packageName: undefined,
-    globalFormulas: {
-      formulas: files.formulas,
-      packages: files.packages,
-    },
-  })
+  }).map((component) => processComponentApis(component, files))
 
   let apiCache: ApiCache
   let body: string
@@ -113,9 +91,9 @@ export const nordcraftPage = async ({
       'The time taken to render the page body - including API calls',
     )
     const pageBody = await renderPageBody({
-      component: toddleComponent,
+      component: page,
       formulaContext,
-      env: formulaContext.env as ToddleServerEnv,
+      env: formulaContext.env,
       req: hono.req.raw,
       files: files,
       includedComponents,
@@ -145,7 +123,7 @@ export const nordcraftPage = async ({
       resetStylesheetPath: '/_static/reset.css',
       // This refers to the generated stylesheet for each page
       pageStylesheetPath: options.pageStylesheetUrl(page.name),
-      page: toddleComponent,
+      page,
       files: files,
       project,
       context: formulaContext,
@@ -154,7 +132,7 @@ export const nordcraftPage = async ({
     }),
   })
   const charset = getCharset({
-    pageInfo: toddleComponent.route?.info,
+    pageInfo: page.route?.info,
     formulaContext,
   })
 

--- a/packages/backend/src/utils/api.ts
+++ b/packages/backend/src/utils/api.ts
@@ -3,7 +3,6 @@ import {
   HttpMethodsWithAllowedBody,
   isApiError,
   requestHash,
-  sortApiEntries,
 } from '@nordcraft/core/dist/api/api'
 import {
   REDIRECT_STATUS_CODES,
@@ -25,7 +24,11 @@ import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import { easySort } from '@nordcraft/core/dist/utils/collections'
 import { validateUrl } from '@nordcraft/core/dist/utils/url'
 import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
-import type { ApiCache, ApiEvaluator } from '@nordcraft/ssr/dist/rendering/api'
+import {
+  sortApiEntries,
+  type ApiCache,
+  type ApiEvaluator,
+} from '@nordcraft/ssr/dist/rendering/api'
 import {
   applyTemplateValues,
   sanitizeProxyHeaders,
@@ -42,7 +45,8 @@ export const evaluateComponentApis: ApiEvaluator = async ({
 
   // We only support v2 APIs in this function
   const sortedApis: [string, ToddleApiV2<string>][] = []
-  sortApiEntries(Object.entries(component.apis)).forEach(
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  sortApiEntries(Object.entries(component.apis ?? {})).forEach(
     ([key, api]) => api instanceof ToddleApiV2 && sortedApis.push([key, api]),
   )
 
@@ -51,7 +55,7 @@ export const evaluateComponentApis: ApiEvaluator = async ({
     await Promise.all(
       // Evaluate independent API requests in parallel
       sortedApis
-        .filter(([_, api]) => api.apiReferences.size === 0)
+        .filter(([_, api]) => api.dependsOn.length === 0)
         .map(async ([name, api]) => {
           const { response, cacheKey } = await fetchApi({
             api,
@@ -72,7 +76,7 @@ export const evaluateComponentApis: ApiEvaluator = async ({
     ...independentApiResponses,
   }
   const dependentApis = sortedApis.filter(
-    ([_, api]) => api.apiReferences.size > 0,
+    ([_, api]) => api.dependsOn.length > 0,
   )
   const dependentApiResponses: Record<string, LegacyApiStatus | ApiStatus> = {}
   for (const [_, api] of dependentApis) {

--- a/packages/core/src/api/LegacyToddleApi.ts
+++ b/packages/core/src/api/LegacyToddleApi.ts
@@ -135,6 +135,9 @@ export class LegacyToddleApi<Handler> {
   get onFailed() {
     return this.api.onFailed
   }
+  get dependsOn() {
+    return this.api.dependsOn
+  }
   *formulasInApi(): Generator<{
     path: (string | number)[]
     formula: Formula

--- a/packages/core/src/api/ToddleApiV2.ts
+++ b/packages/core/src/api/ToddleApiV2.ts
@@ -27,7 +27,7 @@ export class ToddleApiV2<Handler> implements ApiRequest {
     this.globalFormulas = globalFormulas
   }
 
-  get apiReferences(): Set<string> {
+  private get apiReferences(): Set<string> {
     if (this._apiReferences) {
       // Only compute apiReferences once
       return this._apiReferences
@@ -172,6 +172,10 @@ export class ToddleApiV2<Handler> implements ApiRequest {
 
   get '@nordcraft/metadata'() {
     return this.api['@nordcraft/metadata']
+  }
+
+  get dependsOn() {
+    return Array.from(this.apiReferences)
   }
 
   *formulasInApi(): Generator<{

--- a/packages/core/src/api/api.test.ts
+++ b/packages/core/src/api/api.test.ts
@@ -7,10 +7,13 @@ import {
   getRequestPath,
   getRequestQueryParams,
   getUrl,
+  isLegacyApi,
   toFormData,
 } from './api'
 import type { ApiRequest } from './apiTypes'
 import { ApiMethod } from './apiTypes'
+import { LegacyToddleApi } from './LegacyToddleApi'
+import { ToddleApiV2 } from './ToddleApiV2'
 
 describe('getApiPath()', () => {
   test('it returns a valid url path string', () => {
@@ -484,5 +487,49 @@ describe('toFormData()', () => {
     const formData = toFormData(body)
     expect(formData.has('fn')).toBe(false)
     expect(formData.get('valid')).toBe('working')
+  })
+})
+describe('isLegacyApi()', () => {
+  test('it checks if an API is legacy', () => {
+    expect(
+      isLegacyApi({
+        name: 'Legacy API',
+        type: 'REST',
+      }),
+    ).toBe(true)
+    expect(
+      isLegacyApi({
+        name: 'New API',
+        type: 'http',
+        version: 2,
+        inputs: {},
+      }),
+    ).toBe(false)
+    expect(
+      isLegacyApi(
+        new LegacyToddleApi(
+          {
+            name: 'Legacy API',
+            type: 'REST',
+          },
+          'myLegacyApi',
+          {},
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      isLegacyApi(
+        new ToddleApiV2(
+          {
+            name: 'New API',
+            type: 'http',
+            version: 2,
+            inputs: {},
+          },
+          'myNewApi',
+          {},
+        ),
+      ),
+    ).toBe(false)
   })
 })

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -15,7 +15,7 @@ import type {
 import { ApiMethod } from './apiTypes'
 import { isJsonHeader } from './headers'
 import { LegacyToddleApi } from './LegacyToddleApi'
-import { ToddleApiV2 } from './ToddleApiV2'
+import type { ToddleApiV2 } from './ToddleApiV2'
 
 export const NON_BODY_RESPONSE_CODES = [101, 204, 205, 304]
 
@@ -420,62 +420,3 @@ export const createApiEvent = (
     detail,
   })
 }
-
-const compareApiDependencies = <Handler>(
-  a: LegacyToddleApi<Handler> | ToddleApiV2<Handler>,
-  b: LegacyToddleApi<Handler> | ToddleApiV2<Handler>,
-) => {
-  const isADependentOnB = a.apiReferences.has(b.name)
-  const isBDependentOnA = b.apiReferences.has(a.name)
-  if (isADependentOnB === isBDependentOnA) {
-    return 0
-  }
-  // 1 means A goes last - hence B is evaluated before A
-  return isADependentOnB ? 1 : -1
-}
-
-export const sortApiObjects = <Handler>(
-  apis: Array<[string, ComponentAPI]>,
-) => {
-  const apiMap = new Map<
-    string,
-    LegacyToddleApi<Handler> | ToddleApiV2<Handler>
-  >()
-  const getApi = (apiObj: ComponentAPI, key: string) => {
-    let api = apiMap.get(key)
-    if (!api) {
-      api =
-        apiObj.version === 2
-          ? new ToddleApiV2<Handler>(
-              apiObj,
-              key,
-              // global formulas are not required for sorting
-              {
-                formulas: {},
-                packages: {},
-              },
-            )
-          : new LegacyToddleApi<Handler>(
-              apiObj,
-              key,
-              // global formulas are not required for sorting
-              {
-                formulas: {},
-                packages: {},
-              },
-            )
-      apiMap.set(key, api)
-    }
-    return api
-  }
-
-  return [...apis].sort(([aKey, aObj], [bKey, bObj]) => {
-    const a = getApi(aObj, aKey)
-    const b = getApi(bObj, bKey)
-    return compareApiDependencies(a, b)
-  })
-}
-
-export const sortApiEntries = <Handler>(
-  apis: Array<[string, LegacyToddleApi<Handler> | ToddleApiV2<Handler>]>,
-) => [...apis].sort(([_, a], [__, b]) => compareApiDependencies(a, b))

--- a/packages/core/src/api/api.ts
+++ b/packages/core/src/api/api.ts
@@ -14,15 +14,14 @@ import type {
 } from './apiTypes'
 import { ApiMethod } from './apiTypes'
 import { isJsonHeader } from './headers'
-import { LegacyToddleApi } from './LegacyToddleApi'
+import type { LegacyToddleApi } from './LegacyToddleApi'
 import type { ToddleApiV2 } from './ToddleApiV2'
 
 export const NON_BODY_RESPONSE_CODES = [101, 204, 205, 304]
 
 export const isLegacyApi = <Handler>(
   api: ComponentAPI | LegacyToddleApi<Handler> | ToddleApiV2<Handler>,
-): api is LegacyComponentAPI | LegacyToddleApi<Handler> =>
-  api instanceof LegacyToddleApi ? true : !('version' in api)
+): api is LegacyComponentAPI | LegacyToddleApi<Handler> => !('version' in api)
 
 export const createApiRequest = <Handler>({
   api,

--- a/packages/core/src/api/apiTypes.ts
+++ b/packages/core/src/api/apiTypes.ts
@@ -23,6 +23,7 @@ export interface LegacyComponentAPI {
   onCompleted?: Nullable<EventModel>
   onFailed?: Nullable<EventModel>
   version?: never
+  dependsOn?: string[]
 }
 
 export interface LegacyApiStatus {
@@ -137,6 +138,7 @@ export interface ApiRequest extends ApiBase {
   isError?: Nullable<{ formula: Formula }>
   // Formula for determining when the request should time out
   timeout?: Nullable<{ formula: Formula }>
+  dependsOn?: string[]
 }
 
 export interface ApiStatus {

--- a/packages/core/src/component/schemas/api-schema.ts
+++ b/packages/core/src/component/schemas/api-schema.ts
@@ -210,6 +210,10 @@ const ApiRequestSchema: z.ZodType<ApiRequest> = z
       .describe(
         'Rules for redirecting based on response data. The key is a unique identifier for the rule.',
       ),
+    dependsOn: z
+      .array(z.string())
+      .optional()
+      .describe('List of APIs that this API depends on.'),
   })
   .describe('Schema defining an API request from a component or a page.')
 
@@ -244,6 +248,7 @@ const LegacyComponentAPISchema: z.ZodType<LegacyComponentAPI> = z
         type: z.enum(['Bearer id_token', 'Bearer access_token']),
       })
       .nullish(),
+    dependsOn: z.array(z.string()).optional(),
   })
   .describe(
     'Legacy API schema for backward compatibility. Never use this for new APIs.',

--- a/packages/runtime/scripts/build.js
+++ b/packages/runtime/scripts/build.js
@@ -3,7 +3,7 @@ const esbuild = require('esbuild')
 // In order to serve page.main.js + custom-element.main.js as ES modules, it's useful if
 // we build them as part of the runtime package. This way, we can import them from other
 // packages without having to worry about the build process.
-const output = esbuild.build({
+esbuild.build({
   entryPoints: ['src/page.main.ts', 'src/custom-element.main.ts'],
   bundle: true,
   sourcemap: true,
@@ -12,19 +12,4 @@ const output = esbuild.build({
   outdir: 'dist',
   format: 'esm',
   entryNames: '[dir]/[name].esm',
-  metafile: true,
 })
-// Write the metafile
-output
-  .then((result) => {
-    const metafilePath = 'dist/meta.json'
-    require('fs').writeFileSync(
-      metafilePath,
-      JSON.stringify(result.metafile, null, 2),
-    )
-    console.log(`Metafile written to ${metafilePath}`)
-  })
-  .catch((error) => {
-    console.error('Build failed:', error)
-    process.exit(1)
-  })

--- a/packages/runtime/scripts/build.js
+++ b/packages/runtime/scripts/build.js
@@ -3,7 +3,7 @@ const esbuild = require('esbuild')
 // In order to serve page.main.js + custom-element.main.js as ES modules, it's useful if
 // we build them as part of the runtime package. This way, we can import them from other
 // packages without having to worry about the build process.
-esbuild.build({
+const output = esbuild.build({
   entryPoints: ['src/page.main.ts', 'src/custom-element.main.ts'],
   bundle: true,
   sourcemap: true,
@@ -12,4 +12,19 @@ esbuild.build({
   outdir: 'dist',
   format: 'esm',
   entryNames: '[dir]/[name].esm',
+  metafile: true,
 })
+// Write the metafile
+output
+  .then((result) => {
+    const metafilePath = 'dist/meta.json'
+    require('fs').writeFileSync(
+      metafilePath,
+      JSON.stringify(result.metafile, null, 2),
+    )
+    console.log(`Metafile written to ${metafilePath}`)
+  })
+  .catch((error) => {
+    console.error('Build failed:', error)
+    process.exit(1)
+  })

--- a/packages/runtime/src/api/sortApis.ts
+++ b/packages/runtime/src/api/sortApis.ts
@@ -1,0 +1,17 @@
+import type { ComponentAPI } from '@nordcraft/core/dist/api/apiTypes'
+
+export const sortApis = (apis: Array<[string, ComponentAPI]>) => {
+  return [...apis].sort(([_, aObj], [__, bObj]) => {
+    return compareApiDependencies(aObj, bObj)
+  })
+}
+
+const compareApiDependencies = (a: ComponentAPI, b: ComponentAPI) => {
+  const isADependentOnB = a.dependsOn?.includes(b.name) ?? false
+  const isBDependentOnA = b.dependsOn?.includes(a.name) ?? false
+  if (isADependentOnB === isBDependentOnA) {
+    return 0
+  }
+  // 1 means A goes last - hence B is evaluated before A
+  return isADependentOnB ? 1 : -1
+}

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -1,4 +1,4 @@
-import { isLegacyApi, sortApiObjects } from '@nordcraft/core/dist/api/api'
+import { isLegacyApi } from '@nordcraft/core/dist/api/api'
 import type { ComponentAPI } from '@nordcraft/core/dist/api/apiTypes'
 import type {
   ComponentData,
@@ -16,6 +16,7 @@ import { isDefined } from '@nordcraft/core/dist/utils/util'
 import { isContextApiV2 } from '../api/apiUtils'
 import { createLegacyAPI } from '../api/createAPI'
 import { createAPI } from '../api/createAPIv2'
+import { sortApis } from '../api/sortApis'
 import { isContextProvider } from '../context/isContextProvider'
 import { subscribeToContext } from '../context/subscribeToContext'
 import { registerComponentToLogState } from '../debug/logState'
@@ -173,7 +174,7 @@ export function createComponent({
 
   // Note: this function must run procedurally to ensure apis (which are in correct order) can reference each other
   const apis: Record<string, ContextApi> = {}
-  sortApiObjects(
+  sortApis(
     Object.entries(component.apis ?? {}).filter(
       (entry): entry is [string, ComponentAPI] => isDefined(entry[1]),
     ),

--- a/packages/runtime/src/custom-element/ToddleComponent.ts
+++ b/packages/runtime/src/custom-element/ToddleComponent.ts
@@ -1,4 +1,4 @@
-import { isLegacyApi, sortApiObjects } from '@nordcraft/core/dist/api/api'
+import { isLegacyApi } from '@nordcraft/core/dist/api/api'
 import type { ComponentAPI } from '@nordcraft/core/dist/api/apiTypes'
 import type {
   Component,
@@ -20,6 +20,7 @@ import { isDefined } from '@nordcraft/core/dist/utils/util'
 import { isContextApiV2 } from '../api/apiUtils'
 import { createLegacyAPI } from '../api/createAPI'
 import { createAPI } from '../api/createAPIv2'
+import { sortApis } from '../api/sortApis'
 import { renderComponent } from '../components/renderComponent'
 import { isContextProvider } from '../context/isContextProvider'
 import type { Signal } from '../signal/signal'
@@ -105,7 +106,7 @@ export class ToddleComponent extends HTMLElement {
   }
 
   connectedCallback() {
-    sortApiObjects(
+    sortApis(
       Object.entries(this.#component.apis ?? {}).filter(
         (entry): entry is [string, ComponentAPI] => isDefined(entry[1]),
       ),

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -1,4 +1,4 @@
-import { isLegacyApi, sortApiObjects } from '@nordcraft/core/dist/api/api'
+import { isLegacyApi } from '@nordcraft/core/dist/api/api'
 import type { ComponentAPI } from '@nordcraft/core/dist/api/apiTypes'
 import type {
   Component,
@@ -29,6 +29,7 @@ import { match } from 'path-to-regexp'
 import { isContextApiV2 } from './api/apiUtils'
 import { createLegacyAPI } from './api/createAPI'
 import { createAPI } from './api/createAPIv2'
+import { sortApis } from './api/sortApis'
 import { getDynamicMetaEntries } from './components/meta'
 import { renderComponent } from './components/renderComponent'
 import { isContextProvider } from './context/isContextProvider'
@@ -236,7 +237,7 @@ export const createRoot = (domNode: HTMLElement) => {
   }
 
   // Note: this function must run procedurally to ensure apis (which are in correct order) can reference each other
-  sortApiObjects(
+  sortApis(
     Object.entries(component.apis ?? {}).filter(
       (entry): entry is [string, ComponentAPI] => isDefined(entry[1]),
     ),

--- a/packages/ssr/src/rendering/api.ts
+++ b/packages/ssr/src/rendering/api.ts
@@ -1,14 +1,20 @@
 import type {
   ApiStatus,
+  ComponentAPI,
   LegacyApiStatus,
 } from '@nordcraft/core/dist/api/apiTypes'
-import type { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
+import type { Component } from '@nordcraft/core/dist/component/component.types'
+import { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
 import type { FormulaContext } from '@nordcraft/core/dist/formula/formula'
+import type { Nullable } from '@nordcraft/core/dist/types'
+import { mapObject } from '@nordcraft/core/dist/utils/collections'
+import { isDefined } from '@nordcraft/core/src/utils/util'
+import type { ProjectFiles } from '../ssr.types'
 
 export type ApiCache = Record<string, ApiStatus>
 
 export type ApiEvaluator = (args: {
-  component: ToddleComponent<string>
+  component: Component
   formulaContext: FormulaContext
   req: Request
   apiCache: ApiCache
@@ -19,3 +25,61 @@ export type ApiEvaluator = (args: {
     LegacyApiStatus | (ApiStatus & { inputs?: Record<string, unknown> })
   >
 >
+
+const compareApiDependencies = (
+  a: Nullable<ComponentAPI>,
+  b: Nullable<ComponentAPI>,
+) => {
+  if (!isDefined(a)) {
+    return 1
+  }
+  if (!isDefined(b)) {
+    return -1
+  }
+  const isADependentOnB = a.dependsOn?.includes(b.name) ?? false
+  const isBDependentOnA = b.dependsOn?.includes(a.name) ?? false
+  if (isADependentOnB === isBDependentOnA) {
+    return 0
+  }
+  // 1 means A goes last - hence B is evaluated before A
+  return isADependentOnB ? 1 : -1
+}
+
+export const sortApiEntries = (apis: Array<[string, Nullable<ComponentAPI>]>) =>
+  [...apis].sort(([_, a], [__, b]) => compareApiDependencies(a, b))
+
+export const processComponentApis = <T extends Component>(
+  component: T,
+  files: ProjectFiles,
+): T => {
+  const toddleComponent = new ToddleComponent<string>({
+    component,
+    getComponent: (name, packageName) => {
+      const nodeLookupKey = [packageName, name].filter(isDefined).join('/')
+      const component = packageName
+        ? files.packages?.[packageName]?.components[name]
+        : files.components[name]
+      if (!component) {
+        // eslint-disable-next-line no-console
+        console.warn(`Unable to find component ${nodeLookupKey} in files`)
+        return undefined
+      }
+
+      return component
+    },
+    packageName: undefined,
+    globalFormulas: {
+      formulas: files.formulas,
+      packages: files.packages,
+    },
+  })
+  return {
+    ...component,
+    apis: component.apis
+      ? mapObject(component.apis, ([key, api]) => [
+          key,
+          { ...api, dependsOn: toddleComponent.apis[key]?.dependsOn ?? [] },
+        ])
+      : undefined,
+  }
+}

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -727,7 +727,7 @@ export const renderPageBody = async ({
   req,
   projectId,
 }: {
-  component: ToddleComponent<string>
+  component: Component
   env: ToddleServerEnv
   evaluateComponentApis: ApiEvaluator
   files: ProjectFiles

--- a/packages/ssr/src/rendering/head.ts
+++ b/packages/ssr/src/rendering/head.ts
@@ -1,6 +1,8 @@
-import type { Component } from '@nordcraft/core/dist/component/component.types'
+import type {
+  Component,
+  PageComponent,
+} from '@nordcraft/core/dist/component/component.types'
 import { HeadTagTypes } from '@nordcraft/core/dist/component/component.types'
-import type { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
 import type { FormulaContext } from '@nordcraft/core/dist/formula/formula'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import type { OldTheme, Theme } from '@nordcraft/core/dist/styling/theme'
@@ -41,7 +43,7 @@ export const getHeadItems = ({
   context: FormulaContext
   cssBasePath?: string
   files: ProjectFiles
-  page: ToddleComponent<string>
+  page: PageComponent
   resetStylesheetPath?: string
   pageStylesheetPath?: string
   project: ToddleProject


### PR DESCRIPTION

- Added `dependsOn` property to the serialized API objects in the SSR rendering process, allowing the client to sort APIs without expensive calculations
- Adjust types and use the `ToddleComponent` type less when evaluating APIs during SSR
- Cleanup types

This reduces the runtime (`page.main.js`) from:
32.5 KB (114KB)
to:
30.5 KB (101KB)

That's a ~6% reduction (11.5%)

Closes https://github.com/nordcraftengine/nordcraft/issues/1023