### PR TITLE
Allow nullish values for more component properties

### DIFF
--- a/packages/backend/src/routes/customElement.ts
+++ b/packages/backend/src/routes/customElement.ts
@@ -84,14 +84,16 @@ export const customElement =
  *
  * Attributes:
  *
- * ${Object.entries(component.attributes ?? {})
-   .map(([, attr]) => `- ${attr.name}`)
+ * ${Object.values(component.attributes ?? {})
+   .filter(isDefined)
+   .map((attr) => `- ${attr.name}`)
    .join('\n * ')}
  *
  * Events:
  *
- * ${Object.entries(component.events ?? {})
-   .map(([, event]) => `- ${event.name}`)
+ * ${Object.values(component.events ?? {})
+   .filter(isDefined)
+   .map((event) => `- ${event.name}`)
    .join('\n * ')}
  */
 

--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -398,27 +398,31 @@ export class ToddleComponent<Handler> {
       })
     }
     for (const [formulaKey, formula] of Object.entries(this.formulas ?? {})) {
-      yield* getFormulasInFormula({
-        formula: formula.formula,
-        globalFormulas,
-        path: ['formulas', formulaKey, 'formula'],
-        packageName,
-      })
+      if (isDefined(formula)) {
+        yield* getFormulasInFormula({
+          formula: formula.formula,
+          globalFormulas,
+          path: ['formulas', formulaKey, 'formula'],
+          packageName,
+        })
+      }
     }
     for (const [variableKey, variable] of Object.entries(
       this.variables ?? {},
     )) {
-      yield* getFormulasInFormula({
-        formula: variable.initialValue,
-        globalFormulas,
-        path: ['variables', variableKey, 'initialValue'],
-        packageName,
-      })
+      if (isDefined(variable)) {
+        yield* getFormulasInFormula({
+          formula: variable.initialValue,
+          globalFormulas,
+          path: ['variables', variableKey, 'initialValue'],
+          packageName,
+        })
+      }
     }
     for (const [workflowKey, workflow] of Object.entries(
       this.workflows ?? {},
     )) {
-      for (const [actionKey, action] of workflow.actions.entries()) {
+      for (const [actionKey, action] of workflow?.actions.entries() ?? []) {
         yield* getFormulasInAction({
           action,
           globalFormulas,

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -180,9 +180,9 @@ export interface Component {
   // @deprecated - use route->path instead
   page?: Nullable<string> // page url /projects/:id - only for pages
   route?: Nullable<PageRoute>
-  attributes?: Nullable<Record<string, ComponentAttribute>>
-  variables?: Nullable<Record<string, ComponentVariable>>
-  formulas?: Nullable<Record<string, ComponentFormula>>
+  attributes?: Nullable<Record<string, Nullable<ComponentAttribute>>>
+  variables?: Nullable<Record<string, Nullable<ComponentVariable>>>
+  formulas?: Nullable<Record<string, Nullable<ComponentFormula>>>
   contexts?: Nullable<
     Record<
       // `componentName` or `packageName/componentName` if the context comes from a different package than the component itself
@@ -190,10 +190,10 @@ export interface Component {
       ComponentContext
     >
   >
-  workflows?: Nullable<Record<string, ComponentWorkflow>>
+  workflows?: Nullable<Record<string, Nullable<ComponentWorkflow>>>
   apis?: Nullable<Record<string, Nullable<ComponentAPI>>>
   nodes?: Nullable<Record<string, NodeModel>>
-  events?: Nullable<ComponentEvent[]>
+  events?: Nullable<Nullable<ComponentEvent>[]>
   onLoad?: Nullable<EventModel>
   onAttributeChange?: Nullable<EventModel>
   // exported indicates that a component is exported in a package

--- a/packages/core/src/utils/collections.ts
+++ b/packages/core/src/utils/collections.ts
@@ -75,10 +75,13 @@ export const groupBy = <T>(items: T[], f: (t: T) => string) =>
     return acc
   }, {})
 
-export const filterObject = <T>(
+export const filterObject = <T, T2 extends T = T>(
   object: Record<string, T>,
   f: (kv: [string, T]) => boolean,
-): Record<string, T> => Object.fromEntries(Object.entries(object).filter(f))
+): Record<string, T2> =>
+  Object.fromEntries(
+    Object.entries(object).filter((o): o is [string, T2] => f(o)),
+  )
 
 export function get<T = any>(
   collection: T,

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -1,11 +1,14 @@
 import { isLegacyApi, sortApiObjects } from '@nordcraft/core/dist/api/api'
 import type {
   ComponentData,
+  ComponentFormula,
   ComponentNodeModel,
+  ComponentVariable,
   SupportedNamespaces,
 } from '@nordcraft/core/dist/component/component.types'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import { appendUnit } from '@nordcraft/core/dist/styling/customProperty'
+import type { Nullable } from '@nordcraft/core/dist/types'
 import { filterObject, mapObject } from '@nordcraft/core/dist/utils/collections'
 import { getNodeSelector } from '@nordcraft/core/dist/utils/getNodeSelector'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
@@ -131,19 +134,25 @@ export function createComponent({
   subscribeToContext(componentDataSignal, component, ctx)
   componentDataSignal.update((data) => ({
     ...data,
-    Variables: mapObject(component.variables ?? {}, ([name, variable]) => [
-      name,
-      applyFormula(
-        variable.initialValue,
-        {
-          // Initial value
-          ...formulaCtx,
-          component,
-          data: componentDataSignal.get(),
-        },
-        ['variables', name],
+    Variables: mapObject(
+      filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+        component.variables ?? {},
+        ([_, variable]) => isDefined(variable),
       ),
-    ]),
+      ([name, variable]) => [
+        name,
+        applyFormula(
+          variable.initialValue,
+          {
+            // Initial value
+            ...formulaCtx,
+            component,
+            data: componentDataSignal.get(),
+          },
+          ['variables', name],
+        ),
+      ],
+    ),
   }))
   registerComponentToLogState(component, componentDataSignal)
 
@@ -239,12 +248,12 @@ export function createComponent({
     // Subscribe to exposed formulas and update the component's data signal
     const formulaDataSignals = Object.fromEntries(
       Object.entries(component.formulas ?? {})
-        .filter(([, formula]) => formula.exposeInContext)
+        .filter(([, formula]) => formula?.exposeInContext)
         .map(([name, formula]) => [
           name,
           componentDataSignal.map((data) =>
             applyFormula(
-              formula.formula,
+              (formula as ComponentFormula).formula,
               {
                 data,
                 component,

--- a/packages/runtime/src/context/isContextProvider.ts
+++ b/packages/runtime/src/context/isContextProvider.ts
@@ -3,10 +3,6 @@ import type { Component } from '@nordcraft/core/dist/component/component.types'
 
 export const isContextProvider = (component: Component) =>
   (component.formulas &&
-    Object.values(component.formulas).some(
-      ({ exposeInContext }) => exposeInContext,
-    )) ||
+    Object.values(component.formulas).some((f) => f?.exposeInContext)) ||
   (component.workflows &&
-    Object.values(component.workflows).some(
-      ({ exposeInContext }) => exposeInContext,
-    ))
+    Object.values(component.workflows).some((w) => w?.exposeInContext))

--- a/packages/runtime/src/context/subscribeToContext.ts
+++ b/packages/runtime/src/context/subscribeToContext.ts
@@ -1,11 +1,14 @@
 import type {
   Component,
+  ComponentAttribute,
   ComponentData,
+  ComponentVariable,
 } from '@nordcraft/core/dist/component/component.types'
 import type { FormulaContext } from '@nordcraft/core/dist/formula/formula'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
-import { mapObject } from '@nordcraft/core/dist/utils/collections'
+import { filterObject, mapObject } from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
+import type { Nullable } from '@nordcraft/core/src/types'
 import type { Signal } from '../signal/signal'
 import type { ComponentContext } from '../types'
 
@@ -73,7 +76,10 @@ export function subscribeToContext(
         const formulaContext: FormulaContext = {
           data: {
             Attributes: mapObject(
-              testProvider.attributes ?? {},
+              filterObject<Nullable<ComponentAttribute>, ComponentAttribute>(
+                testProvider.attributes ?? {},
+                ([_, attr]) => isDefined(attr),
+              ),
               ([name, attr]) => [name, attr.testValue],
             ),
           },
@@ -101,7 +107,10 @@ export function subscribeToContext(
           }
         }
         formulaContext.data.Variables = mapObject(
-          testProvider.variables ?? {},
+          filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+            testProvider.variables ?? {},
+            ([_, variable]) => isDefined(variable),
+          ),
           ([name, variable]) => [
             name,
             applyFormula(variable.initialValue, {

--- a/packages/runtime/src/custom-element/ToddleComponent.ts
+++ b/packages/runtime/src/custom-element/ToddleComponent.ts
@@ -2,6 +2,8 @@ import { isLegacyApi, sortApiObjects } from '@nordcraft/core/dist/api/api'
 import type {
   Component,
   ComponentData,
+  ComponentFormula,
+  ComponentVariable,
 } from '@nordcraft/core/dist/component/component.types'
 import type { ToddleEnv } from '@nordcraft/core/dist/formula/formula'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
@@ -11,8 +13,8 @@ import {
   theme as defaultTheme,
   THEME_DATA_ATTRIBUTE,
 } from '@nordcraft/core/dist/styling/theme.const'
-import type { Toddle } from '@nordcraft/core/dist/types'
-import { mapObject } from '@nordcraft/core/dist/utils/collections'
+import type { Nullable, Toddle } from '@nordcraft/core/dist/types'
+import { filterObject, mapObject } from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import type { ComponentAPI } from '@nordcraft/core/src/api/apiTypes'
 import { isContextApiV2 } from '../api/apiUtils'
@@ -135,12 +137,12 @@ export class ToddleComponent extends HTMLElement {
       // Subscribe to exposed formulas and update the component's data signal
       const formulaDataSignals = Object.fromEntries(
         Object.entries(this.#component.formulas ?? {})
-          .filter(([, formula]) => formula.exposeInContext)
+          .filter(([, formula]) => formula?.exposeInContext)
           .map(([name, formula]) => [
             name,
             this.#signal.map((data) =>
               applyFormula(
-                formula.formula,
+                (formula as ComponentFormula).formula,
                 {
                   data,
                   component: this.#component,
@@ -327,7 +329,10 @@ export const createSignal = ({
     // Pages are not supported as custom elements, so no need to add location signal
     Location: undefined,
     Variables: mapObject(
-      component.variables ?? {},
+      filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+        component.variables ?? {},
+        ([_, variable]) => isDefined(variable),
+      ),
       ([name, { initialValue }]) => {
         if (!component) {
           throw new Error(`Component not found`)

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -7,7 +7,10 @@ import { isLegacyPluginAction } from '@nordcraft/core/dist/component/actionUtils
 import {
   HeadTagTypes,
   type Component,
+  type ComponentAttribute,
   type ComponentData,
+  type ComponentFormula,
+  type ComponentVariable,
   type MetaEntry,
 } from '@nordcraft/core/dist/component/component.types'
 import { isPageComponent } from '@nordcraft/core/dist/component/isPageComponent'
@@ -40,11 +43,16 @@ import type {
   ArgumentInputDataFunction,
   FormulaHandler,
   FormulaHandlerV2,
+  Nullable,
   PluginAction,
   PluginActionV2,
   Toddle,
 } from '@nordcraft/core/dist/types'
-import { mapObject, omitKeys } from '@nordcraft/core/dist/utils/collections'
+import {
+  filterObject,
+  mapObject,
+  omitKeys,
+} from '@nordcraft/core/dist/utils/collections'
 import { safeFunctionName } from '@nordcraft/core/dist/utils/handlerUtils'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import * as libActions from '@nordcraft/std-lib/dist/actions'
@@ -1322,7 +1330,10 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       fastDeepEqual(ctx?.component.attributes, _component.attributes) === false
     ) {
       Attributes = mapObject(
-        _component.attributes ?? {},
+        filterObject<Nullable<ComponentAttribute>, ComponentAttribute>(
+          _component.attributes ?? {},
+          ([_, attr]) => isDefined(attr),
+        ),
         ([name, { testValue }]) => [name, testValue],
       )
     }
@@ -1369,7 +1380,10 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       }
 
       Attributes = mapObject(
-        _component.attributes ?? {},
+        filterObject<Nullable<ComponentAttribute>, ComponentAttribute>(
+          _component.attributes ?? {},
+          ([_, attr]) => isDefined(attr),
+        ),
         ([name, { testValue }]) => [name, testValue],
       )
     }
@@ -1419,8 +1433,13 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
             const formulaContext: FormulaContext = {
               data: {
                 Attributes: mapObject(
-                  providerComponent.attributes ?? {},
-                  ([name, attr]) => [name, attr.testValue],
+                  filterObject<
+                    Nullable<ComponentAttribute>,
+                    ComponentAttribute
+                  >(providerComponent.attributes ?? {}, ([_, attr]) =>
+                    isDefined(attr),
+                  ),
+                  ([name, { testValue }]) => [name, testValue],
                 ),
                 // Recursively resolve contexts providers before their children to build up the fake context tree in preview mode
                 Contexts: createStaticContextFromComponent(
@@ -1456,7 +1475,10 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
               }
             }
             formulaContext.data.Variables = mapObject(
-              providerComponent.variables ?? {},
+              filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+                providerComponent.variables ?? {},
+                ([_, variable]) => isDefined(variable),
+              ),
               ([name, variable]) => [
                 name,
                 applyFormula(variable.initialValue, formulaContext, [
@@ -1496,7 +1518,10 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       fastDeepEqual(_component.variables, ctx?.component.variables) === false
     ) {
       Variables = mapObject(
-        _component.variables ?? {},
+        filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+          _component.variables ?? {},
+          ([_, variable]) => isDefined(variable),
+        ),
         ([name, { initialValue }]) => [
           name,
           applyFormula(
@@ -1743,12 +1768,12 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       // Subscribe to exposed formulas and update the component's data signal
       const formulaDataSignals = Object.fromEntries(
         Object.entries(component.formulas ?? {})
-          .filter(([, formula]) => formula.exposeInContext)
+          .filter(([, formula]) => formula?.exposeInContext)
           .map(([name, formula]) => [
             name,
             dataSignal.map((data) =>
               applyFormula(
-                formula.formula,
+                (formula as ComponentFormula).formula,
                 {
                   data,
                   component,

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -3,6 +3,8 @@ import type { ComponentAPI } from '@nordcraft/core/dist/api/apiTypes'
 import type {
   Component,
   ComponentData,
+  ComponentFormula,
+  ComponentVariable,
 } from '@nordcraft/core/dist/component/component.types'
 import type { ToddleEnv } from '@nordcraft/core/dist/formula/formula'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
@@ -13,10 +15,11 @@ import type {
   ArgumentInputDataFunction,
   FormulaHandler,
   FormulaHandlerV2,
+  Nullable,
   PluginActionV2,
   Toddle,
 } from '@nordcraft/core/dist/types'
-import { mapObject } from '@nordcraft/core/dist/utils/collections'
+import { filterObject, mapObject } from '@nordcraft/core/dist/utils/collections'
 import { VOID_HTML_ELEMENTS } from '@nordcraft/core/dist/utils/html'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import * as libActions from '@nordcraft/std-lib/dist/actions'
@@ -167,23 +170,29 @@ export const createRoot = (domNode: HTMLElement) => {
     ...window.toddle.pageState,
     // Re-initialize variables since some of them might rely on client-side
     // state (e.g. localStorage, sensors etc.)
-    Variables: mapObject(component.variables ?? {}, ([name, variable]) => [
-      name,
-      applyFormula(
-        variable.initialValue,
-        {
-          data: window.toddle.pageState,
-          component,
-          formulaCache: {},
-          root: document,
-          package: undefined,
-          toddle: window.toddle,
-          env,
-          jsonPath: [],
-        },
-        ['variables', name],
+    Variables: mapObject(
+      filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+        component.variables ?? {},
+        ([_, variable]) => isDefined(variable),
       ),
-    ]),
+      ([name, variable]) => [
+        name,
+        applyFormula(
+          variable.initialValue,
+          {
+            data: window.toddle.pageState,
+            component,
+            formulaCache: {},
+            root: document,
+            package: undefined,
+            toddle: window.toddle,
+            env,
+            jsonPath: [],
+          },
+          ['variables', name],
+        ),
+      ],
+    ),
   })
 
   registerComponentToLogState(component, dataSignal)
@@ -260,11 +269,11 @@ export const createRoot = (domNode: HTMLElement) => {
     // Subscribe to exposed formulas and update the component's data signal
     const formulaDataSignals = Object.fromEntries(
       Object.entries(component.formulas ?? {})
-        .filter(([, formula]) => formula.exposeInContext)
+        .filter(([, formula]) => formula?.exposeInContext)
         .map(([name, formula]) => [
           name,
           dataSignal.map((data) =>
-            applyFormula(formula.formula, {
+            applyFormula((formula as ComponentFormula).formula, {
               data,
               component,
               formulaCache: ctx.formulaCache,

--- a/packages/runtime/src/utils/createFormulaCache.ts
+++ b/packages/runtime/src/utils/createFormulaCache.ts
@@ -1,12 +1,18 @@
 import type {
   Component,
   ComponentData,
+  ComponentFormula,
 } from '@nordcraft/core/dist/component/component.types'
 import type {
   Formula,
   FunctionOperation,
 } from '@nordcraft/core/dist/formula/formula'
-import { get, mapObject } from '@nordcraft/core/dist/utils/collections'
+import type { Nullable } from '@nordcraft/core/dist/types'
+import {
+  filterObject,
+  get,
+  mapObject,
+} from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import type { FormulaCache } from '../types'
 
@@ -14,37 +20,43 @@ export function createFormulaCache(component: Component): FormulaCache {
   if (!isDefined(component.formulas)) {
     return {}
   }
-  return mapObject(component.formulas, ([name, f]) => {
-    const { canCache, keys } = f.memoize
-      ? getFormulaCacheConfig(f.formula, component)
-      : { canCache: false, keys: [] }
-    let cacheInput: any
-    let cacheData: any
+  return mapObject(
+    filterObject<Nullable<ComponentFormula>, ComponentFormula>(
+      component.formulas,
+      ([_, f]) => isDefined(f),
+    ),
+    ([name, f]) => {
+      const { canCache, keys } = f.memoize
+        ? getFormulaCacheConfig(f.formula, component)
+        : { canCache: false, keys: [] }
+      let cacheInput: any
+      let cacheData: any
 
-    return [
-      name,
-      {
-        get: (data: ComponentData) => {
-          if (
-            canCache &&
-            cacheInput &&
-            keys.every((key) => {
-              return get(data, key) === get(cacheInput, key)
-            })
-          ) {
-            return { hit: true, data: cacheData }
-          }
-          return { hit: false }
+      return [
+        name,
+        {
+          get: (data: ComponentData) => {
+            if (
+              canCache &&
+              cacheInput &&
+              keys.every((key) => {
+                return get(data, key) === get(cacheInput, key)
+              })
+            ) {
+              return { hit: true, data: cacheData }
+            }
+            return { hit: false }
+          },
+          set: (data: ComponentData, result: any) => {
+            if (canCache) {
+              cacheInput = data
+              cacheData = result
+            }
+          },
         },
-        set: (data: ComponentData, result: any) => {
-          if (canCache) {
-            cacheInput = data
-            cacheData = result
-          }
-        },
-      },
-    ]
-  })
+      ]
+    },
+  )
 }
 
 function getFormulaCacheConfig(formula: Formula, component: Component) {
@@ -66,10 +78,17 @@ function getFormulaCacheConfig(formula: Formula, component: Component) {
     }
 
     if (op.type === 'apply') {
-      if (!component.formulas?.[op.name]?.memoize) {
+      const formula = component.formulas?.[op.name]
+      if (!formula) {
+        return {
+          canCache: false,
+          keys: [],
+        }
+      }
+      if (!formula.memoize) {
         throw new Error('Cannot memoize')
       }
-      visitOperation(component.formulas?.[op.name]?.formula)
+      visitOperation(formula.formula)
     }
   }
   try {

--- a/packages/search/src/rules/issues/context/noContextConsumersRule.ts
+++ b/packages/search/src/rules/issues/context/noContextConsumersRule.ts
@@ -16,10 +16,10 @@ export const noContextConsumersRule: IssueRule<{
       return
     }
     const exposesFormulas = Object.values(value.formulas ?? {}).some(
-      (f) => f.exposeInContext,
+      (f) => f?.exposeInContext,
     )
     const exposesWorkflows = Object.values(value.workflows ?? {}).some(
-      (w) => w.exposeInContext,
+      (w) => w?.exposeInContext,
     )
     if (!exposesFormulas && !exposesWorkflows) {
       return

--- a/packages/search/src/rules/issues/events/unknownEventRule.ts
+++ b/packages/search/src/rules/issues/events/unknownEventRule.ts
@@ -21,7 +21,7 @@ export const unknownEventRule: IssueRule<{
       ? files.packages?.[value.package]?.components[value.name]
       : files.components[value.name]
     const componentEvents = new Set(
-      (component?.events ?? []).map((e) => e.name),
+      (component?.events ?? []).map((e) => e?.name),
     )
     Object.entries(value.events).forEach(([eventKey, event]) => {
       if (isDefined(event) && !componentEvents.has(event.trigger)) {

--- a/packages/search/src/rules/issues/events/unknownTriggerEventRule.ts
+++ b/packages/search/src/rules/issues/events/unknownTriggerEventRule.ts
@@ -13,7 +13,7 @@ export const unknownTriggerEventRule: IssueRule<{
 
     const [, componentName] = path
     const component = files.components[componentName]
-    if (!component?.events?.some((e) => e.name === value.event)) {
+    if (!component?.events?.some((e) => e?.name === value.event)) {
       report({
         path,
         info: {

--- a/packages/search/src/rules/issues/workflows/unknownTriggerWorkflowParameterRule.ts
+++ b/packages/search/src/rules/issues/workflows/unknownTriggerWorkflowParameterRule.ts
@@ -1,4 +1,5 @@
 import type { ComponentWorkflow } from '@nordcraft/core/dist/component/component.types'
+import type { Nullable } from '@nordcraft/core/dist/types'
 import type { IssueRule } from '../../../types'
 
 export const unknownTriggerWorkflowParameterRule: IssueRule<{
@@ -18,7 +19,7 @@ export const unknownTriggerWorkflowParameterRule: IssueRule<{
       return
     }
 
-    let workflow: ComponentWorkflow | undefined
+    let workflow: Nullable<ComponentWorkflow>
     if (typeof value.contextProvider === 'string') {
       const subscription = args.component.contexts?.[value.contextProvider]
       const isSubscribed = subscription?.workflows?.includes(value.workflow)

--- a/packages/search/src/searchProject.ts
+++ b/packages/search/src/searchProject.ts
@@ -404,39 +404,45 @@ function* visitNode({
       })
 
       for (const key in value.attributes) {
-        yield* visitNode({
-          args: {
-            nodeType: 'component-attribute',
-            value: value.attributes[key],
-            path: [...path, 'attributes', key],
-            rules,
-            files,
-            pathsToVisit,
-            useExactPaths,
-            memo,
-            component,
-          },
-          state,
-          fixOptions: fixOptions as any,
-        })
+        const attribute = value.attributes[key]
+        if (isDefined(attribute)) {
+          yield* visitNode({
+            args: {
+              nodeType: 'component-attribute',
+              value: attribute,
+              path: [...path, 'attributes', key],
+              rules,
+              files,
+              pathsToVisit,
+              useExactPaths,
+              memo,
+              component,
+            },
+            state,
+            fixOptions: fixOptions as any,
+          })
+        }
       }
 
       for (const key in value.variables) {
-        yield* visitNode({
-          args: {
-            nodeType: 'component-variable',
-            value: value.variables[key],
-            path: [...path, 'variables', key],
-            rules,
-            files,
-            pathsToVisit,
-            useExactPaths,
-            memo,
-            component,
-          },
-          state,
-          fixOptions: fixOptions as any,
-        })
+        const variable = value.variables[key]
+        if (isDefined(variable)) {
+          yield* visitNode({
+            args: {
+              nodeType: 'component-variable',
+              value: variable,
+              path: [...path, 'variables', key],
+              rules,
+              files,
+              pathsToVisit,
+              useExactPaths,
+              memo,
+              component,
+            },
+            state,
+            fixOptions: fixOptions as any,
+          })
+        }
       }
 
       for (const key in value.apis) {
@@ -482,39 +488,45 @@ function* visitNode({
       }
 
       for (const key in value.formulas) {
-        yield* visitNode({
-          args: {
-            nodeType: 'component-formula',
-            value: value.formulas[key],
-            path: [...path, 'formulas', key],
-            rules,
-            files,
-            pathsToVisit,
-            useExactPaths,
-            memo,
-            component,
-          },
-          state,
-          fixOptions: fixOptions as any,
-        })
+        const formula = value.formulas[key]
+        if (isDefined(formula)) {
+          yield* visitNode({
+            args: {
+              nodeType: 'component-formula',
+              value: formula,
+              path: [...path, 'formulas', key],
+              rules,
+              files,
+              pathsToVisit,
+              useExactPaths,
+              memo,
+              component,
+            },
+            state,
+            fixOptions: fixOptions as any,
+          })
+        }
       }
 
       for (const key in value.workflows) {
-        yield* visitNode({
-          args: {
-            nodeType: 'component-workflow',
-            value: value.workflows[key],
-            path: [...path, 'workflows', key],
-            rules,
-            files,
-            pathsToVisit,
-            useExactPaths,
-            memo,
-            component,
-          },
-          state,
-          fixOptions: fixOptions as any,
-        })
+        const workflow = value.workflows[key]
+        if (isDefined(workflow)) {
+          yield* visitNode({
+            args: {
+              nodeType: 'component-workflow',
+              value: workflow,
+              path: [...path, 'workflows', key],
+              rules,
+              files,
+              pathsToVisit,
+              useExactPaths,
+              memo,
+              component,
+            },
+            state,
+            fixOptions: fixOptions as any,
+          })
+        }
       }
 
       for (let i = 0; i < (value.events ?? []).length; i++) {

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -5,6 +5,8 @@ import type {
 import type {
   Component,
   ComponentData,
+  ComponentFormula,
+  ComponentVariable,
   MediaQuery,
   NodeModel,
   SupportedNamespaces,
@@ -21,7 +23,7 @@ import {
 } from '@nordcraft/core/dist/styling/className'
 import { appendUnit } from '@nordcraft/core/dist/styling/customProperty'
 import type { Nullable } from '@nordcraft/core/dist/types'
-import { mapValues } from '@nordcraft/core/dist/utils/collections'
+import { filterObject, mapValues } from '@nordcraft/core/dist/utils/collections'
 import { getNodeSelector } from '@nordcraft/core/dist/utils/getNodeSelector'
 import { VOID_HTML_ELEMENTS } from '@nordcraft/core/dist/utils/html'
 import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
@@ -297,10 +299,13 @@ const renderComponent = async ({
           ...data.Contexts,
           [component.name]: Object.fromEntries(
             Object.entries(component.formulas ?? {})
-              .filter(([, formula]) => formula.exposeInContext)
+              .filter(([, formula]) => formula?.exposeInContext)
               .map(([key, formula]) => [
                 key,
-                applyFormula(formula.formula, formulaContext),
+                applyFormula(
+                  (formula as ComponentFormula).formula,
+                  formulaContext,
+                ),
               ]),
           ),
         }
@@ -365,7 +370,10 @@ const renderComponent = async ({
               Contexts: contexts,
               Page: formulaContext.data.Page,
               Variables: mapValues(
-                childComponent.variables ?? {},
+                filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+                  childComponent.variables ?? {},
+                  ([_, variable]) => isDefined(variable),
+                ),
                 ({ initialValue }) => {
                   return applyFormula(initialValue, formulaContext)
                 },
@@ -403,10 +411,10 @@ const renderComponent = async ({
                     ...contexts,
                     [childComponent.name]: Object.fromEntries(
                       Object.entries(childComponent.formulas ?? {})
-                        .filter(([, formula]) => formula.exposeInContext)
+                        .filter(([, formula]) => formula?.exposeInContext)
                         .map(([key, formula]) => [
                           key,
-                          applyFormula(formula.formula, {
+                          applyFormula((formula as ComponentFormula).formula, {
                             component: childComponent,
                             package: _packageName,
                             data: {
@@ -415,29 +423,38 @@ const renderComponent = async ({
                                 ...Object.fromEntries(
                                   Object.entries(childComponent.formulas ?? {})
                                     .filter(
-                                      ([, formula]) => formula.exposeInContext,
+                                      ([, formula]) => formula?.exposeInContext,
                                     )
                                     .map(([key, formula]) => [
                                       key,
-                                      applyFormula(formula.formula, {
-                                        data: {
-                                          Attributes: attrs,
-                                          Apis: { ...data.Apis, ...apis },
-                                          Location: data.Location,
-                                          Page: data.Page,
+                                      applyFormula(
+                                        (formula as ComponentFormula).formula,
+                                        {
+                                          data: {
+                                            Attributes: attrs,
+                                            Apis: { ...data.Apis, ...apis },
+                                            Location: data.Location,
+                                            Page: data.Page,
+                                          },
+                                          component,
+                                          package: _packageName,
+                                          env,
+                                          toddle,
                                         },
-                                        component,
-                                        package: _packageName,
-                                        env,
-                                        toddle,
-                                      }),
+                                      ),
                                     ]),
                                 ),
                               },
                               Apis: apis,
                               Attributes: attrs,
                               Variables: mapValues(
-                                childComponent.variables ?? {},
+                                filterObject<
+                                  Nullable<ComponentVariable>,
+                                  ComponentVariable
+                                >(
+                                  childComponent.variables ?? {},
+                                  ([_, variable]) => isDefined(variable),
+                                ),
                                 ({ initialValue }) => {
                                   return applyFormula(initialValue, {
                                     data: {
@@ -642,12 +659,18 @@ const createComponent = async ({
   }
 
   // Variables initial value has access to component data like attributes, so must be applied after formulaContext is somewhat populated
-  data.Variables = mapValues(component.variables ?? {}, ({ initialValue }) => {
-    return applyFormula(initialValue, {
-      ...formulaContext,
-      data,
-    })
-  })
+  data.Variables = mapValues(
+    filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+      component.variables ?? {},
+      ([_, variable]) => isDefined(variable),
+    ),
+    ({ initialValue }) => {
+      return applyFormula(initialValue, {
+        ...formulaContext,
+        data,
+      })
+    },
+  )
 
   // Own context formulas has access to all other data in the component (attributes, variables, apis etc.) so is applied last
   data.Contexts = {
@@ -656,10 +679,10 @@ const createComponent = async ({
       ...data.Contexts?.[component.name],
       ...Object.fromEntries(
         Object.entries(component.formulas ?? {})
-          .filter(([, formula]) => formula.exposeInContext)
+          .filter(([, formula]) => formula?.exposeInContext)
           .map(([key, formula]) => [
             key,
-            applyFormula(formula.formula, {
+            applyFormula((formula as ComponentFormula).formula, {
               ...formulaContext,
               data,
             }),

--- a/packages/ssr/src/rendering/formulaContext.ts
+++ b/packages/ssr/src/rendering/formulaContext.ts
@@ -1,5 +1,6 @@
 import { mapHeadersToObject } from '@nordcraft/core/dist/api/headers'
 import type {
+  ComponentVariable,
   PageComponent,
   PageRoute,
 } from '@nordcraft/core/dist/component/component.types'
@@ -12,7 +13,8 @@ import {
   isToddleFormula,
 } from '@nordcraft/core/dist/formula/formula'
 import type { PluginFormula } from '@nordcraft/core/dist/formula/formulaTypes'
-import { mapValues } from '@nordcraft/core/dist/utils/collections'
+import type { Nullable } from '@nordcraft/core/dist/types'
+import { filterObject, mapValues } from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import * as libFormulas from '@nordcraft/std-lib/dist/formulas'
 import { getPathSegments } from '../routing/routing'
@@ -71,7 +73,10 @@ export const getPageFormulaContext = ({
       : null,
   }
   formulaContext.data.Variables = mapValues(
-    component?.variables ?? {},
+    filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+      component?.variables ?? {},
+      ([_, variable]) => isDefined(variable),
+    ),
     ({ initialValue }) => {
       return applyFormula(initialValue, formulaContext)
     },

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -1,25 +1,37 @@
 import { isLegacyApi } from '@nordcraft/core/dist/api/api'
+import type { ComponentAPI } from '@nordcraft/core/dist/api/apiTypes'
 import type {
   ActionModel,
   Component,
+  ComponentAttribute,
+  ComponentFormula,
+  ComponentWorkflow,
   CustomActionArgument,
   NodeModel,
 } from '@nordcraft/core/dist/component/component.types'
 import { isFormula, type Formula } from '@nordcraft/core/dist/formula/formula'
-import { mapObject, omitKeys } from '@nordcraft/core/dist/utils/collections'
+import type { Nullable } from '@nordcraft/core/dist/types'
+import {
+  filterObject,
+  mapObject,
+  omitKeys,
+} from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 
 export const removeTestData = (component: Component): Component => ({
   ...component,
-  attributes: mapObject(component.attributes ?? {}, ([key, value]) => [
-    key,
-    omitKeys(value, ['testValue']),
-  ]),
+  attributes: mapObject(
+    filterObject<Nullable<ComponentAttribute>, ComponentAttribute>(
+      component.attributes ?? {},
+      ([_, value]) => isDefined(value),
+    ),
+    ([key, value]) => [key, omitKeys(value, ['testValue'])],
+  ),
   ...(component.events
     ? {
-        events: component.events.map((event) =>
-          omitKeys(event, ['dummyEvent']),
-        ),
+        events: component.events
+          .filter(isDefined)
+          .map((event) => omitKeys(event, ['dummyEvent'])),
       }
     : undefined),
   nodes: mapObject(component.nodes ?? {}, ([key, value]) => {
@@ -54,47 +66,61 @@ export const removeTestData = (component: Component): Component => ({
     : {}),
   ...(component.formulas
     ? {
-        formulas: mapObject(component.formulas, ([key, value]) => [
-          key,
-          {
-            ...value,
-            arguments: (value.arguments ?? []).map((a) =>
-              omitKeys(a, ['testValue']),
-            ),
-            formula: removeFormulaTestData(value.formula),
-          },
-        ]),
+        formulas: mapObject(
+          filterObject<Nullable<ComponentFormula>, ComponentFormula>(
+            component.formulas,
+            ([_, value]) => isDefined(value),
+          ),
+          ([key, value]) => [
+            key,
+            {
+              ...value,
+              arguments: (value.arguments ?? []).map((a) =>
+                omitKeys(a, ['testValue']),
+              ),
+              formula: removeFormulaTestData(value.formula),
+            },
+          ],
+        ),
       }
     : {}),
   ...(component.workflows
     ? {
-        workflows: mapObject(component.workflows, ([key, value]) => [
-          key,
-          {
-            ...omitKeys(value, ['testValue']),
-            // We should find all actions (also nested actions and non-workflow actions) and remove
-            // the description from them. This is a start though
-            actions: value.actions.map(removeActionTestData),
-            parameters: (value.parameters ?? []).map((p) =>
-              omitKeys(p, ['testValue']),
-            ),
-            callbacks: value.callbacks?.map((c) => omitKeys(c, ['testValue'])),
-          },
-        ]),
+        workflows: mapObject(
+          filterObject<Nullable<ComponentWorkflow>, ComponentWorkflow>(
+            component.workflows,
+            ([_, value]) => isDefined(value),
+          ),
+          ([key, value]) => [
+            key,
+            {
+              ...omitKeys(value, ['testValue']),
+              // We should find all actions (also nested actions and non-workflow actions) and remove
+              // the description from them. This is a start though
+              actions: value.actions.map(removeActionTestData),
+              parameters: (value.parameters ?? []).map((p) =>
+                omitKeys(p, ['testValue']),
+              ),
+              callbacks: value.callbacks?.map((c) =>
+                omitKeys(c, ['testValue']),
+              ),
+            },
+          ],
+        ),
       }
     : {}),
-  apis: mapObject(component.apis ?? {}, ([key, api]) => {
-    if (!isDefined(api)) {
-      // Keep null APIs although they're not valid/used
-      return [key, api]
-    }
-    return [
+  apis: mapObject(
+    filterObject<Nullable<ComponentAPI>, ComponentAPI>(
+      component.apis ?? {},
+      ([_, api]) => isDefined(api),
+    ),
+    ([key, api]) => [
       key,
       // service and servicePath are only necessary in the editor. All information about an API
       // request is available on the api object itself
       isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
-    ]
-  }),
+    ],
+  ),
   ...(component.onLoad
     ? {
         onLoad: {


### PR DESCRIPTION

- Adjust types for components to allow/support nullish values for attributes, variables, formulas, workflows, and events
- Filter out nullish values when iterating in all packages
- Adjust types for filterObject to take a second generic for the output type
  