### PR TITLE
Remove empty optional properties

### DIFF
--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -314,7 +314,7 @@ export interface CustomActionModel {
   package?: Nullable<string>
   name: string
   description?: Nullable<string>
-  group?: Nullable<string>
+  group?: Nullable<never>
   data?: Nullable<string | number | boolean | Formula>
   arguments?: Nullable<Partial<CustomActionArgument[]>>
   events?: Nullable<Record<string, ActionModelActions>>

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -93,15 +93,17 @@ export interface ElementNodeModel {
   repeat?: Nullable<Formula>
   repeatKey?: Nullable<Formula>
   tag: string
-  attrs: Partial<Record<string, Formula>>
+  attrs?: Nullable<Partial<Record<string, Formula>>>
   style?: Nullable<NodeStyleModel>
   variants?: Nullable<StyleVariant[]>
   animations?: Nullable<Record<string, Record<string, AnimationKeyframe>>>
-  children: string[]
-  events: Partial<Record<string, Nullable<EventModel>>>
+  children?: Nullable<string[]>
+  events?: Nullable<Partial<Record<string, Nullable<EventModel>>>>
   classes?: Nullable<Record<string, { formula?: Nullable<Formula> }>>
   'style-variables'?: Nullable<Array<StyleVariable>>
   customProperties?: Nullable<Record<CustomPropertyName, CustomProperty>>
+  // Legacy implementations added an invalid property. We'll keep it here to know we can safely remove it
+  styleVariables?: never
 }
 
 export interface ComponentNodeModel {
@@ -117,9 +119,9 @@ export interface ComponentNodeModel {
   style?: Nullable<NodeStyleModel>
   variants?: Nullable<StyleVariant[]>
   animations?: Nullable<Record<string, Record<string, AnimationKeyframe>>>
-  attrs: Record<string, Formula>
-  children: string[]
-  events: Record<string, EventModel>
+  attrs?: Nullable<Record<string, Formula>>
+  children?: Nullable<string[]>
+  events?: Nullable<Partial<Record<string, Nullable<EventModel>>>>
   customProperties?: Nullable<Record<CustomPropertyName, CustomProperty>>
 }
 
@@ -130,7 +132,9 @@ export interface SlotNodeModel {
   condition?: Nullable<Formula>
   repeat?: Nullable<never>
   repeatKey?: Nullable<never>
-  children: string[]
+  children?: Nullable<string[]>
+  // slots cannot have events, but an empty object might have been declared regardless
+  events?: never
 }
 export type NodeModel =
   | TextNodeModel
@@ -328,12 +332,16 @@ export interface SwitchActionModel {
     }>
   >
   default?: Nullable<ActionModelActions>
+  // Should never be set
+  arguments?: never
 }
 
 export interface VariableActionModel {
   type: 'SetVariable'
   variable: string
   data: Nullable<Formula>
+  // Arguments for this action should never be provided, but have been set sometimes
+  arguments?: never
 }
 
 export interface FetchActionModel {
@@ -355,6 +363,8 @@ export interface SetURLParameterAction {
   parameter: string
   data?: Nullable<Formula>
   historyMode?: Nullable<'replace' | 'push'>
+  // Should never be set
+  arguments?: never
 }
 
 export interface SetMultiUrlParameterAction {
@@ -367,12 +377,14 @@ export interface EventActionModel {
   type: 'TriggerEvent'
   event: string
   data?: Nullable<Formula>
+  // Should never be set
+  arguments?: never
 }
 
 export interface WorkflowActionModel {
   type: 'TriggerWorkflow'
   workflow: string
-  parameters: Record<string, { formula?: Nullable<Formula> }>
+  parameters?: Nullable<Record<string, { formula?: Nullable<Formula> }>>
   callbacks?: Nullable<
     Partial<Record<string, { actions?: Nullable<Partial<ActionModel[]>> }>>
   >
@@ -383,6 +395,8 @@ export interface WorkflowCallbackActionModel {
   type: 'TriggerWorkflowCallback'
   event: string
   data?: Nullable<Formula>
+  // Should never be set
+  arguments?: never
 }
 
 export type ActionModel =

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -314,7 +314,7 @@ export interface CustomActionModel {
   package?: Nullable<string>
   name: string
   description?: Nullable<string>
-  group?: Nullable<never>
+  group?: Nullable<unknown>
   data?: Nullable<string | number | boolean | Formula>
   arguments?: Nullable<Partial<CustomActionArgument[]>>
   events?: Nullable<Record<string, ActionModelActions>>

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -75,7 +75,7 @@ export function createComponent({
     reportFormulaEvaluation: ctx.reportFormulaEvaluation,
   }
   const attributesSignal = dataSignal.map((data) => {
-    return mapObject(node.attrs, ([attr, value]) => [
+    return mapObject(node.attrs ?? {}, ([attr, value]) => [
       attr,
       value?.type !== 'value'
         ? applyFormula(
@@ -189,8 +189,8 @@ export function createComponent({
         formulaCache,
         package: node.package ?? ctx.package,
         triggerEvent: (eventTrigger, data) => {
-          const eventHandler = Object.values(node.events).find(
-            (e) => e.trigger === eventTrigger,
+          const eventHandler = Object.values(node.events ?? {}).find(
+            (e) => e?.trigger === eventTrigger,
           )
           if (eventHandler) {
             eventHandler.actions?.forEach((action) =>
@@ -212,8 +212,8 @@ export function createComponent({
           formulaCache,
           package: node.package ?? ctx.package,
           triggerEvent: (eventTrigger, data) => {
-            const eventHandler = Object.values(node.events).find(
-              (e) => e.trigger === eventTrigger,
+            const eventHandler = Object.values(node.events ?? {}).find(
+              (e) => e?.trigger === eventTrigger,
             )
             if (eventHandler) {
               eventHandler.actions?.forEach((action) =>
@@ -233,8 +233,8 @@ export function createComponent({
     })
 
   const onEvent = (eventTrigger: string, data: any) => {
-    const eventHandler = Object.values(node.events).find(
-      (e) => e.trigger === eventTrigger,
+    const eventHandler = Object.values(node.events ?? {}).find(
+      (e) => e?.trigger === eventTrigger,
     )
     if (eventHandler) {
       eventHandler.actions?.forEach((action) =>
@@ -289,8 +289,11 @@ export function createComponent({
   }
 
   const children: Record<string, Array<ComponentChild>> = {}
-  for (let i = 0; i < node.children.length; i++) {
-    const childId = node.children[i]
+  for (let i = 0; i < (node?.children ?? []).length; i++) {
+    const childId = node.children?.[i]
+    if (childId === undefined) {
+      continue
+    }
     const childNode = ctx.component.nodes?.[childId]
     const slotName = childNode?.slot ?? 'default'
     children[slotName] = children[slotName] ?? []

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -1,5 +1,6 @@
 import type {
   ElementNodeModel,
+  EventModel,
   NodeModel,
   SupportedNamespaces,
 } from '@nordcraft/core/dist/component/component.types'
@@ -45,7 +46,7 @@ export function createElement({
   }
 
   // Explicitly setting a namespace has precedence over inferring it from the tag
-  if (node.attrs['xmlns']?.type === 'value') {
+  if (node.attrs?.['xmlns']?.type === 'value') {
     namespace = String(node.attrs['xmlns'].value) as SupportedNamespaces
   }
 
@@ -99,7 +100,7 @@ export function createElement({
     })
   }
 
-  Object.entries(node.attrs).forEach(([attr, value]) => {
+  Object.entries(node.attrs ?? {}).forEach(([attr, value]) => {
     if (!isDefined(value)) {
       return
     }
@@ -233,7 +234,7 @@ export function createElement({
   })
 
   const eventHandlers: [string, (e: Event) => boolean][] = []
-  Object.values(node.events).forEach((event) => {
+  Object.values(node.events ?? {}).forEach((event) => {
     if (!event) {
       return
     }
@@ -253,7 +254,7 @@ export function createElement({
   const nodeTag = node.tag.toLocaleLowerCase()
   if (nodeTag === 'script' || nodeTag === 'style') {
     const textValues: Array<Signal<string> | string> = []
-    node.children
+    ;(node.children ?? [])
       .map<NodeModel | undefined>((child) => ctx.component.nodes?.[child])
       .filter((node) => node?.type === 'text')
       .forEach((node) => {
@@ -289,7 +290,7 @@ export function createElement({
       })
   } else {
     const childNodes: (Element | Text)[] = []
-    node.children.forEach((child, i) => {
+    ;(node.children ?? []).forEach((child, i) => {
       childNodes.push(
         ...createNode({
           parentElement: elem,
@@ -320,7 +321,7 @@ const getEventHandler =
     dataSignal,
     ctx,
   }: {
-    event: ElementNodeModel['events'][string]
+    event: EventModel
     dataSignal: Signal<ComponentData>
     ctx: ComponentContext
   }) =>

--- a/packages/runtime/src/components/createSlot.ts
+++ b/packages/runtime/src/components/createSlot.ts
@@ -49,7 +49,7 @@ export function createSlot({
     })
   } else {
     // Otherwise, return placeholder content
-    children = node.children.flatMap((child, i) => {
+    children = (node.children ?? []).flatMap((child, i) => {
       return createNode({
         id: child,
         path: path + '.' + i,

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -646,7 +646,7 @@ export const createRoot = (
                 } else {
                   const firstTextChild =
                     nodeLookup?.node.type === 'element'
-                      ? nodeLookup.node.children.find(
+                      ? nodeLookup.node.children?.find(
                           (c) => component?.nodes?.[c]?.type === 'text',
                         )
                       : undefined

--- a/packages/runtime/src/editor/links.ts
+++ b/packages/runtime/src/editor/links.ts
@@ -9,6 +9,9 @@ export const updateComponentLinks = (component: Component) => {
   // Find all links and add target="_blank" to them
   Object.entries(component.nodes ?? {}).forEach(([_, node]) => {
     if (node.type === 'element' && node.tag === 'a') {
+      if (!node.attrs) {
+        node.attrs = {}
+      }
       node.attrs['target'] = valueFormula('_blank')
     }
   })

--- a/packages/runtime/src/utils/nodes.ts
+++ b/packages/runtime/src/utils/nodes.ts
@@ -29,7 +29,7 @@ export const getNodeAndAncestors = (
       // 'text' elements don't have any children
       case 'element':
       case 'component':
-      case 'slot':
+      case 'slot': {
         // Ancestors are elements before the target node
         if (i <= nodePath.length - 1) {
           ancestors.push({
@@ -38,7 +38,12 @@ export const getNodeAndAncestors = (
             nodeId: path.slice(0, i + 1).join('.'),
           })
         }
-        return component.nodes?.[node.children[childIndex]]
+        const index = node.children?.[childIndex]
+        if (index === undefined) {
+          return undefined
+        }
+        return component.nodes?.[index]
+      }
       default:
         return undefined
     }

--- a/packages/search/src/rules/issues/attributes/noReferenceAttributeInInstanceRule.ts
+++ b/packages/search/src/rules/issues/attributes/noReferenceAttributeInInstanceRule.ts
@@ -35,7 +35,7 @@ export const noReferenceAttributeInInstanceRule: IssueRule<void> = {
         Object.values(otherComponent?.nodes ?? {})
           .filter((node) => node.type === 'component')
           .forEach((instance) =>
-            Object.keys(instance.attrs).forEach((attr) => {
+            Object.keys(instance.attrs ?? {}).forEach((attr) => {
               attrs.add([instance.name, attr].join('/'))
             }),
           ),

--- a/packages/search/src/rules/issues/dom/createRequiredDirectChildRule.ts
+++ b/packages/search/src/rules/issues/dom/createRequiredDirectChildRule.ts
@@ -24,7 +24,7 @@ export function createRequiredDirectChildRule(
       }
       const getElement = (id: string): NodeModel | undefined =>
         component.nodes?.[id]
-      value.children.forEach((childId) => {
+      ;(value.children ?? []).forEach((childId) => {
         const childNode = getElement(childId)
         if (
           childNode?.type === 'element' &&

--- a/packages/search/src/rules/issues/dom/createRequiredDirectParentRule.ts
+++ b/packages/search/src/rules/issues/dom/createRequiredDirectParentRule.ts
@@ -23,7 +23,7 @@ export function createRequiredDirectParentRule(
       }
       const nodeId = String(args.path[args.path.length - 1])
       const parent = Object.values(component.nodes ?? {}).find(
-        (node) => node.type === 'element' && node.children.includes(nodeId),
+        (node) => node.type === 'element' && node.children?.includes(nodeId),
       )
       if (parent?.type === 'element' && !parentTags.includes(parent.tag)) {
         report({

--- a/packages/search/src/rules/issues/dom/createRequiredElementAttributeRule.ts
+++ b/packages/search/src/rules/issues/dom/createRequiredElementAttributeRule.ts
@@ -37,7 +37,7 @@ export function createRequiredElementAttributeRule({
         const attributes = Array.isArray(attribute) ? attribute : [attribute]
         if (
           attributes.some((attr) => {
-            if (!isDefined(value.attrs[attr])) {
+            if (!isDefined(value.attrs?.[attr])) {
               return false
             }
             const { isStatic, result } = contextlessEvaluateFormula(

--- a/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
+++ b/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
@@ -79,13 +79,13 @@ export const elementWithoutInteractiveContentRule: IssueRule<{
         // Search children in slot/component/element:
         return searchChildren(
           container,
-          child.children,
+          child.children ?? [],
           allResults,
           visitedComponents,
         )
       }, results)
     }
-    const childTags = searchChildren(component, value.children)
+    const childTags = searchChildren(component, value.children ?? [])
     if (childTags.length > 0) {
       childTags.forEach((ic) =>
         report({

--- a/packages/search/src/rules/issues/dom/imageWithoutDimensionRule.ts
+++ b/packages/search/src/rules/issues/dom/imageWithoutDimensionRule.ts
@@ -24,13 +24,13 @@ export const imageWithoutDimensionRule: IssueRule = {
     let hasValidHeight = false
     let hasValidAspectRatio = false
 
-    if (isDefined(value.attrs.width)) {
+    if (isDefined(value.attrs?.width)) {
       const widthEval = contextlessEvaluateFormula(value.attrs.width)
       // If dynamic, we assume it is valid
       hasValidWidth ||= !widthEval.isStatic || checkValue(widthEval.result)
     }
 
-    if (isDefined(value.attrs.height)) {
+    if (isDefined(value.attrs?.height)) {
       const heightEval = contextlessEvaluateFormula(value.attrs.height)
       // If dynamic, we assume it is valid
       hasValidHeight ||= !heightEval.isStatic || checkValue(heightEval.result)

--- a/packages/search/src/rules/issues/dom/nonEmptyVoidElementRule.ts
+++ b/packages/search/src/rules/issues/dom/nonEmptyVoidElementRule.ts
@@ -12,7 +12,7 @@ export const nonEmptyVoidElementRule: IssueRule<{ tag: string }> = {
     if (
       nodeType !== 'component-node' ||
       value.type !== 'element' ||
-      value.children.length <= 0 ||
+      (value.children ?? []).length <= 0 ||
       !VOID_HTML_ELEMENTS.includes(value.tag)
     ) {
       return

--- a/packages/search/src/rules/issues/events/unknownEventRule.ts
+++ b/packages/search/src/rules/issues/events/unknownEventRule.ts
@@ -23,7 +23,7 @@ export const unknownEventRule: IssueRule<{
     const componentEvents = new Set(
       (component?.events ?? []).map((e) => e?.name),
     )
-    Object.entries(value.events).forEach(([eventKey, event]) => {
+    Object.entries(value.events ?? {}).forEach(([eventKey, event]) => {
       if (isDefined(event) && !componentEvents.has(event.trigger)) {
         report({
           path: [...path, 'events', eventKey],

--- a/packages/search/src/rules/issues/slots/unknownComponentSlotRule.ts
+++ b/packages/search/src/rules/issues/slots/unknownComponentSlotRule.ts
@@ -38,7 +38,7 @@ export const unknownComponentSlotRule: IssueRule<{ slotName: string }> = {
       .map((node) => node.name ?? 'default')
 
     // Loop the children and report issue when using a slot that doesn't exist
-    value.children.forEach((child) => {
+    value.children?.forEach((child) => {
       const childNode = files.components[currentComponentName]?.nodes?.[child]
       const usedSlot = childNode?.slot ?? 'default'
 

--- a/packages/search/src/util/helpers.ts
+++ b/packages/search/src/util/helpers.ts
@@ -123,10 +123,10 @@ export const interactiveContentElementDefinition = (
       return false
     }
     if ('whenAttributeIsPresent' in ic) {
-      return isDefined(element.attrs[ic.whenAttributeIsPresent])
+      return isDefined(element.attrs?.[ic.whenAttributeIsPresent])
     }
     if ('whenAttributeIsNot' in ic) {
-      const attributeFormula = element.attrs[ic.whenAttributeIsNot.attribute]
+      const attributeFormula = element.attrs?.[ic.whenAttributeIsNot.attribute]
       return (
         attributeFormula?.type === 'value' &&
         attributeFormula.value === ic.whenAttributeIsNot.value

--- a/packages/ssr/src/rendering/attributes.ts
+++ b/packages/ssr/src/rendering/attributes.ts
@@ -59,7 +59,7 @@ export function getNodeAttrs({
   env: ToddleEnv
   toddle: FormulaContext['toddle']
 }) {
-  const { style, ...restAttrs } = node.attrs
+  const { style, ...restAttrs } = node.attrs ?? {}
   const nodeAttrs = Object.entries(restAttrs).reduce<string[]>(
     (appliedAttributes, [name, attrValue]) => {
       const value = applyFormula(attrValue, {

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -159,7 +159,7 @@ const renderComponent = async ({
             : defaultChild
         } else {
           const slotChildren = await Promise.all(
-            node.children.map((child) =>
+            (node.children ?? []).map((child) =>
               renderNode({
                 id: child,
                 path: `${path}[${node.name ?? 'default'}]`,
@@ -251,23 +251,25 @@ const renderComponent = async ({
         if (
           ['script', 'style'].includes(node.tag.toLocaleLowerCase()) === false
         ) {
-          const childNodes = await Promise.all(
-            node.children.map((child, i) =>
-              renderNode({
-                id: child,
-                path: `${path}.${i}`,
-                namespace,
-                node: component.nodes?.[child],
-                data,
-                packageName,
-              }),
-            ),
-          )
+          const childNodes = node.children
+            ? await Promise.all(
+                node.children.map((child, i) =>
+                  renderNode({
+                    id: child,
+                    path: `${path}.${i}`,
+                    namespace,
+                    node: component.nodes?.[child],
+                    data,
+                    packageName,
+                  }),
+                ),
+              )
+            : []
           innerHTML = childNodes.join('')
         }
         if (node.tag.toLocaleLowerCase() === 'style') {
           // render style content as text
-          const textNode = node.children[0]
+          const textNode = node.children?.[0]
             ? component.nodes?.[node.children[0]]
             : undefined
           if (textNode?.type === 'text') {
@@ -291,7 +293,7 @@ const renderComponent = async ({
         }
       }
       case 'component': {
-        const attrs = mapValues(node.attrs, (formula) =>
+        const attrs = mapValues(node.attrs ?? {}, (formula) =>
           applyFormula(formula, formulaContext),
         )
 
@@ -392,7 +394,7 @@ const renderComponent = async ({
         })
 
         const childNodes = await Promise.all(
-          node.children.map(async (child, i) => {
+          (node.children ?? []).map(async (child, i) => {
             const slotName =
               typeof child === 'string'
                 ? (component.nodes?.[child]?.slot ?? 'default')
@@ -486,7 +488,7 @@ const renderComponent = async ({
 
         const children: Record<string, SlottedContent> = {}
         childNodes.forEach((renderFn, i) => {
-          const childNodeId = node.children[i]
+          const childNodeId = node.children?.[i]
           // Add children to the correct slot in the right order
           const slotName =
             typeof childNodeId === 'string'

--- a/packages/ssr/src/rendering/testData.test.ts
+++ b/packages/ssr/src/rendering/testData.test.ts
@@ -126,8 +126,6 @@ describe('removeTestData', () => {
       }),
     ).toMatchInlineSnapshot(`
       {
-        "apis": {},
-        "attributes": {},
         "formulas": {
           "formula2": {
             "arguments": [
@@ -157,8 +155,6 @@ describe('removeTestData', () => {
           },
         },
         "name": "test",
-        "nodes": {},
-        "variables": {},
       }
     `)
   })
@@ -331,14 +327,9 @@ describe('removeTestData', () => {
     })
     expect(updatedData).toMatchInlineSnapshot(`
       {
-        "apis": {},
-        "attributes": {},
         "name": "test",
         "nodes": {
           "root": {
-            "attrs": {},
-            "children": [],
-            "classes": {},
             "events": {
               "onClick": {
                 "actions": [
@@ -359,7 +350,6 @@ describe('removeTestData', () => {
                 "trigger": "click",
               },
             },
-            "style": {},
             "tag": "div",
             "type": "element",
           },
@@ -400,7 +390,6 @@ describe('removeTestData', () => {
           ],
           "trigger": "onLoad",
         },
-        "variables": {},
       }
     `)
   })
@@ -440,10 +429,7 @@ describe('removeTestData', () => {
     })
     expect(updatedData).toMatchInlineSnapshot(`
       {
-        "apis": {},
-        "attributes": {},
         "name": "test",
-        "nodes": {},
         "onAttributeChange": {
           "actions": [],
           "trigger": "onAttributeChange",
@@ -452,7 +438,6 @@ describe('removeTestData', () => {
           "actions": [],
           "trigger": "onLoad",
         },
-        "variables": {},
         "workflows": {
           "My Workflow": {
             "actions": [],
@@ -471,5 +456,43 @@ describe('removeTestData', () => {
         },
       }
     `)
+  })
+  test('it removes unnecessary arguments from event actions', () => {
+    const cleanedComponent = removeTestData({
+      name: 'test',
+      variables: {},
+      apis: {},
+      nodes: {
+        root: {
+          name: 'Intersection observer',
+          type: 'component',
+          style: {
+            width: '100%',
+            height: '100%',
+          },
+          events: {
+            Change: {
+              actions: [
+                {
+                  data: {
+                    path: ['Event', 'isIntersecting'],
+                    type: 'path',
+                  },
+                  type: 'SetVariable',
+                  variable: 'intersecting',
+                  arguments: null as any, // Check that this gets removed
+                },
+              ],
+              trigger: 'Change',
+            },
+          },
+          package: 'intersection_observer',
+          children: ['Kd8s0Y74_nYzk7T-Ow-ct'],
+        },
+      },
+    }) as any
+    expect(
+      cleanedComponent.nodes.root.events.Change.actions[0].arguments,
+    ).toBeUndefined()
   })
 })

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -7,9 +7,21 @@ import type {
   ComponentFormula,
   ComponentWorkflow,
   CustomActionArgument,
+  CustomActionModel,
+  EventActionModel,
   NodeModel,
+  SetURLParameterAction,
+  SwitchActionModel,
+  TextNodeModel,
+  VariableActionModel,
+  WorkflowActionModel,
+  WorkflowCallbackActionModel,
 } from '@nordcraft/core/dist/component/component.types'
-import { isFormula, type Formula } from '@nordcraft/core/dist/formula/formula'
+import {
+  isFormula,
+  type ApplyOperation,
+  type Formula,
+} from '@nordcraft/core/dist/formula/formula'
 import type { Nullable } from '@nordcraft/core/dist/types'
 import {
   filterObject,
@@ -18,127 +30,273 @@ import {
 } from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 
-export const removeTestData = (component: Component): Component => ({
-  ...component,
-  attributes: mapObject(
-    filterObject<Nullable<ComponentAttribute>, ComponentAttribute>(
-      component.attributes ?? {},
-      ([_, value]) => isDefined(value),
-    ),
-    ([key, value]) => [key, omitKeys(value, ['testValue'])],
-  ),
-  ...(component.events
-    ? {
-        events: component.events
-          .filter(isDefined)
-          .map((event) => omitKeys(event, ['dummyEvent'])),
-      }
-    : undefined),
-  nodes: mapObject(component.nodes ?? {}, ([key, value]) => {
-    if (value.type === 'element') {
-      const updatedNode: NodeModel = {
-        ...value,
-        events: mapObject(value.events, ([eventKey, eventValue]) => [
-          eventKey,
-          eventValue
-            ? {
-                ...eventValue,
-                actions: eventValue.actions?.map(removeActionTestData),
-              }
-            : null,
-        ]),
-      }
-      return [key, updatedNode as NodeModel]
-    }
-    return [key, value]
-  }),
-  ...(component.route
-    ? {
-        route: {
-          ...component.route,
-          path: component.route.path.map((p) => omitKeys(p, ['testValue'])),
-          query: mapObject(component.route.query, ([key, value]) => [
-            key,
-            omitKeys(value, ['testValue']),
+export const removeTestData = (component: Component): Component =>
+  removeOptionalPropertiesIfEmpty<Component>(
+    {
+      ...component,
+      attributes: mapObject(
+        filterObject<Nullable<ComponentAttribute>, ComponentAttribute>(
+          component.attributes ?? {},
+          ([_, value]) => isDefined(value),
+        ),
+        ([key, value]) => [key, omitKeys(value, ['testValue'])],
+      ),
+      ...(component.events
+        ? {
+            events: component.events
+              .filter(isDefined)
+              .map((event) => omitKeys(event, ['dummyEvent'])),
+          }
+        : undefined),
+      nodes: processNodes(component.nodes),
+      ...(component.route
+        ? {
+            route: {
+              ...component.route,
+              path: component.route.path.map((p) => omitKeys(p, ['testValue'])),
+              query: mapObject(component.route.query, ([key, value]) => [
+                key,
+                omitKeys(value, ['testValue']),
+              ]),
+            },
+          }
+        : {}),
+      ...(component.formulas
+        ? {
+            formulas: mapObject(
+              filterObject<Nullable<ComponentFormula>, ComponentFormula>(
+                component.formulas,
+                ([_, value]) => isDefined(value),
+              ),
+              ([key, value]) => [
+                key,
+                {
+                  ...value,
+                  arguments: (value.arguments ?? []).map((a) =>
+                    omitKeys(a, ['testValue']),
+                  ),
+                  formula: removeFormulaTestData(value.formula),
+                },
+              ],
+            ),
+          }
+        : {}),
+      ...(component.workflows
+        ? {
+            workflows: mapObject(
+              filterObject<Nullable<ComponentWorkflow>, ComponentWorkflow>(
+                component.workflows,
+                ([_, value]) => isDefined(value),
+              ),
+              ([key, value]) => [
+                key,
+                {
+                  ...omitKeys(value, ['testValue']),
+                  // We should find all actions (also nested actions and non-workflow actions) and remove
+                  // the description from them. This is a start though
+                  actions: value.actions.map(removeActionTestData),
+                  parameters: (value.parameters ?? []).map((p) =>
+                    omitKeys(p, ['testValue']),
+                  ),
+                  callbacks: value.callbacks?.map((c) =>
+                    omitKeys(c, ['testValue']),
+                  ),
+                },
+              ],
+            ),
+          }
+        : {}),
+      apis: mapObject(
+        filterObject<Nullable<ComponentAPI>, ComponentAPI>(
+          component.apis ?? {},
+          ([_, api]) => isDefined(api),
+        ),
+        ([key, api]) => [
+          key,
+          // service and servicePath are only necessary in the editor. All information about an API
+          // request is available on the api object itself
+          isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
+        ],
+      ),
+      ...(component.onLoad
+        ? {
+            onLoad: {
+              ...component.onLoad,
+              actions: component.onLoad.actions?.map(removeActionTestData),
+            },
+          }
+        : undefined),
+      ...(component.onAttributeChange
+        ? {
+            onAttributeChange: {
+              ...component.onAttributeChange,
+              actions:
+                component.onAttributeChange.actions?.map(removeActionTestData),
+            },
+          }
+        : undefined),
+    },
+    [
+      'version',
+      'page',
+      'route',
+      'attributes',
+      'variables',
+      'formulas',
+      'contexts',
+      'workflows',
+      'apis',
+      'nodes',
+      'events',
+      'onLoad',
+      'onAttributeChange',
+      'exported',
+      'customElement',
+    ],
+  )
+
+const processNodes = (
+  nodes: Component['nodes'],
+): Record<string, NodeModel> | undefined => {
+  if (!isDefined(nodes)) {
+    return undefined
+  }
+  return mapObject(nodes, ([key, value]) => {
+    switch (value.type) {
+      case 'element': {
+        const updatedNode: NodeModel = {
+          ...value,
+          events: mapObject(value.events ?? {}, ([eventKey, eventValue]) => [
+            eventKey,
+            eventValue
+              ? {
+                  ...eventValue,
+                  actions: eventValue.actions?.map(removeActionTestData),
+                }
+              : null,
           ]),
-        },
+          repeat: value.repeat
+            ? removeFormulaTestData(value.repeat)
+            : undefined,
+          repeatKey: value.repeatKey
+            ? removeFormulaTestData(value.repeatKey)
+            : undefined,
+        }
+        return [
+          key,
+          removeOptionalPropertiesIfEmpty(updatedNode, [
+            'animations',
+            'attrs',
+            'children',
+            'condition',
+            'classes',
+            'customProperties',
+            'events',
+            'id',
+            'repeat',
+            'repeatKey',
+            'slot',
+            'style-variables',
+            'style',
+            'styleVariables',
+            'variants',
+          ]) as NodeModel,
+        ]
       }
-    : {}),
-  ...(component.formulas
-    ? {
-        formulas: mapObject(
-          filterObject<Nullable<ComponentFormula>, ComponentFormula>(
-            component.formulas,
-            ([_, value]) => isDefined(value),
-          ),
-          ([key, value]) => [
-            key,
+      case 'text': {
+        return [
+          key,
+          removeOptionalPropertiesIfEmpty<TextNodeModel>(
             {
               ...value,
-              arguments: (value.arguments ?? []).map((a) =>
-                omitKeys(a, ['testValue']),
-              ),
-              formula: removeFormulaTestData(value.formula),
+              repeat: value.repeat
+                ? removeFormulaTestData(value.repeat)
+                : undefined,
+              repeatKey: value.repeatKey
+                ? removeFormulaTestData(value.repeatKey)
+                : undefined,
             },
-          ],
-        ),
+            ['id', 'slot', 'repeat', 'repeatKey'],
+          ) as NodeModel,
+        ]
       }
-    : {}),
-  ...(component.workflows
-    ? {
-        workflows: mapObject(
-          filterObject<Nullable<ComponentWorkflow>, ComponentWorkflow>(
-            component.workflows,
-            ([_, value]) => isDefined(value),
-          ),
-          ([key, value]) => [
-            key,
-            {
-              ...omitKeys(value, ['testValue']),
-              // We should find all actions (also nested actions and non-workflow actions) and remove
-              // the description from them. This is a start though
-              actions: value.actions.map(removeActionTestData),
-              parameters: (value.parameters ?? []).map((p) =>
-                omitKeys(p, ['testValue']),
-              ),
-              callbacks: value.callbacks?.map((c) =>
-                omitKeys(c, ['testValue']),
-              ),
-            },
-          ],
-        ),
+      case 'component': {
+        const updatedNode: NodeModel = {
+          ...value,
+          events: mapObject(value.events ?? {}, ([eventKey, eventValue]) => [
+            eventKey,
+            eventValue
+              ? {
+                  ...eventValue,
+                  actions: eventValue.actions?.map(removeActionTestData),
+                }
+              : null,
+          ]),
+          repeat: value.repeat
+            ? removeFormulaTestData(value.repeat)
+            : undefined,
+          repeatKey: value.repeatKey
+            ? removeFormulaTestData(value.repeatKey)
+            : undefined,
+        }
+        return [
+          key,
+          removeOptionalPropertiesIfEmpty(updatedNode, [
+            'id',
+            'slot',
+            'path',
+            'package',
+            'condition',
+            'repeat',
+            'repeatKey',
+            'style',
+            'variants',
+            'animations',
+            'attrs',
+            'children',
+            'events',
+          ]) as NodeModel,
+        ]
       }
-    : {}),
-  apis: mapObject(
-    filterObject<Nullable<ComponentAPI>, ComponentAPI>(
-      component.apis ?? {},
-      ([_, api]) => isDefined(api),
-    ),
-    ([key, api]) => [
-      key,
-      // service and servicePath are only necessary in the editor. All information about an API
-      // request is available on the api object itself
-      isLegacyApi(api) ? api : omitKeys(api, ['service', 'servicePath']),
-    ],
-  ),
-  ...(component.onLoad
-    ? {
-        onLoad: {
-          ...component.onLoad,
-          actions: component.onLoad.actions?.map(removeActionTestData),
-        },
+      case 'slot': {
+        return [
+          key,
+          removeOptionalPropertiesIfEmpty(
+            omitKeys(
+              value,
+              // Always remove repeat and repeatKey from slots as they're not supported
+              ['repeat', 'repeatKey'],
+            ),
+            ['children', 'condition', 'events', 'name', 'slot'],
+          ) as NodeModel,
+        ]
       }
-    : undefined),
-  ...(component.onAttributeChange
-    ? {
-        onAttributeChange: {
-          ...component.onAttributeChange,
-          actions:
-            component.onAttributeChange.actions?.map(removeActionTestData),
-        },
-      }
-    : undefined),
-})
+    }
+  })
+}
+
+type OptionalKeys<T extends object> = {
+  [K in keyof T]-?: object extends Pick<T, K> ? K : never
+}[keyof T]
+
+const removeOptionalPropertiesIfEmpty = <T extends object>(
+  obj: T,
+  keysToRemove: OptionalKeys<T>[],
+): T => {
+  const newObj = { ...obj }
+  for (const key of keysToRemove) {
+    const value = obj[key]
+    if (
+      value === null ||
+      value === undefined ||
+      (Array.isArray(value) && value.length === 0) || // Covers empty arrays
+      (typeof value === 'object' && Object.keys(value).length === 0) // Covers empty objects
+    ) {
+      delete newObj[key]
+    }
+  }
+  return newObj
+}
 
 const removeActionTestData = (action: ActionModel): ActionModel => {
   if (!isDefined(action)) {
@@ -146,36 +304,47 @@ const removeActionTestData = (action: ActionModel): ActionModel => {
   }
   switch (action.type) {
     case 'SetVariable':
-      return {
-        ...action,
-        ...(action.data
-          ? { data: removeFormulaTestData(action.data) }
-          : undefined),
-      }
+      return removeOptionalPropertiesIfEmpty<VariableActionModel>(
+        {
+          ...action,
+          ...(action.data
+            ? { data: removeFormulaTestData(action.data) }
+            : undefined),
+        },
+        ['arguments'],
+      )
     case 'TriggerEvent':
     case 'SetURLParameter':
     case 'TriggerWorkflowCallback':
-      return {
-        ...action,
-        ...(action.data
-          ? { data: removeFormulaTestData(action.data) }
-          : undefined),
-      }
-    case 'Switch':
-      return {
-        ...action,
-        cases: (action.cases ?? []).map((c) => ({
-          ...c,
-          ...(c.condition
-            ? { condition: removeFormulaTestData(c.condition) }
+      return removeOptionalPropertiesIfEmpty<
+        EventActionModel | SetURLParameterAction | WorkflowCallbackActionModel
+      >(
+        {
+          ...action,
+          ...(action.data
+            ? { data: removeFormulaTestData(action.data) }
             : undefined),
-          actions: c.actions.map(removeActionTestData),
-        })),
-        default: {
-          ...action.default,
-          actions: (action.default?.actions ?? []).map(removeActionTestData),
         },
-      }
+        ['arguments'],
+      )
+    case 'Switch':
+      return removeOptionalPropertiesIfEmpty<SwitchActionModel>(
+        {
+          ...action,
+          cases: (action.cases ?? []).map((c) => ({
+            ...c,
+            ...(c.condition
+              ? { condition: removeFormulaTestData(c.condition) }
+              : undefined),
+            actions: c.actions.map(removeActionTestData),
+          })),
+          default: {
+            ...action.default,
+            actions: (action.default?.actions ?? []).map(removeActionTestData),
+          },
+        },
+        ['arguments'],
+      )
     case 'Fetch':
       return {
         ...action,
@@ -210,38 +379,41 @@ const removeActionTestData = (action: ActionModel): ActionModel => {
     case 'Custom':
     case undefined:
     case null:
-      return {
-        // The 'group' property was used for categorizing actions and should
-        // not have been persisted in projects. But since it's there (for some actions)
-        // we should remove it
-        ...omitKeys(action, ['description', 'group', 'label']),
-        ...(action.arguments
-          ? {
-              arguments: action.arguments.map((a) =>
-                a ? removeActionArgumentTestData(a) : a,
-              ),
-            }
-          : undefined),
-        ...(action.events
-          ? {
-              events: mapObject(
-                action.events ?? {},
-                ([eventKey, eventValue]) => [
-                  eventKey,
-                  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                  eventValue
-                    ? {
-                        ...eventValue,
-                        actions: (eventValue.actions ?? []).map(
-                          removeActionTestData,
-                        ),
-                      }
-                    : eventValue,
-                ],
-              ),
-            }
-          : undefined),
-      }
+      return removeOptionalPropertiesIfEmpty<CustomActionModel>(
+        {
+          // The 'group' property was used for categorizing actions and should
+          // not have been persisted in projects. But since it's there (for some actions)
+          // we should remove it
+          ...omitKeys(action, ['description', 'group', 'label']),
+          ...(action.arguments
+            ? {
+                arguments: action.arguments.map((a) =>
+                  a ? removeActionArgumentTestData(a) : a,
+                ),
+              }
+            : undefined),
+          ...(action.events
+            ? {
+                events: mapObject(
+                  action.events ?? {},
+                  ([eventKey, eventValue]) => [
+                    eventKey,
+                    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                    eventValue
+                      ? {
+                          ...eventValue,
+                          actions: (eventValue.actions ?? []).map(
+                            removeActionTestData,
+                          ),
+                        }
+                      : eventValue,
+                  ],
+                ),
+              }
+            : undefined),
+        },
+        ['arguments', 'events', 'package'],
+      )
     case 'SetURLParameters':
       return {
         ...action,
@@ -251,39 +423,42 @@ const removeActionTestData = (action: ActionModel): ActionModel => {
         ]),
       }
     case 'TriggerWorkflow':
-      return {
-        ...action,
-        // TODO: Below was breaking the build - investigate. Test by adding an animation etc. and see if it is being set to null by mistake
-        // ...(action.parameters
-        //   ? {
-        //       parameters: mapObject(action.parameters, ([key, value]) => [
-        //         key,
-        //         {
-        //           ...value,
-        //           formula: isFormula(value)
-        //             ? removeFormulaTestData(value)
-        //             : isFormula(value.formula)
-        //               ? removeFormulaTestData(value.formula)
-        //               : value.formula,
-        //         },
-        //       ]),
-        //     }
-        //   : undefined),
-        ...(action.callbacks
-          ? {
-              callbacks: mapObject(action.callbacks, ([key, value]) => [
-                key,
-                {
-                  ...value,
-                  actions:
-                    value?.actions?.map((a) =>
-                      a ? removeActionTestData(a) : a,
-                    ) ?? [],
-                },
-              ]),
-            }
-          : undefined),
-      }
+      return removeOptionalPropertiesIfEmpty<WorkflowActionModel>(
+        {
+          ...action,
+          // TODO: Below was breaking the build - investigate. Test by adding an animation etc. and see if it is being set to null by mistake
+          // ...(action.parameters
+          //   ? {
+          //       parameters: mapObject(action.parameters, ([key, value]) => [
+          //         key,
+          //         {
+          //           ...value,
+          //           formula: isFormula(value)
+          //             ? removeFormulaTestData(value)
+          //             : isFormula(value.formula)
+          //               ? removeFormulaTestData(value.formula)
+          //               : value.formula,
+          //         },
+          //       ]),
+          //     }
+          //   : undefined),
+          ...(action.callbacks
+            ? {
+                callbacks: mapObject(action.callbacks, ([key, value]) => [
+                  key,
+                  {
+                    ...value,
+                    actions:
+                      value?.actions?.map((a) =>
+                        a ? removeActionTestData(a) : a,
+                      ) ?? [],
+                  },
+                ]),
+              }
+            : undefined),
+        },
+        ['callbacks', 'contextProvider', 'parameters'],
+      )
     case 'AbortFetch':
       // Fetch aborts have no test data
       return action
@@ -302,15 +477,25 @@ const removeActionArgumentTestData = (action: CustomActionArgument) => {
   }
 }
 
-const removeFormulaTestData = (formula: Formula): Formula => {
-  if (!isFormula(formula)) {
-    return formula
+const removeFormulaTestData = (_formula: Formula): Formula => {
+  if (!isFormula(_formula)) {
+    return _formula
   }
+  const formula = removeOptionalPropertiesIfEmpty<Formula>(_formula, [
+    'label',
+    '@nordcraft/metadata',
+  ])
   switch (formula.type) {
     case 'path':
-    case 'value':
-    case 'function':
       return formula
+    case 'value':
+      return formula
+    case 'function':
+      return removeOptionalPropertiesIfEmpty(formula, [
+        'arguments',
+        'display_name',
+        'variableArguments',
+      ])
     case 'record':
       return {
         ...formula,
@@ -332,13 +517,16 @@ const removeFormulaTestData = (formula: Formula): Formula => {
           })) ?? [],
       }
     case 'apply':
-      return {
-        ...formula,
-        arguments: (formula.arguments ?? []).map((a) => ({
-          ...omitKeys(a, ['testValue']),
-          formula: removeFormulaTestData(a.formula),
-        })),
-      }
+      return removeOptionalPropertiesIfEmpty<ApplyOperation>(
+        {
+          ...formula,
+          arguments: (formula.arguments ?? []).map((a) => ({
+            ...omitKeys(a, ['testValue']),
+            formula: removeFormulaTestData(a.formula),
+          })),
+        },
+        ['arguments'],
+      )
     case 'switch':
       return {
         ...formula,

--- a/packages/ssr/src/utils/media.ts
+++ b/packages/ssr/src/utils/media.ts
@@ -19,7 +19,7 @@ export const transformRelativePaths =
           ...node,
           ...(node.type === 'element'
             ? {
-                attrs: Object.entries(node.attrs).reduce(
+                attrs: Object.entries(node.attrs ?? {}).reduce(
                   (acc, [key, formula]) => {
                     if (
                       ['src'].includes(key) &&


### PR DESCRIPTION
Most optional propertis in components, nodes, actions etc. that have a value which is:

- `undefined`
- `null`
- `[]`
- `{}`

are not needed client side and can be removed along with other test data.
This reduces the amount of data that is sent to the client for hydration.
This PR also adjusts types and makes additional properties optional.

---

Benchmarks:

**Nordcraft website**
Before: 269KB (1,840KB)
After: 260KB (1,698KB)
Reduction: 3,3% (7,8%)

**Nordcraft editor**
Before: 1,544KB (15,047KB)
After: 1,500KB (14,408KB)
Reduction: 2,9% (4,3%)