### PR TITLE
Issue rule for animated custom properties that are not in theme

### DIFF
--- a/packages/search/src/rules/issues/style/animatedStyleNotInThemeRule.test.ts
+++ b/packages/search/src/rules/issues/style/animatedStyleNotInThemeRule.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../../searchProject'
+import { animatedStyleNotInThemeRule } from './animatedStyleNotInThemeRule'
+
+describe('animatedStyleNotInThemeRule', () => {
+  test('should report CSS variables used in animations that are not in the theme', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          themes: {
+            Default: {
+              fonts: [],
+              propertyDefinitions: {
+                '--theme-var': {
+                  syntax: { type: 'primitive', name: 'color' },
+                  description: 'A theme variable',
+                  inherits: true,
+                  initialValue: 'blue',
+                  values: {},
+                },
+              },
+            },
+          },
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  tag: 'div',
+                  type: 'element',
+                  attrs: {},
+                  style: {},
+                  events: {},
+                  classes: {},
+                  children: [],
+                  animations: {
+                    myAnimation: {
+                      k1: {
+                        position: 0,
+                        key: '--missing-var',
+                        value: '0',
+                      },
+                      k2: {
+                        position: 100,
+                        key: '--theme-var',
+                        value: '1',
+                      },
+                    },
+                  },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [animatedStyleNotInThemeRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+  })
+
+  test('should not report when all animated CSS variables are in the theme', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          themes: {
+            Default: {
+              fonts: [],
+              propertyDefinitions: {
+                '--theme-var': {
+                  syntax: { type: 'primitive', name: 'color' },
+                  description: 'A theme variable',
+                  inherits: true,
+                  initialValue: 'blue',
+                  values: {},
+                },
+              },
+            },
+          },
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  tag: 'div',
+                  type: 'element',
+                  attrs: {},
+                  style: {},
+                  events: {},
+                  classes: {},
+                  children: [],
+                  animations: {
+                    myAnimation: {
+                      k1: {
+                        position: 0,
+                        key: '--theme-var',
+                        value: 'blue',
+                      },
+                      k2: {
+                        position: 100,
+                        key: '--theme-var',
+                        value: 'red',
+                      },
+                    },
+                  },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [animatedStyleNotInThemeRule],
+      }),
+    )
+
+    expect(problems).toBeEmpty()
+  })
+
+  test('should not report regular CSS properties', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          themes: {
+            Default: {
+              fonts: [],
+              propertyDefinitions: {},
+            },
+          },
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  tag: 'div',
+                  type: 'element',
+                  attrs: {},
+                  style: {},
+                  events: {},
+                  classes: {},
+                  children: [],
+                  animations: {
+                    myAnimation: {
+                      k1: {
+                        position: 0,
+                        key: 'opacity',
+                        value: '0',
+                      },
+                      k2: {
+                        position: 100,
+                        key: 'opacity',
+                        value: '1',
+                      },
+                    },
+                  },
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [animatedStyleNotInThemeRule],
+      }),
+    )
+
+    expect(problems).toBeEmpty()
+  })
+})

--- a/packages/search/src/rules/issues/style/animatedStyleNotInThemeRule.ts
+++ b/packages/search/src/rules/issues/style/animatedStyleNotInThemeRule.ts
@@ -1,0 +1,47 @@
+import type { CustomPropertyDefinition } from '@nordcraft/core/dist/styling/theme'
+import type { IssueRule } from '../../../types'
+
+export const animatedStyleNotInThemeRule: IssueRule = {
+  code: 'animated style not in theme',
+  level: 'warning',
+  category: 'No References',
+  visit: (report, { files, value, path, nodeType }) => {
+    if (nodeType !== 'animation') {
+      return
+    }
+
+    const themeProperties = files.themes?.Default?.propertyDefinitions
+    if (!themeProperties) {
+      return
+    }
+
+    const keyframes = Object.values(value.value)
+    const animatedProperties = new Set<string>()
+
+    keyframes.forEach((keyframe) => {
+      if (keyframe.key.startsWith('--')) {
+        animatedProperties.add(keyframe.key)
+      }
+    })
+
+    if (animatedProperties.size === 0) {
+      return
+    }
+
+    for (const prop of animatedProperties) {
+      if (
+        !(themeProperties[prop as `--${string}`] as
+          | CustomPropertyDefinition
+          | undefined)
+      ) {
+        report({
+          path: [...path, 'style', prop],
+          info: {
+            title: `Animated CSS variable is not declared in theme`,
+            description: `Only globally declared CSS variables with a correct syntax type can be animated. Declare the CSS variable "${prop}" in the theme or remove it from the animation.`,
+          },
+        })
+      }
+    }
+  },
+}

--- a/packages/search/src/rules/issues/style/styleRules.index.ts
+++ b/packages/search/src/rules/issues/style/styleRules.index.ts
@@ -1,3 +1,4 @@
+import { animatedStyleNotInThemeRule } from './animatedStyleNotInThemeRule'
 import { invalidStyleSyntaxRule } from './invalidStyleSyntaxRule'
 import { legacyStyleVariableRule } from './legacyStyleVariableRule'
 import { legacyThemeRule } from './legacyThemeRule'
@@ -14,4 +15,5 @@ export default [
   unknownClassnameRule,
   unknownCSSVariableRule,
   noReferenceGlobalCSSVariableRule,
+  animatedStyleNotInThemeRule,
 ]

--- a/packages/search/src/types.ts
+++ b/packages/search/src/types.ts
@@ -68,6 +68,7 @@ import type { NoPostNavigateActionRuleFix } from './rules/issues/workflows/noPos
 import type { UnknownContextWorkflowRuleFix } from './rules/issues/workflows/unknownContextWorkflowRule'
 
 export type Code =
+  | 'animated style not in theme'
   | 'duplicate action argument name'
   | 'duplicate event trigger'
   | 'duplicate formula argument name'


### PR DESCRIPTION
Custom properties cannot be animated if they are not globally declared