### PR TITLE
Fix how we read the value from a variable in animations

### DIFF
--- a/packages/css-parser/src/parseAnimation.test.ts
+++ b/packages/css-parser/src/parseAnimation.test.ts
@@ -817,4 +817,54 @@ describe('parseAnimation', () => {
       },
     ])
   })
+
+  test('Use variable for delay', () => {
+    expect(
+      getParsedAnimation(
+        {
+          animation: '3s linear var(--delay) infinite alternate sun-rise',
+        },
+        [
+          {
+            formula: {
+              type: 'value',
+              value: 2,
+            },
+            unit: 's',
+            name: '--delay',
+            value: '2s',
+          } as any,
+        ],
+      ),
+    ).toEqual([
+      {
+        duration: {
+          type: 'time',
+          value: '3',
+          unit: 's',
+        },
+        timing: {
+          type: 'keyword',
+          value: 'linear',
+        },
+        delay: {
+          type: 'function',
+          name: 'var',
+          value: '--delay',
+        },
+        direction: {
+          type: 'keyword',
+          value: 'alternate',
+        },
+        iterationCount: {
+          type: 'keyword',
+          value: 'infinite',
+        },
+        name: {
+          type: 'keyword',
+          value: 'sun-rise',
+        },
+      },
+    ])
+  })
 })

--- a/packages/css-parser/src/parseAnimation.ts
+++ b/packages/css-parser/src/parseAnimation.ts
@@ -538,10 +538,17 @@ const parseAnimation = ({
           ? usedVariable.value.replaceAll(usedVariable.unit, '')
           : usedVariable.value
 
+        if (valueWithoutUnit === '') {
+          invalidValue = true
+          return
+        }
+
+        const valueWithUnit = usedVariable.value
+
         const parsedVariable = parseMultipleValues([
           {
             type: 'word',
-            value: valueWithoutUnit,
+            value: valueWithUnit,
           },
         ])
 


### PR DESCRIPTION
There was an issue when using a time variable for the animation delay. This small change will fix that.