### PR TITLE
Remove legacy routing support and dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,6 @@
         "@nordcraft/core": "workspace:*",
         "@nordcraft/std-lib": "workspace:*",
         "fast-deep-equal": "3.1.3",
-        "path-to-regexp": "6.3.0",
       },
     },
     "packages/search": {

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -177,8 +177,6 @@ export interface Component {
    * @deprecated - we are no longer using version 2 components, but we are keeping this field for backwards compatibility
    */
   version?: Nullable<2>
-  // @deprecated - use route->path instead
-  page?: Nullable<string> // page url /projects/:id - only for pages
   route?: Nullable<PageRoute>
   attributes?: Nullable<Record<string, Nullable<ComponentAttribute>>>
   variables?: Nullable<Record<string, Nullable<ComponentVariable>>>

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "@nordcraft/core": "workspace:*",
     "@nordcraft/std-lib": "workspace:*",
-    "fast-deep-equal": "3.1.3",
-    "path-to-regexp": "6.3.0"
+    "fast-deep-equal": "3.1.3"
   },
   "scripts": {
     "build": "tsgo && bun scripts/build.js",

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -389,7 +389,6 @@ export const createRoot = (
               Location: data.Location
                 ? {
                     ...data.Location,
-                    path: component?.page ?? '',
                   }
                 : undefined,
               // Ensure that URL parameters are only available for pages and not components
@@ -496,13 +495,6 @@ export const createRoot = (
                 Props: Record<string, unknown>
               } = {
                 ...data,
-                Location:
-                  data.Location && component?.page
-                    ? {
-                        ...data.Location,
-                        query: attrs as Record<string, string>,
-                      }
-                    : data.Location,
                 Props: attrs ?? {},
               }
               return newData

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -25,7 +25,6 @@ import { isDefined } from '@nordcraft/core/dist/utils/util'
 import * as libActions from '@nordcraft/std-lib/dist/actions'
 import * as libFormulas from '@nordcraft/std-lib/dist/formulas'
 import fastDeepEqual from 'fast-deep-equal'
-import { match } from 'path-to-regexp'
 import { isContextApiV2 } from './api/apiUtils'
 import { createLegacyAPI } from './api/createAPI'
 import { createAPI } from './api/createAPIv2'
@@ -107,7 +106,6 @@ export const initGlobalObject = (code?: {
       data: {},
       locationSignal: signal<any>({
         route: component.route,
-        page: component.page as string,
         path: window.location.pathname,
         params,
         query,
@@ -153,7 +151,6 @@ export const createRoot = (domNode: HTMLElement) => {
     window.toddle.locationSignal.update(() => {
       return {
         route: component?.route,
-        page: component!.page as string,
         path: window.location.pathname,
         params,
         query,
@@ -346,14 +343,6 @@ function parseUrl(component: Component) {
         params[segment.name] = segment.name
       }
     })
-  } else {
-    const urlPattern = match<Record<string, string>>(component.page ?? '', {
-      decode: decodeURIComponent,
-    })
-    const res = urlPattern(window.location.pathname) || {
-      params: {},
-    }
-    params = res.params
   }
 
   const [hash] = window.location.hash.split('?')

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -330,7 +330,7 @@ export const createRoot = (domNode: HTMLElement) => {
 
 function parseUrl(component: Component) {
   const path = window.location.pathname.split('/').slice(1)
-  let params: Record<string, string | null> = {}
+  const params: Record<string, string | null> = {}
   if (component.route) {
     component.route.path.forEach((segment, i) => {
       if (segment.type === 'param') {

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -30,7 +30,6 @@ export type LocationSignal = Signal<Location>
 
 export interface Location {
   route: Component['route']
-  page?: string
   path: string
   params: Record<string, string | null>
   query: Record<string, string | string[] | null>

--- a/packages/runtime/src/utils/url.ts
+++ b/packages/runtime/src/utils/url.ts
@@ -1,34 +1,25 @@
 import { isDefined } from '@nordcraft/core/dist/utils/util'
-import { compile } from 'path-to-regexp'
 import type { Location } from '../types'
 
-export const getLocationUrl = ({
-  query,
-  page,
-  route,
-  params,
-  hash,
-}: Location) => {
-  let path: string
-  if (route) {
-    const pathSegments: string[] = []
-    for (const segment of route.path) {
-      if (segment.type === 'static') {
-        pathSegments.push(segment.name)
+export const getLocationUrl = ({ query, route, params, hash }: Location) => {
+  if (!route) {
+    return
+  }
+  const pathSegments: string[] = []
+  for (const segment of route.path) {
+    if (segment.type === 'static') {
+      pathSegments.push(segment.name)
+    } else {
+      const segmentValue = params[segment.name]
+      if (isDefined(segmentValue)) {
+        pathSegments.push(segmentValue)
       } else {
-        const segmentValue = params[segment.name]
-        if (isDefined(segmentValue)) {
-          pathSegments.push(segmentValue)
-        } else {
-          // If a param is missing, we can't build the rest of the path
-          break
-        }
+        // If a param is missing, we can't build the rest of the path
+        break
       }
     }
-    path = '/' + pathSegments.join('/')
-  } else {
-    path = compile(page as string, { encode: encodeURIComponent })(params)
   }
+  const path = '/' + pathSegments.join('/')
   const hashString = hash === undefined || hash === '' ? '' : '#' + hash
   const queryString = Object.entries(query)
     .filter(([_, q]) => q !== null)

--- a/packages/ssr/src/rendering/formulaContext.ts
+++ b/packages/ssr/src/rendering/formulaContext.ts
@@ -46,7 +46,6 @@ export const getPageFormulaContext = ({
   const formulaContext: FormulaContext & { env: ToddleServerEnv } = {
     data: {
       Location: {
-        page: component?.page ?? '',
         path: url.pathname,
         params: combinedParams,
         query: searchParamsWithDefaults,


### PR DESCRIPTION
Routing using the `page` property with a regex pattern has not been supported for several years now, and it should be safe to remove once we have verified that there's no traffic using that feature.

This reduces the runtime's size (page.main.js) from 32.5KB (114KB) to 30.2KB (108KB) which is a ~7% reduction