### PR TITLE
Improved text-editing in canvas

### DIFF
--- a/packages/core/src/formula/formula.ts
+++ b/packages/core/src/formula/formula.ts
@@ -209,13 +209,55 @@ export const isToddleFormula = <Handler>(
 
 export function applyFormula(
   formula: Formula | string | number | undefined | null | boolean,
-  _ctx: FormulaContext,
+  ctx: FormulaContext,
   extendedPath?: Array<string | number> | undefined,
 ): any {
-  const path = [...(_ctx?.jsonPath ?? []), ...(extendedPath ?? [])]
-  const ctx = { ..._ctx, jsonPath: path }
-  const report = (value: any, p: Array<string | number> = path) => {
-    ctx?.reportFormulaEvaluation?.(p, value, ctx)
+  // Short-circuit when not reporting to avoid unnecessary overhead of creating new objects and function
+  if (!ctx.reportFormulaEvaluation) {
+    if (!isFormula(formula)) {
+      return formula
+    }
+    try {
+      switch (formula.type) {
+        case 'value':
+          return formula.value
+        case 'path':
+          return applyPathFormula(formula, ctx.data)
+        case 'switch':
+          return applySwitchFormula(formula, ctx)
+        case 'or':
+          return applyOrFormula(formula, ctx)
+        case 'and':
+          return applyAndFormula(formula, ctx)
+        case 'object':
+          return applyObjectFormula(formula, ctx)
+        case 'record':
+          return applyRecordFormula(formula, ctx)
+        case 'array':
+          return applyArrayFormula(formula, ctx)
+        case 'function':
+          return applyFunctionFormula(formula, ctx)
+        case 'apply':
+          return applyApplyFormula(formula, ctx)
+        default:
+          if (ctx.env?.logErrors) {
+            console.error('Could not recognize formula', formula)
+          }
+      }
+    } catch (e) {
+      if (ctx.env?.logErrors) {
+        console.error(e)
+      }
+      return null
+    }
+
+    return undefined
+  }
+
+  const jsonPath = [...(ctx.jsonPath ?? []), ...(extendedPath ?? [])]
+  const _ctx = { ...ctx, jsonPath }
+  const report = (value: any, p: Array<string | number> = jsonPath) => {
+    ctx.reportFormulaEvaluation?.(p, value, _ctx)
     return value
   }
 
@@ -228,58 +270,58 @@ export function applyFormula(
         return report(formula.value)
       }
       case 'path': {
-        return report(applyPathFormula(formula, ctx.data))
+        return report(applyPathFormula(formula, _ctx.data))
       }
       case 'switch': {
         if (
-          ctx.reportFormulaEvaluation &&
-          ctx.jsonPath.length < MAX_REPORT_DEPTH
+          _ctx.reportFormulaEvaluation &&
+          _ctx.jsonPath.length < MAX_REPORT_DEPTH
         ) {
-          return report(applyEvaluateAllSwitchFormula(formula, ctx))
+          return report(applyEvaluateAllSwitchFormula(formula, _ctx))
         }
-        return applySwitchFormula(formula, ctx)
+        return applySwitchFormula(formula, _ctx)
       }
       case 'or': {
         if (
-          ctx.reportFormulaEvaluation &&
-          ctx.jsonPath.length < MAX_REPORT_DEPTH
+          _ctx.reportFormulaEvaluation &&
+          _ctx.jsonPath.length < MAX_REPORT_DEPTH
         ) {
-          return report(applyEvaluateAllOrFormula(formula, ctx))
+          return report(applyEvaluateAllOrFormula(formula, _ctx))
         }
-        return applyOrFormula(formula, ctx)
+        return applyOrFormula(formula, _ctx)
       }
       case 'and': {
         if (
-          ctx.reportFormulaEvaluation &&
-          ctx.jsonPath.length < MAX_REPORT_DEPTH
+          _ctx.reportFormulaEvaluation &&
+          _ctx.jsonPath.length < MAX_REPORT_DEPTH
         ) {
-          return report(applyEvaluateAllAndFormula(formula, ctx))
+          return report(applyEvaluateAllAndFormula(formula, _ctx))
         }
-        return applyAndFormula(formula, ctx)
+        return applyAndFormula(formula, _ctx)
       }
       case 'object': {
-        return report(applyObjectFormula(formula, ctx))
+        return report(applyObjectFormula(formula, _ctx))
       }
       case 'record': {
         // object used to be called record, there are still examples in the wild.
-        return report(applyRecordFormula(formula, ctx))
+        return report(applyRecordFormula(formula, _ctx))
       }
       case 'array': {
-        return report(applyArrayFormula(formula, ctx))
+        return report(applyArrayFormula(formula, _ctx))
       }
       case 'function': {
-        return report(applyFunctionFormula(formula, ctx))
+        return report(applyFunctionFormula(formula, _ctx))
       }
       case 'apply': {
-        return report(applyApplyFormula(formula, ctx))
+        return report(applyApplyFormula(formula, _ctx))
       }
       default:
-        if (ctx.env?.logErrors) {
+        if (_ctx.env?.logErrors) {
           console.error('Could not recognize formula', formula)
         }
     }
   } catch (e) {
-    if (ctx.env?.logErrors) {
+    if (_ctx.env?.logErrors) {
       console.error(e)
     }
     return report(null)

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -68,10 +68,12 @@ import {
   CSS_VAR_VIEWPORT_HEIGHT,
   DATA_ATTR_VIEWPORT_HEIGHT,
 } from './editor/const'
-import { dragEnded } from './editor/drag-drop/dragEnded'
-import { dragMove } from './editor/drag-drop/dragMove'
-import { dragReorder } from './editor/drag-drop/dragReorder'
-import { dragStarted } from './editor/drag-drop/dragStarted'
+import {
+  handleDragAltToggle,
+  handleDragEnded,
+  handleDragMouseMove,
+  handleDragStarted,
+} from './editor/drag-drop/dragHandlers'
 import { throttleToIdleCallback } from './editor/editorUtils'
 import { introspectApiRequest } from './editor/graphql'
 import { isInputTarget } from './editor/input'
@@ -79,11 +81,14 @@ import { updateComponentLinks } from './editor/links'
 import { getRectData } from './editor/overlay'
 import { postMessageToEditor } from './editor/postMessageToEditor'
 import { requestResizeCanvas } from './editor/resizeCanvas'
-import {
-  TextNodeComputedStyles,
-  type DragState,
-  type NordcraftPreviewEvent,
-} from './editor/types'
+import { handleTextMouseDown } from './editor/text-selection/mouseDown'
+import { handleTextMouseMove } from './editor/text-selection/mouseMove'
+import { handleTextNodeSelection } from './editor/text-selection/selection'
+import type {
+  SelectionAnchor,
+  SelectionMode,
+} from './editor/text-selection/types'
+import { type DragState, type NordcraftPreviewEvent } from './editor/types'
 import { handleAction } from './events/handleAction'
 import type { Signal } from './signal/signal'
 import { signal } from './signal/signal'
@@ -106,7 +111,6 @@ import {
   isNodeOrAncestorConditional,
   stripNodeIdRepeatIndices,
 } from './utils/nodes'
-import { rectHasPoint } from './utils/rectHasPoint'
 import {
   getScrollStateRestorer,
   storeScrollState,
@@ -306,6 +310,13 @@ export const createRoot = (
   let metaKey = false
   let previewStyleAnimationFrame = -1
   let timelineTimeAnimationFrame = -1
+  let selectionAnchor: SelectionAnchor | null = null
+  let selectionMode: SelectionMode = 'char'
+  let prevButtons = 0
+  let lastMouseDownTime = 0
+  let lastMouseDownX = 0
+  let lastMouseDownY = 0
+  let mouseDownCount = 0
 
   const setupDataSignalSubscribers = () => {
     dataSignal.subscribe((data) => {
@@ -513,35 +524,20 @@ export const createRoot = (
         case 'selection': {
           if (selectedNodeId !== message.data.selectedNodeId) {
             selectedNodeId = message.data.selectedNodeId ?? null
+            window.dispatchEvent(new CustomEvent('selected-node-changed'))
             clearSelectedStyleVariant()
 
             updateConditionalElements()
 
             const node = getDOMNodeFromNodeId(selectedNodeId)
             markSelectedElement(node)
-            const element =
-              component?.nodes?.[node?.getAttribute('data-node-id') ?? '']
             if (
               node &&
-              element &&
-              element.type === 'text' &&
-              element.value.type === 'value'
+              node instanceof HTMLElement &&
+              node.getAttribute('data-node-type') === 'text'
             ) {
-              const computedStyle = window.getComputedStyle(node)
-              postMessageToEditor({
-                type: 'textComputedStyle',
-                computedStyle: Object.fromEntries(
-                  Object.values(TextNodeComputedStyles).map((style) => [
-                    style,
-                    computedStyle.getPropertyValue(style),
-                  ]),
-                ),
-              })
-            } else if (node && node.getAttribute('data-node-type') !== 'text') {
-              // Reset computed style on blur
-              postMessageToEditor({
-                type: 'textComputedStyle',
-                computedStyle: {},
+              requestAnimationFrame(() => {
+                handleTextNodeSelection(node)
               })
             }
           }
@@ -568,38 +564,67 @@ export const createRoot = (
             : null
           return
         }
-        case 'mousemove':
+        case 'mousedown': {
+          const { x, y } = message.data
+          const node = getDOMNodeFromNodeId(selectedNodeId)
+
+          if (
+            node &&
+            node.getAttribute('data-node-type') === 'text' &&
+            node instanceof HTMLElement
+          ) {
+            const result = handleTextMouseDown({
+              node,
+              x,
+              y,
+              context: {
+                lastMouseDownTime,
+                lastMouseDownX,
+                lastMouseDownY,
+                mouseDownCount,
+              },
+            })
+            selectionAnchor = result.selectionAnchor
+            selectionMode = result.selectionMode
+            lastMouseDownTime = result.context.lastMouseDownTime
+            lastMouseDownX = result.context.lastMouseDownX
+            lastMouseDownY = result.context.lastMouseDownY
+            mouseDownCount = result.context.mouseDownCount
+          }
+          break
+        }
+
+        case 'mousemove': {
           if (dragState && !dragState.destroying) {
-            const { x, y } = message.data
-            dragState.lastCursorPosition = { x, y }
-            const draggingInsideContainer = rectHasPoint(
-              dragState.initialContainer.getBoundingClientRect(),
-              { x, y },
-            )
-
-            // Move the element towards the cursor when out of bounds
-            const rect = dragState.element.getBoundingClientRect()
-            if (!rectHasPoint(rect, { x, y })) {
-              dragState.offset.x -= (x - (rect.left + rect.width / 2)) * 0.1
-              dragState.offset.y -= (y - (rect.top + rect.height / 2)) * 0.1
-            }
-
-            if (draggingInsideContainer && !metaKey) {
-              dragReorder(dragState)
-            } else {
-              dragMove(
-                dragState,
-                metaKey
-                  ? [dragState.element]
-                  : [dragState.element, dragState.initialContainer],
-              )
-            }
-            dragState.element.style.setProperty(
-              'translate',
-              `${x - dragState.offset.x}px ${y - dragState.offset.y}px`,
-            )
+            handleDragMouseMove(message.data, dragState, metaKey)
             return
           }
+
+          const node = getDOMNodeFromNodeId(selectedNodeId)
+          if (
+            node &&
+            node instanceof HTMLElement &&
+            node.getAttribute('data-node-type') === 'text'
+          ) {
+            const { x, y, buttons } = message.data
+            const result = handleTextMouseMove({
+              node,
+              x,
+              y,
+              buttons,
+              prevButtons,
+              selectionAnchor,
+              selectionMode,
+            })
+            selectionAnchor = result.selectionAnchor
+            selectionMode = result.selectionMode
+            prevButtons = buttons
+
+            if (result.handled) {
+              return
+            }
+          }
+        }
         case 'click':
         case 'dblclick':
           if (mode === 'test' || !component) {
@@ -631,7 +656,15 @@ export const createRoot = (
           })
 
           const id = element?.getAttribute('data-id') ?? null
-          if (type === 'click' && id !== selectedNodeId) {
+          const elementIsSameAsSelected = id && id === selectedNodeId
+          if (
+            elementIsSameAsSelected &&
+            element?.getAttribute('data-node-type') === 'text'
+          ) {
+            return
+          }
+
+          if (type === 'click') {
             if (message.data.metaKey) {
               // Figure out if the clicked element is a text element
               // or if one of its descendants is a text element
@@ -665,6 +698,24 @@ export const createRoot = (
               })
             }
           } else if (type === 'mousemove' && id !== highlightedNodeId) {
+            // Do not send highlight if cursor is inside current selectedElement and current selected element is a text type
+            const selectedNode = getDOMNodeFromNodeId(selectedNodeId)
+            const selectedNodeIsText =
+              selectedNode?.getAttribute('data-node-type') === 'text'
+            const cursorInsideSelectedElement =
+              selectedNode instanceof HTMLElement &&
+              selectedNode.contains(document.elementFromPoint(x, y))
+            if (selectedNodeIsText && cursorInsideSelectedElement) {
+              // Highlight the text node if the cursor is inside the currently selected text node, even if the selected element has a different id than the text node (e.g. when clicking on a span inside a text node)
+              postMessageToEditor({
+                type: 'highlight',
+                highlightedNodeId: stripNodeIdRepeatIndices(
+                  selectedNode.getAttribute('data-id'),
+                ),
+              })
+              return
+            }
+
             postMessageToEditor({
               type: 'highlight',
               highlightedNodeId: stripNodeIdRepeatIndices(id),
@@ -773,94 +824,15 @@ export const createRoot = (
           break
         }
         case 'drag-started':
-          const draggedElement = getDOMNodeFromNodeId(selectedNodeId)
-          if (!draggedElement || !draggedElement.parentElement) {
-            return
-          }
-          const repeatedNodes = Array.from(
-            draggedElement.parentElement.children,
-          ).filter(
-            (node) =>
-              node instanceof HTMLElement &&
-              node.getAttribute('data-id')?.startsWith(selectedNodeId + '('),
-          ) as HTMLElement[]
-          dragState = dragStarted({
-            element: draggedElement as HTMLElement,
-            lastCursorPosition: { x: message.data.x, y: message.data.y },
-            repeatedNodes,
-            asCopy: altKey,
-          })
-          if (altKey) {
-            const nextRect = dragState.element.getBoundingClientRect()
-            dragState.offset.x += nextRect.left - dragState.initialRect.left
-            dragState.offset.y += nextRect.top - dragState.initialRect.top
-          }
-
+          dragState = handleDragStarted(message.data, selectedNodeId, altKey)
           break
         case 'drag-ended':
-          switch (dragState?.mode) {
-            case 'reorder':
-              const parentDataId =
-                dragState?.initialContainer.getAttribute('data-id')
-              const parentNodeId =
-                dragState?.initialContainer.getAttribute('data-node-id')
-              if (!parentDataId || !parentNodeId) {
-                return
-              }
-
-              const nextSibling = dragState?.element.nextElementSibling
-              const nextSiblingId = parseInt(
-                nextSibling?.getAttribute('data-id')?.split('.').at(-1) ?? '',
-              )
-
-              const rect = dragState?.element?.getBoundingClientRect()
-              if (
-                rect &&
-                !message.data.canceled &&
-                (nextSibling !== dragState?.initialNextSibling ||
-                  dragState?.copy)
-              ) {
-                void dragEnded(dragState, false).then(() => {
-                  postMessageToEditor({
-                    type: 'nodeMoved',
-                    copy: Boolean(dragState?.copy),
-                    parent: parentDataId,
-                    index: !isNaN(nextSiblingId)
-                      ? nextSiblingId
-                      : component?.nodes?.[parentNodeId]?.children?.length,
-                  })
-                  dragState = null
-                })
-              } else {
-                void dragEnded(dragState, true).then(() => {
-                  dragState = null
-                })
-              }
-              break
-            case 'insert':
-              const selectedPermutation =
-                dragState?.insertAreas?.[
-                  dragState?.selectedInsertAreaIndex ?? -1
-                ]
-              if (selectedPermutation && !message.data.canceled) {
-                void dragEnded(dragState, false).then(() => {
-                  postMessageToEditor({
-                    type: 'nodeMoved',
-                    copy: Boolean(dragState?.copy),
-                    parent: selectedPermutation?.parent.getAttribute('data-id'),
-                    index: selectedPermutation?.index,
-                  })
-                  dragState = null
-                })
-              } else {
-                void dragEnded(dragState, true).then(() => {
-                  dragState = null
-                })
-              }
-              break
-            case undefined:
-              // TODO: Handle the case where the drag state is undefined
-              break
+          if (dragState) {
+            void handleDragEnded(message.data, dragState, component).then(
+              (newState) => {
+                dragState = newState
+              },
+            )
           }
           break
         case 'keydown':
@@ -871,22 +843,11 @@ export const createRoot = (
             !dragState.destroying &&
             message.data.altKey !== altKey
           ) {
-            const asCopy = message.data.altKey
-            const prevRect = dragState.element.getBoundingClientRect()
-            void dragEnded(dragState, true).then(() => {
-              if (!dragState) return
-              dragState = dragStarted({
-                element: dragState.element,
-                lastCursorPosition: dragState.lastCursorPosition,
-                repeatedNodes: dragState.repeatedNodes,
-                asCopy,
-                initialContainer: dragState.initialContainer,
-                initialNextSibling: dragState.initialNextSibling,
-              })
-              const nextRect = dragState.element.getBoundingClientRect()
-              dragState.offset.x += nextRect.left - prevRect.left
-              dragState.offset.y += nextRect.top - prevRect.top
-            })
+            void handleDragAltToggle(message.data.altKey, dragState).then(
+              (newState) => {
+                dragState = newState
+              },
+            )
           }
           altKey = message.data.altKey
           metaKey = message.data.metaKey

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -85,10 +85,11 @@ import { handleTextMouseDown } from './editor/text-selection/mouseDown'
 import { handleTextMouseMove } from './editor/text-selection/mouseMove'
 import { handleTextNodeSelection } from './editor/text-selection/selection'
 import type {
-  SelectionAnchor,
-  SelectionMode,
-} from './editor/text-selection/types'
-import { type DragState, type NordcraftPreviewEvent } from './editor/types'
+  DragState,
+  NordcraftPreviewEvent,
+  PointerState,
+  SelectionState,
+} from './editor/types'
 import { handleAction } from './events/handleAction'
 import type { Signal } from './signal/signal'
 import { signal } from './signal/signal'
@@ -292,6 +293,16 @@ export const createRoot = (
     })
     componentFormulaData = {}
   })
+  const selectionState: SelectionState = {
+    anchor: null,
+    mode: 'char',
+  }
+  const pointerState: PointerState = {
+    lastPressPosition: { x: 0, y: 0 },
+    buttons: 0,
+    lastPressTime: 0,
+    pressCount: 0,
+  }
   let selectedNodeId: string | null = null
   let highlightedNodeId: string | null = null
   let styleVariantSelection: {
@@ -310,13 +321,6 @@ export const createRoot = (
   let metaKey = false
   let previewStyleAnimationFrame = -1
   let timelineTimeAnimationFrame = -1
-  let selectionAnchor: SelectionAnchor | null = null
-  let selectionMode: SelectionMode = 'char'
-  let prevButtons = 0
-  let lastMouseDownTime = 0
-  let lastMouseDownX = 0
-  let lastMouseDownY = 0
-  let mouseDownCount = 0
 
   const setupDataSignalSubscribers = () => {
     dataSignal.subscribe((data) => {
@@ -492,6 +496,7 @@ export const createRoot = (
           mode = message.data.mode
           document.body.setAttribute('data-mode', message.data.mode)
           updateConditionalElements()
+          window.dispatchEvent(new CustomEvent('selected-node-changed'))
           break
         }
         case 'attrs': {
@@ -543,17 +548,6 @@ export const createRoot = (
           }
           return
         }
-        case 'update_inner_text': {
-          const { innerText } = message.data
-          const selectedNode = getDOMNodeFromNodeId(selectedNodeId)
-          if (
-            selectedNode &&
-            selectedNode.getAttribute('data-node-type') === 'text'
-          ) {
-            ;(selectedNode as HTMLElement).innerText = innerText
-          }
-          return
-        }
         case 'highlight': {
           const highlightId = message.data.highlightedNodeId
           highlightedNodeId = highlightId
@@ -573,23 +567,13 @@ export const createRoot = (
             node.getAttribute('data-node-type') === 'text' &&
             node instanceof HTMLElement
           ) {
-            const result = handleTextMouseDown({
+            handleTextMouseDown({
               node,
               x,
               y,
-              context: {
-                lastMouseDownTime,
-                lastMouseDownX,
-                lastMouseDownY,
-                mouseDownCount,
-              },
+              pointerState,
+              selectionState,
             })
-            selectionAnchor = result.selectionAnchor
-            selectionMode = result.selectionMode
-            lastMouseDownTime = result.context.lastMouseDownTime
-            lastMouseDownX = result.context.lastMouseDownX
-            lastMouseDownY = result.context.lastMouseDownY
-            mouseDownCount = result.context.mouseDownCount
           }
           break
         }
@@ -607,20 +591,16 @@ export const createRoot = (
             node.getAttribute('data-node-type') === 'text'
           ) {
             const { x, y, buttons } = message.data
-            const result = handleTextMouseMove({
+            const handled = handleTextMouseMove({
               node,
               x,
               y,
               buttons,
-              prevButtons,
-              selectionAnchor,
-              selectionMode,
+              pointerState,
+              selectionState,
             })
-            selectionAnchor = result.selectionAnchor
-            selectionMode = result.selectionMode
-            prevButtons = buttons
 
-            if (result.handled) {
+            if (handled) {
               return
             }
           }

--- a/packages/runtime/src/editor/drag-drop/dragHandlers.ts
+++ b/packages/runtime/src/editor/drag-drop/dragHandlers.ts
@@ -1,0 +1,161 @@
+import type { Component } from '@nordcraft/core/dist/component/component.types'
+import { getDOMNodeFromNodeId } from '../../editor-preview.main'
+import { rectHasPoint } from '../../utils/rectHasPoint'
+import { postMessageToEditor } from '../postMessageToEditor'
+import type { DragState } from '../types'
+import { dragEnded } from './dragEnded'
+import { dragMove } from './dragMove'
+import { dragReorder } from './dragReorder'
+import { dragStarted } from './dragStarted'
+
+export const handleDragStarted = (
+  messageData: { x: number; y: number },
+  selectedNodeId: string | null,
+  altKey: boolean,
+): DragState | null => {
+  const draggedElement = getDOMNodeFromNodeId(selectedNodeId)
+  if (!draggedElement?.parentElement) {
+    return null
+  }
+  const repeatedNodes = Array.from(
+    draggedElement.parentElement.children,
+  ).filter(
+    (node) =>
+      node instanceof HTMLElement &&
+      node.getAttribute('data-id')?.startsWith(selectedNodeId + '('),
+  ) as HTMLElement[]
+
+  const dragState = dragStarted({
+    element: draggedElement as HTMLElement,
+    lastCursorPosition: { x: messageData.x, y: messageData.y },
+    repeatedNodes,
+    asCopy: altKey,
+  })
+
+  if (altKey && dragState) {
+    const nextRect = dragState.element.getBoundingClientRect()
+    dragState.offset.x += nextRect.left - dragState.initialRect.left
+    dragState.offset.y += nextRect.top - dragState.initialRect.top
+  }
+
+  return dragState
+}
+
+export const handleDragMouseMove = (
+  messageData: { x: number; y: number },
+  dragState: DragState,
+  metaKey: boolean,
+) => {
+  const { x, y } = messageData
+  dragState.lastCursorPosition = { x, y }
+  const draggingInsideContainer = rectHasPoint(
+    dragState.initialContainer.getBoundingClientRect(),
+    { x, y },
+  )
+  const rect = dragState.element.getBoundingClientRect()
+  if (!rectHasPoint(rect, { x, y })) {
+    dragState.offset.x -= (x - (rect.left + rect.width / 2)) * 0.1
+    dragState.offset.y -= (y - (rect.top + rect.height / 2)) * 0.1
+  }
+  if (draggingInsideContainer && !metaKey) {
+    dragReorder(dragState)
+  } else {
+    dragMove(
+      dragState,
+      metaKey
+        ? [dragState.element]
+        : [dragState.element, dragState.initialContainer],
+    )
+  }
+  dragState.element.style.setProperty(
+    'translate',
+    `${x - dragState.offset.x}px ${y - dragState.offset.y}px`,
+  )
+}
+
+export const handleDragAltToggle = async (
+  asCopy: boolean,
+  dragState: DragState,
+): Promise<DragState | null> => {
+  const prevRect = dragState.element.getBoundingClientRect()
+  await dragEnded(dragState, true)
+  const newState = dragStarted({
+    element: dragState.element,
+    lastCursorPosition: dragState.lastCursorPosition,
+    repeatedNodes: dragState.repeatedNodes,
+    asCopy,
+    initialContainer: dragState.initialContainer,
+    initialNextSibling: dragState.initialNextSibling,
+  })
+
+  if (newState) {
+    const nextRect = newState.element.getBoundingClientRect()
+    newState.offset.x += nextRect.left - prevRect.left
+    newState.offset.y += nextRect.top - prevRect.top
+  }
+
+  return newState
+}
+
+export const handleDragEnded = async (
+  messageData: { canceled?: boolean },
+  dragState: DragState,
+  component: Component | null,
+): Promise<DragState | null> => {
+  switch (dragState?.mode) {
+    case 'reorder': {
+      const parentDataId = dragState?.initialContainer.getAttribute('data-id')
+      const parentNodeId =
+        dragState?.initialContainer.getAttribute('data-node-id')
+      if (!parentDataId || !parentNodeId) {
+        return dragState
+      }
+
+      const nextSibling = dragState?.element.nextElementSibling
+      const nextSiblingId = parseInt(
+        nextSibling?.getAttribute('data-id')?.split('.').at(-1) ?? '',
+      )
+
+      const rect = dragState?.element?.getBoundingClientRect()
+      if (
+        rect &&
+        !messageData.canceled &&
+        (nextSibling !== dragState?.initialNextSibling || dragState?.copy)
+      ) {
+        await dragEnded(dragState, false)
+        postMessageToEditor({
+          type: 'nodeMoved',
+          copy: Boolean(dragState?.copy),
+          parent: parentDataId,
+          index: !isNaN(nextSiblingId)
+            ? nextSiblingId
+            : component?.nodes?.[parentNodeId]?.children?.length,
+        })
+        return null
+      } else {
+        await dragEnded(dragState, true)
+        return null
+      }
+    }
+    case 'insert': {
+      const selectedPermutation =
+        dragState?.insertAreas?.[dragState?.selectedInsertAreaIndex ?? -1]
+      if (selectedPermutation && !messageData.canceled) {
+        await dragEnded(dragState, false)
+        postMessageToEditor({
+          type: 'nodeMoved',
+          copy: Boolean(dragState?.copy),
+          parent: selectedPermutation?.parent.getAttribute('data-id'),
+          index: selectedPermutation?.index,
+        })
+        return null
+      } else {
+        await dragEnded(dragState, true)
+        return null
+      }
+    }
+    case undefined:
+      return null
+  }
+  return dragState
+}

--- a/packages/runtime/src/editor/overlay.ts
+++ b/packages/runtime/src/editor/overlay.ts
@@ -5,14 +5,7 @@ export function getRectData(selectedNode: Element | null | undefined) {
 
   const { borderRadius, rotate, padding, margin, gap } =
     window.getComputedStyle(selectedNode)
-  let rect: DOMRect
-  if (selectedNode.getAttribute('data-node-type') === 'text') {
-    selectedNode.classList.add('__nc-text-node-measure')
-    rect = selectedNode.getBoundingClientRect()
-    selectedNode.classList.remove('__nc-text-node-measure')
-  } else {
-    rect = selectedNode.getBoundingClientRect()
-  }
+  const rect = selectedNode.getBoundingClientRect()
 
   return {
     left: rect.left,

--- a/packages/runtime/src/editor/resizeCanvas.ts
+++ b/packages/runtime/src/editor/resizeCanvas.ts
@@ -14,11 +14,20 @@ function resizeCanvas({
   // First pass: Set base height to resolve relative units the same way each render
   domNode.style.maxHeight = `${viewport.height}px`
 
+  // Temporarily set the scroll height variable to the actual window height
+  // so that vh units resolve relative to the simulated viewport height
+  domNode.style.setProperty(
+    CSS_VAR_SCROLL_HEIGHT,
+    String(Math.round(window.innerHeight)),
+  )
+
   // Force reflow
   void domNode.offsetHeight
 
   // Measure the actual content size
-  const scrollHeight = Math.max(domNode.scrollHeight, viewport.height)
+  const scrollHeight = Math.round(
+    Math.max(domNode.scrollHeight, viewport.height),
+  )
 
   // Update viewport height ratio for vh to work inside the canvas
   domNode.style.setProperty(CSS_VAR_SCROLL_HEIGHT, String(scrollHeight))

--- a/packages/runtime/src/editor/resizeCanvas.ts
+++ b/packages/runtime/src/editor/resizeCanvas.ts
@@ -62,7 +62,7 @@ export const requestResizeCanvas = (
     return
   }
 
-  requestAnimationFrame(() => {
+  cancelRequestResizeCanvas = requestAnimationFrame(() => {
     resizeCanvas({
       force: options.force ?? false,
       viewport: {

--- a/packages/runtime/src/editor/text-selection/mouseDown.ts
+++ b/packages/runtime/src/editor/text-selection/mouseDown.ts
@@ -1,58 +1,52 @@
+import type { PointerState, SelectionState } from '../types'
 import { handleTextNodeSelection } from './selection'
-import type { SelectionAnchor, SelectionMode } from './types'
 
-export interface MouseDownContext {
-  lastMouseDownTime: number
-  lastMouseDownX: number
-  lastMouseDownY: number
-  mouseDownCount: number
-}
+const DOUBLE_CLICK_TIME_MAX = 500
+const DOUBLE_CLICK_DISTANCE_MAX = 2
 
-export interface MouseDownResult {
-  selectionAnchor: SelectionAnchor | null
-  selectionMode: SelectionMode
-  context: MouseDownContext
-}
-
+/**
+ * Proxy handler for mousedown events on text nodes to manage selection state and communicate with the editor.
+ * Handles single, double, and triple clicks for character, word, and full node selection respectively, similar to how standard text editors work.
+ */
 export const handleTextMouseDown = ({
   node,
   x,
   y,
-  context,
+  pointerState,
+  selectionState,
 }: {
   node: HTMLElement
   x: number
   y: number
-  context: MouseDownContext
-}): MouseDownResult => {
-  let { lastMouseDownTime, lastMouseDownX, lastMouseDownY, mouseDownCount } =
-    context
+  pointerState: PointerState
+  selectionState: SelectionState
+}): void => {
   const now = Date.now()
   const caretPosition = document.caretPositionFromPoint(x, y)
 
   const isDoubleDown =
-    now - lastMouseDownTime < 600 &&
-    Math.abs(x - lastMouseDownX) < 10 &&
-    Math.abs(y - lastMouseDownY) < 10
+    now - pointerState.lastPressTime < DOUBLE_CLICK_TIME_MAX &&
+    Math.abs(x - pointerState.lastPressPosition.x) <=
+      DOUBLE_CLICK_DISTANCE_MAX &&
+    Math.abs(y - pointerState.lastPressPosition.y) <= DOUBLE_CLICK_DISTANCE_MAX
 
   const isTripleDown =
-    isDoubleDown && now - lastMouseDownTime < 600 && mouseDownCount >= 2
+    isDoubleDown &&
+    now - pointerState.lastPressTime < DOUBLE_CLICK_TIME_MAX &&
+    pointerState.pressCount >= 2
 
-  lastMouseDownTime = now
-  lastMouseDownX = x
-  lastMouseDownY = y
-  mouseDownCount = isDoubleDown ? mouseDownCount + 1 : 1
-
-  let selectionAnchor: SelectionAnchor | null = null
-  let selectionMode: SelectionMode = 'char'
+  pointerState.lastPressTime = now
+  pointerState.lastPressPosition.x = x
+  pointerState.lastPressPosition.y = y
+  pointerState.pressCount = isDoubleDown ? pointerState.pressCount + 1 : 1
 
   if (caretPosition && node.contains(caretPosition.offsetNode)) {
     const selection = window.getSelection()
     if (selection) {
       if (isTripleDown) {
         // Triple mousedown — select all text in the node
-        selectionAnchor = null
-        selectionMode = 'all'
+        selectionState.anchor = null
+        selectionState.mode = 'all'
         selection.removeAllRanges()
         const range = document.createRange()
         range.selectNodeContents(node)
@@ -62,7 +56,7 @@ export const handleTextMouseDown = ({
         caretPosition.offsetNode.nodeType === Node.TEXT_NODE
       ) {
         // Double mousedown — select word under cursor, anchor to word boundaries
-        selectionMode = 'word'
+        selectionState.mode = 'word'
         const text = caretPosition.offsetNode.textContent ?? ''
         const { offset } = caretPosition
         let start = offset
@@ -71,7 +65,7 @@ export const handleTextMouseDown = ({
         while (end < text.length && !/\s/.test(text[end])) end++
 
         // Anchor is the full word boundary so drag extends word-by-word
-        selectionAnchor = {
+        selectionState.anchor = {
           node: caretPosition.offsetNode,
           wordStart: start,
           wordEnd: end > start ? end : start,
@@ -85,8 +79,8 @@ export const handleTextMouseDown = ({
         selection.addRange(range)
       } else {
         // Single mousedown — place caret
-        selectionMode = 'char'
-        selectionAnchor = {
+        selectionState.mode = 'char'
+        selectionState.anchor = {
           node: caretPosition.offsetNode,
           offset: caretPosition.offset,
           wordStart: caretPosition.offset,
@@ -105,16 +99,5 @@ export const handleTextMouseDown = ({
   node.focus()
   if (node.getAttribute('contenteditable') !== 'plaintext-only') {
     handleTextNodeSelection(node)
-  }
-
-  return {
-    selectionAnchor,
-    selectionMode,
-    context: {
-      lastMouseDownTime,
-      lastMouseDownX,
-      lastMouseDownY,
-      mouseDownCount,
-    },
   }
 }

--- a/packages/runtime/src/editor/text-selection/mouseDown.ts
+++ b/packages/runtime/src/editor/text-selection/mouseDown.ts
@@ -1,0 +1,120 @@
+import { handleTextNodeSelection } from './selection'
+import type { SelectionAnchor, SelectionMode } from './types'
+
+export interface MouseDownContext {
+  lastMouseDownTime: number
+  lastMouseDownX: number
+  lastMouseDownY: number
+  mouseDownCount: number
+}
+
+export interface MouseDownResult {
+  selectionAnchor: SelectionAnchor | null
+  selectionMode: SelectionMode
+  context: MouseDownContext
+}
+
+export const handleTextMouseDown = ({
+  node,
+  x,
+  y,
+  context,
+}: {
+  node: HTMLElement
+  x: number
+  y: number
+  context: MouseDownContext
+}): MouseDownResult => {
+  let { lastMouseDownTime, lastMouseDownX, lastMouseDownY, mouseDownCount } =
+    context
+  const now = Date.now()
+  const caretPosition = document.caretPositionFromPoint(x, y)
+
+  const isDoubleDown =
+    now - lastMouseDownTime < 600 &&
+    Math.abs(x - lastMouseDownX) < 10 &&
+    Math.abs(y - lastMouseDownY) < 10
+
+  const isTripleDown =
+    isDoubleDown && now - lastMouseDownTime < 600 && mouseDownCount >= 2
+
+  lastMouseDownTime = now
+  lastMouseDownX = x
+  lastMouseDownY = y
+  mouseDownCount = isDoubleDown ? mouseDownCount + 1 : 1
+
+  let selectionAnchor: SelectionAnchor | null = null
+  let selectionMode: SelectionMode = 'char'
+
+  if (caretPosition && node.contains(caretPosition.offsetNode)) {
+    const selection = window.getSelection()
+    if (selection) {
+      if (isTripleDown) {
+        // Triple mousedown — select all text in the node
+        selectionAnchor = null
+        selectionMode = 'all'
+        selection.removeAllRanges()
+        const range = document.createRange()
+        range.selectNodeContents(node)
+        selection.addRange(range)
+      } else if (
+        isDoubleDown &&
+        caretPosition.offsetNode.nodeType === Node.TEXT_NODE
+      ) {
+        // Double mousedown — select word under cursor, anchor to word boundaries
+        selectionMode = 'word'
+        const text = caretPosition.offsetNode.textContent ?? ''
+        const { offset } = caretPosition
+        let start = offset
+        while (start > 0 && !/\s/.test(text[start - 1])) start--
+        let end = offset
+        while (end < text.length && !/\s/.test(text[end])) end++
+
+        // Anchor is the full word boundary so drag extends word-by-word
+        selectionAnchor = {
+          node: caretPosition.offsetNode,
+          wordStart: start,
+          wordEnd: end > start ? end : start,
+          offset: start,
+        }
+
+        selection.removeAllRanges()
+        const range = document.createRange()
+        range.setStart(caretPosition.offsetNode, start)
+        range.setEnd(caretPosition.offsetNode, end > start ? end : start)
+        selection.addRange(range)
+      } else {
+        // Single mousedown — place caret
+        selectionMode = 'char'
+        selectionAnchor = {
+          node: caretPosition.offsetNode,
+          offset: caretPosition.offset,
+          wordStart: caretPosition.offset,
+          wordEnd: caretPosition.offset,
+        }
+        selection.removeAllRanges()
+        const range = document.createRange()
+        range.setStart(caretPosition.offsetNode, caretPosition.offset)
+        range.collapse(true)
+        selection.addRange(range)
+      }
+    }
+  }
+
+  window.focus()
+  node.focus()
+  if (node.getAttribute('contenteditable') !== 'plaintext-only') {
+    handleTextNodeSelection(node)
+  }
+
+  return {
+    selectionAnchor,
+    selectionMode,
+    context: {
+      lastMouseDownTime,
+      lastMouseDownX,
+      lastMouseDownY,
+      mouseDownCount,
+    },
+  }
+}

--- a/packages/runtime/src/editor/text-selection/mouseMove.ts
+++ b/packages/runtime/src/editor/text-selection/mouseMove.ts
@@ -1,0 +1,104 @@
+import type { SelectionAnchor, SelectionMode } from './types'
+
+export interface MouseMoveResult {
+  selectionAnchor: SelectionAnchor | null
+  selectionMode: SelectionMode
+  handled: boolean
+}
+
+export const handleTextMouseMove = ({
+  node,
+  x,
+  y,
+  buttons,
+  prevButtons,
+  selectionAnchor,
+  selectionMode,
+}: {
+  node: HTMLElement
+  x: number
+  y: number
+  buttons: number
+  prevButtons: number
+  selectionAnchor: SelectionAnchor | null
+  selectionMode: SelectionMode
+}): MouseMoveResult => {
+  const primaryPressed = (buttons & 1) === 1
+  const primaryJustReleased = !primaryPressed && (prevButtons & 1) === 1
+
+  if (primaryJustReleased) {
+    return {
+      selectionAnchor: null,
+      selectionMode: 'char',
+      handled: false,
+    }
+  }
+
+  if (primaryPressed && selectionAnchor && selectionMode !== 'all') {
+    const caretPosition = document.caretPositionFromPoint(x, y)
+    const selection = window.getSelection()
+
+    if (caretPosition && node.contains(caretPosition.offsetNode) && selection) {
+      const {
+        node: anchorNode,
+        offset: anchorOffset,
+        wordStart: anchorWordStart,
+        wordEnd: anchorWordEnd,
+      } = selectionAnchor
+      const focusNode = caretPosition.offsetNode
+      const focusOffset = caretPosition.offset
+
+      const position = anchorNode.compareDocumentPosition(focusNode)
+      const focusIsBeforeAnchor =
+        !!(position & Node.DOCUMENT_POSITION_PRECEDING) ||
+        (position === 0 && focusOffset < anchorOffset)
+
+      selection.removeAllRanges()
+      const range = document.createRange()
+
+      if (selectionMode === 'word' && focusNode.nodeType === Node.TEXT_NODE) {
+        // Extend selection word-by-word
+        const text = focusNode.textContent ?? ''
+        let focusWordStart = focusOffset
+        let focusWordEnd = focusOffset
+        while (focusWordStart > 0 && !/\s/.test(text[focusWordStart - 1]))
+          focusWordStart--
+        while (focusWordEnd < text.length && !/\s/.test(text[focusWordEnd]))
+          focusWordEnd++
+
+        if (focusIsBeforeAnchor) {
+          // Dragging backwards: start from focus word start, end at anchor word end
+          range.setStart(focusNode, focusWordStart)
+          range.setEnd(anchorNode, anchorWordEnd ?? anchorOffset)
+        } else {
+          // Dragging forwards: start from anchor word start, end at focus word end
+          range.setStart(anchorNode, anchorWordStart ?? anchorOffset)
+          range.setEnd(focusNode, focusWordEnd)
+        }
+      } else {
+        // Char mode — extend character by character
+        if (focusIsBeforeAnchor) {
+          range.setStart(focusNode, focusOffset)
+          range.setEnd(anchorNode, anchorOffset)
+        } else {
+          range.setStart(anchorNode, anchorOffset)
+          range.setEnd(focusNode, focusOffset)
+        }
+      }
+
+      selection.addRange(range)
+      node.focus()
+      return {
+        selectionAnchor,
+        selectionMode,
+        handled: true,
+      }
+    }
+  }
+
+  return {
+    selectionAnchor,
+    selectionMode,
+    handled: false,
+  }
+}

--- a/packages/runtime/src/editor/text-selection/mouseMove.ts
+++ b/packages/runtime/src/editor/text-selection/mouseMove.ts
@@ -1,40 +1,37 @@
-import type { SelectionAnchor, SelectionMode } from './types'
-
-export interface MouseMoveResult {
-  selectionAnchor: SelectionAnchor | null
-  selectionMode: SelectionMode
-  handled: boolean
-}
+import type { PointerState, SelectionState } from '../types'
 
 export const handleTextMouseMove = ({
   node,
   x,
   y,
   buttons,
-  prevButtons,
-  selectionAnchor,
-  selectionMode,
+  pointerState,
+  selectionState,
 }: {
   node: HTMLElement
   x: number
   y: number
   buttons: number
-  prevButtons: number
-  selectionAnchor: SelectionAnchor | null
-  selectionMode: SelectionMode
-}): MouseMoveResult => {
+  pointerState: PointerState
+  selectionState: SelectionState
+}): boolean => {
   const primaryPressed = (buttons & 1) === 1
-  const primaryJustReleased = !primaryPressed && (prevButtons & 1) === 1
+  const primaryJustReleased =
+    !primaryPressed && (pointerState.buttons & 1) === 1
 
   if (primaryJustReleased) {
-    return {
-      selectionAnchor: null,
-      selectionMode: 'char',
-      handled: false,
-    }
+    selectionState.anchor = null
+    selectionState.mode = 'char'
+    return false
   }
 
-  if (primaryPressed && selectionAnchor && selectionMode !== 'all') {
+  pointerState.buttons = buttons
+
+  if (
+    primaryPressed &&
+    selectionState.anchor &&
+    selectionState.mode !== 'all'
+  ) {
     const caretPosition = document.caretPositionFromPoint(x, y)
     const selection = window.getSelection()
 
@@ -44,7 +41,7 @@ export const handleTextMouseMove = ({
         offset: anchorOffset,
         wordStart: anchorWordStart,
         wordEnd: anchorWordEnd,
-      } = selectionAnchor
+      } = selectionState.anchor
       const focusNode = caretPosition.offsetNode
       const focusOffset = caretPosition.offset
 
@@ -56,7 +53,10 @@ export const handleTextMouseMove = ({
       selection.removeAllRanges()
       const range = document.createRange()
 
-      if (selectionMode === 'word' && focusNode.nodeType === Node.TEXT_NODE) {
+      if (
+        selectionState.mode === 'word' &&
+        focusNode.nodeType === Node.TEXT_NODE
+      ) {
         // Extend selection word-by-word
         const text = focusNode.textContent ?? ''
         let focusWordStart = focusOffset
@@ -88,17 +88,9 @@ export const handleTextMouseMove = ({
 
       selection.addRange(range)
       node.focus()
-      return {
-        selectionAnchor,
-        selectionMode,
-        handled: true,
-      }
+      return true
     }
   }
 
-  return {
-    selectionAnchor,
-    selectionMode,
-    handled: false,
-  }
+  return false
 }

--- a/packages/runtime/src/editor/text-selection/selection.ts
+++ b/packages/runtime/src/editor/text-selection/selection.ts
@@ -1,0 +1,69 @@
+import { stripNodeIdRepeatIndices } from '../../utils/nodes'
+import { postMessageToEditor } from '../postMessageToEditor'
+
+export const handleTextNodeSelection = (node: HTMLElement) => {
+  const initialContent = node.innerText
+  node.contentEditable = 'plaintext-only'
+  window.focus()
+  node.focus()
+
+  postMessageToEditor({
+    type: 'highlight',
+    highlightedNodeId: stripNodeIdRepeatIndices(node.getAttribute('data-id')),
+  })
+
+  // Select all text when focusing the text node
+  const selection = window.getSelection()
+  if (selection) {
+    const range = document.createRange()
+    range.selectNodeContents(node)
+    selection.removeAllRanges()
+    selection.addRange(range)
+  }
+
+  const finishEditing = () => {
+    window.removeEventListener('selected-node-changed', finishEditing)
+    node.removeAttribute('contenteditable')
+    // Clear selected text
+    requestAnimationFrame(() => {
+      const selection = window.getSelection()
+      if (selection) {
+        selection.removeAllRanges()
+      }
+    })
+
+    // Loose tab focus from document entirely
+    if (document.activeElement === node) {
+      ;(document.activeElement as HTMLElement).blur()
+    }
+
+    if (node.innerText === initialContent) {
+      return
+    }
+
+    postMessageToEditor({
+      type: 'updateTextNodeContent',
+      innerText: node.innerText,
+      nodeId: node.getAttribute('data-node-id'),
+    })
+  }
+
+  setTimeout(() => {
+    window.addEventListener('selected-node-changed', finishEditing, {
+      once: true,
+    })
+  }, 0)
+
+  node.addEventListener('keydown', (e) => {
+    e.stopPropagation()
+    if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey)) {
+      e.preventDefault()
+      finishEditing()
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      node.textContent = initialContent
+      finishEditing()
+    }
+  })
+}

--- a/packages/runtime/src/editor/text-selection/types.ts
+++ b/packages/runtime/src/editor/text-selection/types.ts
@@ -1,8 +1,0 @@
-export type SelectionAnchor = {
-  node: Node
-  offset: number
-  wordStart: number
-  wordEnd: number
-}
-
-export type SelectionMode = 'char' | 'word' | 'all'

--- a/packages/runtime/src/editor/text-selection/types.ts
+++ b/packages/runtime/src/editor/text-selection/types.ts
@@ -1,0 +1,8 @@
+export type SelectionAnchor = {
+  node: Node
+  offset: number
+  wordStart: number
+  wordEnd: number
+}
+
+export type SelectionMode = 'char' | 'word' | 'all'

--- a/packages/runtime/src/editor/types.ts
+++ b/packages/runtime/src/editor/types.ts
@@ -65,7 +65,6 @@ export type NordcraftPreviewEvent =
       buttons: number
     }
   | { type: 'report_document_scroll_size' }
-  | { type: 'update_inner_text'; innerText: string }
   | { type: 'reload' }
   | { type: 'fetch_api'; apiKey: string }
   | { type: 'introspect_qraphql_api'; apiKey: string }
@@ -290,4 +289,25 @@ export enum TextNodeComputedStyles {
   WRITING_MODE = 'writing-mode',
   LINE_BREAK = 'line-break',
   OVERFLOW_WRAP = 'overflow-wrap',
+}
+
+export type SelectionState = {
+  anchor: SelectionAnchor | null
+  mode: SelectionMode
+}
+
+export type SelectionMode = 'char' | 'word' | 'all'
+
+export type SelectionAnchor = {
+  node: Node
+  offset: number
+  wordStart: number
+  wordEnd: number
+}
+
+export type PointerState = {
+  lastPressPosition: Point
+  buttons: number
+  lastPressTime: number
+  pressCount: number
 }

--- a/packages/runtime/src/editor/types.ts
+++ b/packages/runtime/src/editor/types.ts
@@ -58,10 +58,11 @@ export type NordcraftPreviewEvent =
   | { type: 'selection'; selectedNodeId: string | null }
   | { type: 'highlight'; highlightedNodeId: string | null }
   | {
-      type: 'click' | 'mousemove' | 'dblclick'
+      type: 'click' | 'mousemove' | 'mousedown' | 'dblclick'
       metaKey: boolean
       x: number
       y: number
+      buttons: number
     }
   | { type: 'report_document_scroll_size' }
   | { type: 'update_inner_text'; innerText: string }
@@ -206,6 +207,11 @@ export type EditorPostMessageType =
       type: 'introspectionResult'
       data: any
       apiKey: string
+    }
+  | {
+      type: 'updateTextNodeContent'
+      innerText: string
+      nodeId: string | null
     }
 
 export type DragState = {

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -199,7 +199,6 @@ const processNodes = (
             'style-variables',
             'style',
             'styleVariables',
-            'variants',
           ]) as NodeModel,
         ]
       }


### PR DESCRIPTION
Completely redesigned how we edit text in canvas by actually editing in the iframe with contenteditable instead of faking it as today. There were a few issues that made this difficult, like proxying mouse-events through the canvas to select text.

This PR also:
- Moved the drag-and-drop logic to separate files along with the logic for text editing
- Made the auto-size canvas more stable
- Noticeably improved performance by bypassing the report formula logic entirely when not reporting.

Use editor branch `dev` to test these changes as the canvas needs to subscribe to the new update text event.