### PR TITLE
Use class hash selectors instead of data-id when possible

### DIFF
--- a/packages/core/src/styling/className.ts
+++ b/packages/core/src/styling/className.ts
@@ -12,6 +12,9 @@ export const getClassName = (object: any) => {
   return className
 }
 
+export const getPathClassName = (path: string) =>
+  generateAlphabeticName(hash(path))
+
 export const toValidClassName = (
   input: string,
   escapeSpecialCharacters = false,

--- a/packages/core/src/utils/getNodeSelector.test.ts
+++ b/packages/core/src/utils/getNodeSelector.test.ts
@@ -1,11 +1,12 @@
 import type { StyleVariant } from '../component/component.types'
+import { getPathClassName } from '../styling/className'
 import { getNodeSelector } from './getNodeSelector'
 
 describe('getNodeSelector', () => {
   test('should return a selector to a specific node when given a path', () => {
     const path = '0.1.2'
     const selector = getNodeSelector(path)
-    expect(selector).toBe('[data-id="0.1.2"]')
+    expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should return a selector to a specific node from a component instance', () => {
@@ -13,7 +14,9 @@ describe('getNodeSelector', () => {
     const componentName = 'test-component'
     const nodeId = 'test-node'
     const selector = getNodeSelector(path, { componentName, nodeId })
-    expect(selector).toBe('[data-id="0.1.2"].test-component\\:test-node')
+    expect(selector).toBe(
+      `.${getPathClassName(path)}.test-component\\:test-node`,
+    )
   })
 
   test('should return a selector to a specific node variant when given a path and variant', () => {
@@ -24,7 +27,7 @@ describe('getNodeSelector', () => {
       breakpoint: 'medium',
     }
     const selector = getNodeSelector(path, { variant })
-    expect(selector).toBe('[data-id="0.1.2"]:hover')
+    expect(selector).toBe(`.${getPathClassName(path)}:hover`)
   })
 
   test('should return a selector to a specific node variant from a component instance', () => {
@@ -39,20 +42,20 @@ describe('getNodeSelector', () => {
     }
     const selector = getNodeSelector(path, { componentName, nodeId, variant })
     expect(selector).toBe(
-      '[data-id="0.1.2"].test-component\\:test-node.test-class:active',
+      `.${getPathClassName(path)}.test-component\\:test-node.test-class:active`,
     )
   })
 
   test('should escape unescaped slashes in the path', () => {
     const path = '0.1/2'
     const selector = getNodeSelector(path)
-    expect(selector).toBe('[data-id="0.1\\/2"]')
+    expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should not escape already escaped slashes in the path', () => {
     const path = '0.1\\/2'
     const selector = getNodeSelector(path)
-    expect(selector).toBe('[data-id="0.1\\/2"]')
+    expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should prefix selector with an underscore if it starts with a number', () => {
@@ -61,6 +64,6 @@ describe('getNodeSelector', () => {
       componentName: '404',
       nodeId: 'test-node',
     })
-    expect(selector).toBe('[data-id="0.1\\/2"]._404\\:test-node')
+    expect(selector).toBe(`.${getPathClassName(path)}._404\\:test-node`)
   })
 })

--- a/packages/core/src/utils/getNodeSelector.ts
+++ b/packages/core/src/utils/getNodeSelector.ts
@@ -1,3 +1,4 @@
+import { getPathClassName } from '../styling/className'
 import { variantSelector, type StyleVariant } from '../styling/variantSelector'
 import type { Nullable } from '../types'
 
@@ -17,7 +18,7 @@ export function getNodeSelector(
   path: string,
   { componentName, nodeId, variant }: NodeSelectorOptions = {},
 ): string {
-  let selector = `[data-id="${path}"]`
+  let selector = `.${getPathClassName(path)}`
   if (componentName) {
     // Do not allow classes to start with a number, for example a page named "404" would result in a selector starting with a number which is invalid in CSS.
     selector += startsWithNumber(componentName)

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -7,6 +7,7 @@ import type {
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import {
   getClassName,
+  getPathClassName,
   toValidClassName,
 } from '@nordcraft/core/dist/styling/className'
 import { appendUnit } from '@nordcraft/core/dist/styling/customProperty'
@@ -67,6 +68,17 @@ export function createElement({
   elem.setAttribute('data-node-id', id)
   if (path) {
     elem.setAttribute('data-id', path)
+    if (
+      (node.customProperties &&
+        Object.entries(node.customProperties).length > 0) ||
+      node.variants?.some(
+        (variant) =>
+          variant.customProperties &&
+          Object.entries(variant.customProperties).length > 0,
+      )
+    ) {
+      elem.classList.add(getPathClassName(path))
+    }
   }
   if (ctx.isRootComponent === false && id !== 'root') {
     elem.setAttribute('data-component', ctx.component.name)

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -19,6 +19,7 @@ import type {
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import {
   getClassName,
+  getPathClassName,
   toValidClassName,
 } from '@nordcraft/core/dist/styling/className'
 import { appendUnit } from '@nordcraft/core/dist/styling/customProperty'
@@ -245,6 +246,16 @@ const renderComponent = async ({
             },
           )
         })
+
+        const hasDynamicProperties =
+          Object.keys(node.customProperties ?? {}).length > 0 ||
+          node.variants?.some(
+            (variant) => Object.keys(variant.customProperties ?? {}).length > 0,
+          )
+
+        if (hasDynamicProperties) {
+          classList.push(getPathClassName(path))
+        }
 
         let innerHTML = ''
 


### PR DESCRIPTION
`[data-id=""]` selectors are much slower than class selectors. Most browsers has an internal index of where classes are used, so lookup nodes is the same as actually selected.

attribute selectors are a lot slower, as first the attribute is selected, and then every single selected attribute will have to match the value of the attribute. This can lead to multiple times more lookups than ends up matching the selector.