### PR TITLE
Treat nodes as nullish/partial

### DIFF
--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -70,11 +70,17 @@ export class ToddleComponent<Handler> {
           globalFormulas: this.globalFormulas,
         }),
       )
-      Object.values(component.nodes ?? {}).forEach(
-        visitNode(node.package ?? packageName),
-      )
+      Object.values(component.nodes ?? {}).forEach((node) => {
+        if (isDefined(node)) {
+          visitNode((node as any).package ?? packageName)(node)
+        }
+      })
     }
-    Object.values(this.nodes ?? {}).forEach(visitNode())
+    Object.values(this.nodes ?? {}).forEach((node) => {
+      if (isDefined(node)) {
+        visitNode()(node)
+      }
+    })
     return [...components.values()]
   }
 
@@ -455,7 +461,9 @@ export class ToddleComponent<Handler> {
       })
     }
     for (const [nodeKey, node] of Object.entries(this.nodes ?? {})) {
-      yield* visitNode(node, ['nodes', nodeKey])
+      if (isDefined(node)) {
+        yield* visitNode(node, ['nodes', nodeKey])
+      }
     }
   }
 
@@ -542,7 +550,9 @@ export class ToddleComponent<Handler> {
       ])
     }
     for (const [nodeKey, node] of Object.entries(this.nodes ?? {})) {
-      yield* visitNode(node, ['nodes', nodeKey])
+      if (isDefined(node)) {
+        yield* visitNode(node, ['nodes', nodeKey])
+      }
     }
   }
 

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -196,7 +196,7 @@ export interface Component {
   >
   workflows?: Nullable<Record<string, Nullable<ComponentWorkflow>>>
   apis?: Nullable<Record<string, Nullable<ComponentAPI>>>
-  nodes?: Nullable<Record<string, NodeModel>>
+  nodes?: Nullable<Partial<Record<string, NodeModel>>>
   events?: Nullable<Nullable<ComponentEvent>[]>
   onLoad?: Nullable<EventModel>
   onAttributeChange?: Nullable<EventModel>

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -196,7 +196,7 @@ export interface Component {
   >
   workflows?: Nullable<Record<string, Nullable<ComponentWorkflow>>>
   apis?: Nullable<Record<string, Nullable<ComponentAPI>>>
-  nodes?: Nullable<Partial<Record<string, NodeModel>>>
+  nodes?: Nullable<Partial<Record<string, NodeModel | null>>>
   events?: Nullable<Nullable<ComponentEvent>[]>
   onLoad?: Nullable<EventModel>
   onAttributeChange?: Nullable<EventModel>

--- a/packages/core/src/styling/style.css.ts
+++ b/packages/core/src/styling/style.css.ts
@@ -270,6 +270,9 @@ export const createStylesheet = (
       return
     }
     Object.entries(component.nodes).forEach(([id, node]) => {
+      if (!isDefined(node)) {
+        return
+      }
       if (node.type === 'component') {
         const childComponent = components.find(
           (c) =>
@@ -310,7 +313,7 @@ export const getAllFonts = (components: Component[]) => {
     components
       .flatMap((component) => {
         return Object.values(component.nodes ?? {}).flatMap((node) => {
-          if (node.type === 'element') {
+          if (node?.type === 'element') {
             return [
               node.style?.fontFamily,
               node.style?.['font-family'],

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -255,7 +255,9 @@ export function createElement({
   if (nodeTag === 'script' || nodeTag === 'style') {
     const textValues: Array<Signal<string> | string> = []
     ;(node.children ?? [])
-      .map<NodeModel | undefined>((child) => ctx.component.nodes?.[child])
+      .map<NodeModel | undefined | null>(
+        (child) => ctx.component.nodes?.[child],
+      )
       .filter((node) => node?.type === 'text')
       .forEach((node) => {
         if (node.value.type === 'value') {

--- a/packages/runtime/src/components/createSlot.ts
+++ b/packages/runtime/src/components/createSlot.ts
@@ -1,8 +1,8 @@
 import type {
+  Component,
   NodeModel,
   SlotNodeModel,
 } from '@nordcraft/core/dist/component/component.types'
-import type { Nullable } from '@nordcraft/core/dist/types'
 import type { NodeRenderer } from './createNode'
 import { createNode } from './createNode'
 
@@ -81,13 +81,13 @@ export function createSlot({
 function getSlotComponentIndex(
   nodeName: string,
   node: NodeModel,
-  componentNodes: Nullable<Record<string, NodeModel>>,
+  componentNodes: Component['nodes'],
 ) {
   let slotsWithSameNameIndex = 0
   if (componentNodes) {
     for (const n in componentNodes) {
       const currentNode = componentNodes[n]
-      if (currentNode.type === 'slot' && currentNode.name === nodeName) {
+      if (currentNode?.type === 'slot' && currentNode.name === nodeName) {
         if (currentNode === node) {
           break
         }

--- a/packages/runtime/src/editor/links.ts
+++ b/packages/runtime/src/editor/links.ts
@@ -8,18 +8,7 @@ import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 export const updateComponentLinks = (component: Component) => {
   // Find all links and add target="_blank" to them
   Object.entries(component.nodes ?? {}).forEach(([_, node]) => {
-    if (!node?.type) {
-      console.warn(
-        'Node has no type, skipping',
-        node,
-        'key',
-        _,
-        'component',
-        component.name,
-      )
-      return
-    }
-    if (node.type === 'element' && node.tag === 'a') {
+    if (node?.type === 'element' && node.tag === 'a') {
       if (!node.attrs) {
         node.attrs = {}
       }

--- a/packages/runtime/src/editor/links.ts
+++ b/packages/runtime/src/editor/links.ts
@@ -8,6 +8,17 @@ import { valueFormula } from '@nordcraft/core/dist/formula/formulaUtils'
 export const updateComponentLinks = (component: Component) => {
   // Find all links and add target="_blank" to them
   Object.entries(component.nodes ?? {}).forEach(([_, node]) => {
+    if (!node?.type) {
+      console.warn(
+        'Node has no type, skipping',
+        node,
+        'key',
+        _,
+        'component',
+        component.name,
+      )
+      return
+    }
     if (node.type === 'element' && node.tag === 'a') {
       if (!node.attrs) {
         node.attrs = {}

--- a/packages/runtime/src/styles/style.ts
+++ b/packages/runtime/src/styles/style.ts
@@ -154,6 +154,9 @@ ${
       return
     }
     Object.entries(component.nodes).forEach(([id, node]) => {
+      if (!isDefined(node)) {
+        return
+      }
       if (node.type === 'component') {
         const childComponent = components.find(
           (c) =>

--- a/packages/runtime/src/utils/nodes.ts
+++ b/packages/runtime/src/utils/nodes.ts
@@ -2,6 +2,7 @@ import type {
   Component,
   NodeModel,
 } from '@nordcraft/core/dist/component/component.types'
+import { isDefined } from '@nordcraft/core/dist/utils/util'
 
 type NodeWithNodeId = NodeModel & { nodeId: string }
 
@@ -24,31 +25,34 @@ export const getNodeAndAncestors = (
   // nodePath skips the root element as it's selected as the initial
   // value in the reduce below
   const nodePath = pathParsed.slice(1)
-  const node = nodePath.reduce((node: NodeModel | undefined, childIndex, i) => {
-    switch (node?.type) {
-      // 'text' elements don't have any children
-      case 'element':
-      case 'component':
-      case 'slot': {
-        // Ancestors are elements before the target node
-        if (i <= nodePath.length - 1) {
-          ancestors.push({
-            ...node,
-            // Use the original path as origin to get correct nodeIds
-            nodeId: path.slice(0, i + 1).join('.'),
-          })
+  const node = nodePath.reduce(
+    (node: NodeModel | undefined | null, childIndex, i) => {
+      switch (node?.type) {
+        // 'text' elements don't have any children
+        case 'element':
+        case 'component':
+        case 'slot': {
+          // Ancestors are elements before the target node
+          if (i <= nodePath.length - 1) {
+            ancestors.push({
+              ...node,
+              // Use the original path as origin to get correct nodeIds
+              nodeId: path.slice(0, i + 1).join('.'),
+            })
+          }
+          const index = node.children?.[childIndex]
+          if (index === undefined) {
+            return undefined
+          }
+          return component.nodes?.[index]
         }
-        const index = node.children?.[childIndex]
-        if (index === undefined) {
+        default:
           return undefined
-        }
-        return component.nodes?.[index]
       }
-      default:
-        return undefined
-    }
-  }, root)
-  if (node === undefined) {
+    },
+    root,
+  )
+  if (!isDefined(node)) {
     return undefined
   }
   return { node: { ...node, nodeId: id }, ancestors }

--- a/packages/runtime/src/utils/omitStyle.ts
+++ b/packages/runtime/src/utils/omitStyle.ts
@@ -1,5 +1,6 @@
 import type { Component } from '@nordcraft/core/dist/component/component.types'
 import type { StyleVariant } from '@nordcraft/core/dist/styling/variantSelector'
+import { isDefined } from '@nordcraft/core/dist/utils/util'
 
 export function omitSubnodeStyleForComponent<T extends Component | undefined>(
   component: T,
@@ -7,6 +8,7 @@ export function omitSubnodeStyleForComponent<T extends Component | undefined>(
   const clone = structuredClone(component)
   Object.entries(clone?.nodes ?? {}).forEach(([nodeId, node]) => {
     if (
+      isDefined(node) &&
       (node.type === 'element' || node.type === 'component') &&
       nodeId !== 'root'
     ) {

--- a/packages/search/src/rules/issues/attributes/noReferenceAttributeInInstanceRule.ts
+++ b/packages/search/src/rules/issues/attributes/noReferenceAttributeInInstanceRule.ts
@@ -33,7 +33,7 @@ export const noReferenceAttributeInInstanceRule: IssueRule<void> = {
       const attrs = new Set<string>()
       Object.values(args.files.components).forEach((otherComponent) =>
         Object.values(otherComponent?.nodes ?? {})
-          .filter((node) => node.type === 'component')
+          .filter((node) => node?.type === 'component')
           .forEach((instance) =>
             Object.keys(instance.attrs ?? {}).forEach((attr) => {
               attrs.add([instance.name, attr].join('/'))

--- a/packages/search/src/rules/issues/components/componentIsReferenced.memo.ts
+++ b/packages/search/src/rules/issues/components/componentIsReferenced.memo.ts
@@ -13,7 +13,7 @@ export const componentIsReferenced = (
       Object.values(component?.nodes ?? {})
         .filter(
           (node) =>
-            node.type === 'component' &&
+            node?.type === 'component' &&
             // Do not add cyclical references
             node.name !== component?.name,
         )

--- a/packages/search/src/rules/issues/components/unknownComponentRule.ts
+++ b/packages/search/src/rules/issues/components/unknownComponentRule.ts
@@ -10,7 +10,7 @@ export const unknownComponentRule: IssueRule<{
   visit: (report, { path, files, value, nodeType }) => {
     if (
       nodeType !== 'component-node' ||
-      value.type !== 'component' ||
+      value?.type !== 'component' ||
       // Check if the component exists in the project
       (!isDefined(value.package) && isDefined(files.components[value.name])) ||
       // Check if the component exists in a specified package

--- a/packages/search/src/rules/issues/context/noContextConsumersRule.ts
+++ b/packages/search/src/rules/issues/context/noContextConsumersRule.ts
@@ -25,13 +25,13 @@ export const noContextConsumersRule: IssueRule<{
       return
     }
     const hasSlots = Object.values(value.nodes ?? {}).some(
-      (n) => n.type === 'slot',
+      (n) => n?.type === 'slot',
     )
     if (hasSlots) {
       return
     }
     const hasComponents = Object.values(value.nodes ?? {}).some(
-      (n) => n.type === 'component',
+      (n) => n?.type === 'component',
     )
     if (hasComponents) {
       return

--- a/packages/search/src/rules/issues/dom/createRequiredDirectChildRule.ts
+++ b/packages/search/src/rules/issues/dom/createRequiredDirectChildRule.ts
@@ -1,4 +1,3 @@
-import type { NodeModel } from '@nordcraft/core/dist/component/component.types'
 import type { IssueRule, Level } from '../../../types'
 
 export function createRequiredDirectChildRule(
@@ -22,8 +21,7 @@ export function createRequiredDirectChildRule(
       if (value?.type !== 'element' || !parentTags.includes(value.tag)) {
         return
       }
-      const getElement = (id: string): NodeModel | undefined =>
-        component.nodes?.[id]
+      const getElement = (id: string) => component.nodes?.[id]
       ;(value.children ?? []).forEach((childId) => {
         const childNode = getElement(childId)
         if (

--- a/packages/search/src/rules/issues/dom/createRequiredDirectChildRule.ts
+++ b/packages/search/src/rules/issues/dom/createRequiredDirectChildRule.ts
@@ -19,7 +19,7 @@ export function createRequiredDirectChildRule(
         return
       }
       const { value, component, path } = args
-      if (value.type !== 'element' || !parentTags.includes(value.tag)) {
+      if (value?.type !== 'element' || !parentTags.includes(value.tag)) {
         return
       }
       const getElement = (id: string): NodeModel | undefined =>

--- a/packages/search/src/rules/issues/dom/createRequiredDirectParentRule.ts
+++ b/packages/search/src/rules/issues/dom/createRequiredDirectParentRule.ts
@@ -18,12 +18,12 @@ export function createRequiredDirectParentRule(
         return
       }
       const { value, component, path } = args
-      if (value.type !== 'element' || !childTags.includes(value.tag)) {
+      if (value?.type !== 'element' || !childTags.includes(value.tag)) {
         return
       }
       const nodeId = String(args.path[args.path.length - 1])
       const parent = Object.values(component.nodes ?? {}).find(
-        (node) => node.type === 'element' && node.children?.includes(nodeId),
+        (node) => node?.type === 'element' && node.children?.includes(nodeId),
       )
       if (parent?.type === 'element' && !parentTags.includes(parent.tag)) {
         report({

--- a/packages/search/src/rules/issues/dom/createRequiredElementAttributeRule.ts
+++ b/packages/search/src/rules/issues/dom/createRequiredElementAttributeRule.ts
@@ -31,7 +31,7 @@ export function createRequiredElementAttributeRule({
     visit: (report, { path, nodeType, value }) => {
       if (
         nodeType === 'component-node' &&
-        value.type === 'element' &&
+        value?.type === 'element' &&
         value.tag === tag
       ) {
         const attributes = Array.isArray(attribute) ? attribute : [attribute]

--- a/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
+++ b/packages/search/src/rules/issues/dom/elementWithoutInteractiveContentRule.ts
@@ -22,7 +22,7 @@ export const elementWithoutInteractiveContentRule: IssueRule<{
     }
     const { value, component, path, files } = args
     if (
-      value.type !== 'element' ||
+      value?.type !== 'element' ||
       !ELEMENTS_WITHOUT_INTERACTIVE_CONTENT.includes(value.tag)
     ) {
       return

--- a/packages/search/src/rules/issues/dom/imageWithoutDimensionRule.ts
+++ b/packages/search/src/rules/issues/dom/imageWithoutDimensionRule.ts
@@ -14,7 +14,7 @@ export const imageWithoutDimensionRule: IssueRule = {
   visit: (report, { path, nodeType, value }) => {
     if (
       nodeType !== 'component-node' ||
-      value.type !== 'element' ||
+      value?.type !== 'element' ||
       !['img', 'source'].includes(value.tag)
     ) {
       return

--- a/packages/search/src/rules/issues/dom/nonEmptyVoidElementRule.ts
+++ b/packages/search/src/rules/issues/dom/nonEmptyVoidElementRule.ts
@@ -11,7 +11,7 @@ export const nonEmptyVoidElementRule: IssueRule<{ tag: string }> = {
   visit: (report, { path, nodeType, value }) => {
     if (
       nodeType !== 'component-node' ||
-      value.type !== 'element' ||
+      value?.type !== 'element' ||
       (value.children ?? []).length <= 0 ||
       !VOID_HTML_ELEMENTS.includes(value.tag)
     ) {

--- a/packages/search/src/rules/issues/events/duplicateEventTriggerRule.ts
+++ b/packages/search/src/rules/issues/events/duplicateEventTriggerRule.ts
@@ -5,7 +5,7 @@ export const duplicateEventTriggerRule: IssueRule<{ trigger: string }> = {
   level: 'warning',
   category: 'Quality',
   visit: (report, { nodeType, path, value }) => {
-    if (nodeType !== 'component-node' || value.type !== 'element') {
+    if (nodeType !== 'component-node' || value?.type !== 'element') {
       return
     }
     const eventTriggers = new Set<string>()

--- a/packages/search/src/rules/issues/events/unknownEventRule.ts
+++ b/packages/search/src/rules/issues/events/unknownEventRule.ts
@@ -10,7 +10,7 @@ export const unknownEventRule: IssueRule<{
   visit: (report, { path, files, value, nodeType }) => {
     if (
       nodeType !== 'component-node' ||
-      value.type !== 'component' ||
+      value?.type !== 'component' ||
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       Object.entries(value.events ?? {}).length === 0
     ) {

--- a/packages/search/src/rules/issues/formulas/unknownRepeatIndexFormulaRule.ts
+++ b/packages/search/src/rules/issues/formulas/unknownRepeatIndexFormulaRule.ts
@@ -30,17 +30,17 @@ export const unknownRepeatIndexFormulaRule: IssueRule = {
       return
     }
     const findParentWithRepeat = (
-      args: [id: string, node: NodeModel] | undefined,
+      args: [id: string, node?: NodeModel | null] | undefined,
     ): NodeModel | undefined => {
       if (!args) {
         return
       }
       const [id, node] = args
-      if (node.repeat) {
+      if (node?.repeat) {
         return node
       }
       const parent = Object.entries(component.nodes ?? {}).find(([_, node]) =>
-        node.children?.includes(id),
+        node?.children?.includes(id),
       )
       return findParentWithRepeat(parent)
     }

--- a/packages/search/src/rules/issues/formulas/unknownRepeatItemFormulaRule.ts
+++ b/packages/search/src/rules/issues/formulas/unknownRepeatItemFormulaRule.ts
@@ -31,17 +31,17 @@ export const unknownRepeatItemFormulaRule: IssueRule = {
       return
     }
     const findParentWithRepeat = (
-      args: [id: string, node: NodeModel] | undefined,
+      args: [id: string, node?: NodeModel | null] | undefined,
     ): NodeModel | undefined => {
       if (!args) {
         return
       }
       const [id, node] = args
-      if (node.repeat) {
+      if (node?.repeat) {
         return node
       }
       const parent = Object.entries(component.nodes ?? {}).find(([_, node]) =>
-        node.children?.includes(id),
+        node?.children?.includes(id),
       )
       return findParentWithRepeat(parent)
     }

--- a/packages/search/src/rules/issues/miscellaneous/createStaticSizeConstraintRule.ts
+++ b/packages/search/src/rules/issues/miscellaneous/createStaticSizeConstraintRule.ts
@@ -23,7 +23,7 @@ export function createStaticSizeConstraintRule(
       ) {
         let size = 0
         const component = args.component
-        const evaluateElement = (element?: NodeModel): string => {
+        const evaluateElement = (element?: NodeModel | null): string => {
           if (
             !element ||
             ['element', 'text', 'slot', 'component'].includes(element.type) ===

--- a/packages/search/src/rules/issues/miscellaneous/createStaticSizeConstraintRule.ts
+++ b/packages/search/src/rules/issues/miscellaneous/createStaticSizeConstraintRule.ts
@@ -18,7 +18,7 @@ export function createStaticSizeConstraintRule(
     visit: (report, args) => {
       if (
         args.nodeType === 'component-node' &&
-        args.value.type === 'element' &&
+        args.value?.type === 'element' &&
         args.value.tag === tag
       ) {
         let size = 0

--- a/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.test.ts
+++ b/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.test.ts
@@ -51,6 +51,48 @@ describe('find noReferenceNodeRule', () => {
     ])
   })
 
+  test('should detect "null" nodes with no references', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          formulas: {},
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  id: 'root',
+                  type: 'element',
+                  tag: 'div',
+                  children: [],
+                  attrs: {},
+                  style: {},
+                  events: {},
+                  classes: {},
+                },
+                '1LisbD0eCjsuccoUwajn1': null as any,
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [noReferenceNodeRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].details).toEqual({ node: '1LisbD0eCjsuccoUwajn1' })
+    expect(problems[0].path).toEqual([
+      'components',
+      'test',
+      'nodes',
+      '1LisbD0eCjsuccoUwajn1',
+    ])
+  })
+
   test('should not detect nodes with references', () => {
     const problems = Array.from(
       searchProject({

--- a/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.test.ts
+++ b/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.test.ts
@@ -179,6 +179,49 @@ describe('fix noReferenceNodeRule', () => {
       'used',
     ])
   })
+
+  test('should delete "null" nodes with no references', () => {
+    const files: ProjectFiles = {
+      formulas: {},
+      components: {
+        test: {
+          name: 'test',
+          nodes: {
+            root: {
+              id: 'root',
+              type: 'element',
+              tag: 'div',
+              children: ['used'],
+              attrs: {},
+              style: {},
+              events: {},
+              classes: {},
+            },
+            '1LisbD0eCjsuccoUwajn1': null,
+            used: {
+              id: 'used',
+              type: 'text',
+              value: { type: 'value', value: 'I am used' },
+            },
+          },
+          formulas: {},
+          apis: {},
+          attributes: {},
+          variables: {},
+        },
+      },
+    }
+    const fixedFiles = fixProject({
+      files,
+      rule: noReferenceNodeRule,
+      fixType: 'delete-orphan-node',
+    })
+    expect(Object.keys(fixedFiles.components.test!.nodes ?? {})).toEqual([
+      'root',
+      'used',
+    ])
+  })
+
   test('should remove children of orphan node', () => {
     const files: ProjectFiles = {
       formulas: {},

--- a/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.ts
+++ b/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.ts
@@ -19,9 +19,18 @@ export const noReferenceNodeRule: IssueRule<{ node: string }> = {
       () =>
         new Set(
           Object.values(component.nodes ?? {}).flatMap(
-            (node) => node.children ?? [],
+            (node) => node?.children ?? [],
           ),
         ),
+    )
+
+    console.log(
+      'Checking node',
+      nodeId,
+      'in component',
+      component.name,
+      'referenced',
+      referencedNodesInComponent.has(nodeId),
     )
 
     if (nodeId !== 'root' && !referencedNodesInComponent.has(nodeId)) {

--- a/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.ts
+++ b/packages/search/src/rules/issues/miscellaneous/noReferenceNodeRule.ts
@@ -24,15 +24,6 @@ export const noReferenceNodeRule: IssueRule<{ node: string }> = {
         ),
     )
 
-    console.log(
-      'Checking node',
-      nodeId,
-      'in component',
-      component.name,
-      'referenced',
-      referencedNodesInComponent.has(nodeId),
-    )
-
     if (nodeId !== 'root' && !referencedNodesInComponent.has(nodeId)) {
       report({
         path,

--- a/packages/search/src/rules/issues/slots/unknownComponentSlotRule.ts
+++ b/packages/search/src/rules/issues/slots/unknownComponentSlotRule.ts
@@ -12,7 +12,7 @@ export const unknownComponentSlotRule: IssueRule<{ slotName: string }> = {
     }
 
     // We only want to check the immediate children of a "sub component"
-    if (value.type !== 'component' || (value?.children ?? []).length === 0) {
+    if (value?.type !== 'component' || (value?.children ?? []).length === 0) {
       return
     }
 
@@ -34,7 +34,7 @@ export const unknownComponentSlotRule: IssueRule<{ slotName: string }> = {
     })
 
     const usableSlots = Object.values(subComponent.nodes ?? {})
-      .filter((node): node is SlotNodeModel => node.type === 'slot')
+      .filter((node): node is SlotNodeModel => node?.type === 'slot')
       .map((node) => node.name ?? 'default')
 
     // Loop the children and report issue when using a slot that doesn't exist

--- a/packages/search/src/rules/issues/style/noReferenceGlobalCSSVariable.ts
+++ b/packages/search/src/rules/issues/style/noReferenceGlobalCSSVariable.ts
@@ -24,7 +24,7 @@ export const noReferenceGlobalCSSVariableRule: IssueRule<{
         const vars = new Set<string>()
         Object.entries(files.components).forEach(([_, component]) => {
           Object.values(component?.nodes ?? {}).forEach((node) => {
-            if (node.type === 'element' || node.type === 'component') {
+            if (node?.type === 'element' || node?.type === 'component') {
               ;[{ style: node.style }, ...(node.variants ?? [])].forEach(
                 ({ style }) => {
                   Object.values(style ?? {}).forEach((styleValue) => {
@@ -51,7 +51,7 @@ export const noReferenceGlobalCSSVariableRule: IssueRule<{
         Object.values(files.packages ?? {}).forEach((pkg) => {
           Object.values(pkg?.components ?? {}).forEach((component) => {
             Object.values(component?.nodes ?? {}).forEach((node) => {
-              if (node.type === 'element' || node.type === 'component') {
+              if (node?.type === 'element' || node?.type === 'component') {
                 ;[{ style: node.style }, ...(node.variants ?? [])].forEach(
                   ({ style }) => {
                     Object.values(style ?? {}).forEach((styleValue) => {

--- a/packages/search/src/rules/issues/style/unknownCSSVariable.ts
+++ b/packages/search/src/rules/issues/style/unknownCSSVariable.ts
@@ -100,7 +100,7 @@ export const unknownCSSVariableRule: IssueRule<
           }
 
           const parent = Object.entries(component.nodes ?? {}).find(([_, n]) =>
-            n.children?.includes(nodeName),
+            n?.children?.includes(nodeName),
           )
           if (parent) {
             visitVars(parent[0])

--- a/packages/search/src/rules/search/fieldSearchRule.ts
+++ b/packages/search/src/rules/search/fieldSearchRule.ts
@@ -1,5 +1,5 @@
 import equal from 'fast-deep-equal'
-import type { NodeType, SearchRule } from '../../types'
+import type { SearchRule } from '../../types'
 import { parseSearchQuery } from '../../util/parseSearchQuery'
 
 type MatchResult =
@@ -253,9 +253,7 @@ export function createFieldSearchRule({
 }: {
   query: string
   withDetails?: boolean
-  skippedFields?: Partial<{
-    [K in NodeType as K['nodeType']]: (keyof K['value'])[]
-  }>
+  skippedFields?: Record<string, string[]>
 }): SearchRule {
   const parsedQuery = parseSearchQuery(query)
   const reportedPaths = new Set<string>()

--- a/packages/search/src/searchProject.ts
+++ b/packages/search/src/searchProject.ts
@@ -567,10 +567,11 @@ function* visitNode({
       }
 
       for (const key in value.nodes) {
+        const node = value.nodes[key]
         yield* visitNode({
           args: {
             nodeType: 'component-node',
-            value: value.nodes[key],
+            value: node,
             path: [...path, 'nodes', key],
             rules,
             files,
@@ -583,12 +584,12 @@ function* visitNode({
           fixOptions: fixOptions as any,
         })
         if (
-          value.nodes[key].type === 'component' ||
-          value.nodes[key].type === 'element'
+          isDefined(node) &&
+          (node.type === 'component' || node.type === 'element')
         ) {
           // Visit attributes on component and element nodes
-          for (const attrKey in value.nodes[key].attrs) {
-            const attr = value.nodes[key].attrs[attrKey]
+          for (const attrKey in node.attrs) {
+            const attr = node.attrs[attrKey]
             yield* visitNode({
               args: {
                 nodeType: 'component-node-attribute',
@@ -599,7 +600,7 @@ function* visitNode({
                 pathsToVisit,
                 useExactPaths,
                 memo,
-                node: value.nodes[key],
+                node: node,
               },
               state,
               fixOptions: fixOptions as any,
@@ -739,7 +740,7 @@ function* visitNode({
       break
 
     case 'component-node':
-      if (value.type === 'element' || value.type === 'component') {
+      if (value?.type === 'element' || value?.type === 'component') {
         for (const [styleKey, styleValue] of Object.entries(
           value.style ?? {},
         )) {

--- a/packages/search/src/types.ts
+++ b/packages/search/src/types.ts
@@ -376,7 +376,7 @@ export type ComponentEvent = {
 
 export type ComponentNodeNode = {
   nodeType: 'component-node'
-  value: NodeModel
+  value?: NodeModel | null
   component: ToddleComponent<Function>
 } & Base
 

--- a/packages/search/src/util/removeUnused.fix.ts
+++ b/packages/search/src/util/removeUnused.fix.ts
@@ -12,31 +12,26 @@ export const removeFromPathFix: FixFunction<NodeType> = ({
 export const removeNodeFromPathFix: FixFunction<NodeType> = ({ data }) => {
   const nodeId = String(data.path[data.path.length - 1])
   const componentNodesPath = data.path.slice(0, -1).map(String)
-  const nodes = structuredClone(get(data.files, componentNodesPath)) as Record<
-    string,
-    NodeModel
+  const nodes = structuredClone(get(data.files, componentNodesPath)) as Partial<
+    Record<string, NodeModel | null>
   >
 
   // Clean parent reference
   for (const key in nodes) {
-    if (nodes[key].children?.includes(nodeId)) {
-      nodes[key].children = nodes[key].children.filter((p) => p !== nodeId)
+    const node = nodes[key]
+    if (node?.children?.includes(nodeId)) {
+      node.children = node.children.filter((p) => p !== nodeId)
     }
   }
 
   // Clean children recursively
   const removeNodeAndChildren = (nodeId: string) => {
     const node = nodes[nodeId] as NodeModel | undefined
-    if (!node) {
-      return
-    }
-
-    if (node.children) {
+    if (node?.children) {
       for (const childId of node.children) {
         removeNodeAndChildren(childId)
       }
     }
-
     delete nodes[nodeId]
   }
 

--- a/packages/ssr/src/components/utils.ts
+++ b/packages/ssr/src/components/utils.ts
@@ -64,17 +64,21 @@ function takeComponentsIncludedInProject(
       dependencies.set(nodeName, { ...component, name: nodeName })
     }
 
-    Object.values(component.nodes ?? {}).forEach((node) =>
-      visitNode(
-        node,
-        (node.type === 'component' ? node.package : undefined) ?? packageName,
-      ),
-    )
+    Object.values(component.nodes ?? {}).forEach((node) => {
+      if (isDefined(node)) {
+        visitNode(
+          node,
+          (node.type === 'component' ? node.package : undefined) ?? packageName,
+        )
+      }
+    })
   }
 
-  Object.values(parent.nodes ?? {}).forEach((node) =>
-    visitNode(node, node.type === 'component' ? node.package : undefined),
-  )
+  Object.values(parent.nodes ?? {}).forEach((node) => {
+    if (isDefined(node)) {
+      visitNode(node, node.type === 'component' ? node.package : undefined)
+    }
+  })
 
   return Array.from(dependencies.values())
 }

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -92,7 +92,7 @@ const renderComponent = async ({
   }: {
     id: string
     path: string
-    node: NodeModel | undefined
+    node: NodeModel | undefined | null
     data: ComponentData
     packageName: string | undefined
     isComponentRootNode?: boolean

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -162,7 +162,7 @@ const processNodes = (
     return undefined
   }
   return mapObject(
-    filterObject<NodeModel | undefined, NodeModel>(nodes, ([_, value]) =>
+    filterObject<NodeModel | undefined | null, NodeModel>(nodes, ([_, value]) =>
       isDefined(value),
     ),
     ([key, value]) => {

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -161,115 +161,120 @@ const processNodes = (
   if (!isDefined(nodes)) {
     return undefined
   }
-  return mapObject(nodes, ([key, value]) => {
-    switch (value.type) {
-      case 'element': {
-        const updatedNode: NodeModel = {
-          ...value,
-          events: mapObject(value.events ?? {}, ([eventKey, eventValue]) => [
-            eventKey,
-            eventValue
-              ? {
-                  ...eventValue,
-                  actions: eventValue.actions?.map(removeActionTestData),
-                }
-              : null,
-          ]),
-          repeat: value.repeat
-            ? removeFormulaTestData(value.repeat)
-            : undefined,
-          repeatKey: value.repeatKey
-            ? removeFormulaTestData(value.repeatKey)
-            : undefined,
+  return mapObject(
+    filterObject<NodeModel | undefined, NodeModel>(nodes, ([_, value]) =>
+      isDefined(value),
+    ),
+    ([key, value]) => {
+      switch (value.type) {
+        case 'element': {
+          const updatedNode: NodeModel = {
+            ...value,
+            events: mapObject(value.events ?? {}, ([eventKey, eventValue]) => [
+              eventKey,
+              eventValue
+                ? {
+                    ...eventValue,
+                    actions: eventValue.actions?.map(removeActionTestData),
+                  }
+                : null,
+            ]),
+            repeat: value.repeat
+              ? removeFormulaTestData(value.repeat)
+              : undefined,
+            repeatKey: value.repeatKey
+              ? removeFormulaTestData(value.repeatKey)
+              : undefined,
+          }
+          return [
+            key,
+            removeOptionalPropertiesIfEmpty(updatedNode, [
+              'animations',
+              'attrs',
+              'children',
+              'condition',
+              'classes',
+              'customProperties',
+              'events',
+              'id',
+              'repeat',
+              'repeatKey',
+              'slot',
+              'style-variables',
+              'styleVariables',
+            ]) as NodeModel,
+          ]
         }
-        return [
-          key,
-          removeOptionalPropertiesIfEmpty(updatedNode, [
-            'animations',
-            'attrs',
-            'children',
-            'condition',
-            'classes',
-            'customProperties',
-            'events',
-            'id',
-            'repeat',
-            'repeatKey',
-            'slot',
-            'style-variables',
-            'styleVariables',
-          ]) as NodeModel,
-        ]
-      }
-      case 'text': {
-        return [
-          key,
-          removeOptionalPropertiesIfEmpty<TextNodeModel>(
-            {
-              ...value,
-              repeat: value.repeat
-                ? removeFormulaTestData(value.repeat)
-                : undefined,
-              repeatKey: value.repeatKey
-                ? removeFormulaTestData(value.repeatKey)
-                : undefined,
-            },
-            ['id', 'slot', 'repeat', 'repeatKey'],
-          ) as NodeModel,
-        ]
-      }
-      case 'component': {
-        const updatedNode: NodeModel = {
-          ...value,
-          events: mapObject(value.events ?? {}, ([eventKey, eventValue]) => [
-            eventKey,
-            eventValue
-              ? {
-                  ...eventValue,
-                  actions: eventValue.actions?.map(removeActionTestData),
-                }
-              : null,
-          ]),
-          repeat: value.repeat
-            ? removeFormulaTestData(value.repeat)
-            : undefined,
-          repeatKey: value.repeatKey
-            ? removeFormulaTestData(value.repeatKey)
-            : undefined,
+        case 'text': {
+          return [
+            key,
+            removeOptionalPropertiesIfEmpty<TextNodeModel>(
+              {
+                ...value,
+                repeat: value.repeat
+                  ? removeFormulaTestData(value.repeat)
+                  : undefined,
+                repeatKey: value.repeatKey
+                  ? removeFormulaTestData(value.repeatKey)
+                  : undefined,
+              },
+              ['id', 'slot', 'repeat', 'repeatKey'],
+            ) as NodeModel,
+          ]
         }
-        return [
-          key,
-          removeOptionalPropertiesIfEmpty(updatedNode, [
-            'id',
-            'slot',
-            'path',
-            'package',
-            'condition',
-            'repeat',
-            'repeatKey',
-            'variants',
-            'animations',
-            'attrs',
-            'children',
-            'events',
-          ]) as NodeModel,
-        ]
+        case 'component': {
+          const updatedNode: NodeModel = {
+            ...value,
+            events: mapObject(value.events ?? {}, ([eventKey, eventValue]) => [
+              eventKey,
+              eventValue
+                ? {
+                    ...eventValue,
+                    actions: eventValue.actions?.map(removeActionTestData),
+                  }
+                : null,
+            ]),
+            repeat: value.repeat
+              ? removeFormulaTestData(value.repeat)
+              : undefined,
+            repeatKey: value.repeatKey
+              ? removeFormulaTestData(value.repeatKey)
+              : undefined,
+          }
+          return [
+            key,
+            removeOptionalPropertiesIfEmpty(updatedNode, [
+              'id',
+              'slot',
+              'path',
+              'package',
+              'condition',
+              'repeat',
+              'repeatKey',
+              'variants',
+              'animations',
+              'attrs',
+              'children',
+              'events',
+            ]) as NodeModel,
+          ]
+        }
+        case 'slot': {
+          return [
+            key,
+            removeOptionalPropertiesIfEmpty(
+              omitKeys(
+                value,
+                // Always remove repeat and repeatKey from slots as they're not supported
+                ['repeat', 'repeatKey'],
+              ),
+              ['children', 'condition', 'events', 'name', 'slot'],
+            ) as NodeModel,
+          ]
+        }
       }
-      case 'slot': {
-        return [
-          key,
-          removeOptionalPropertiesIfEmpty(
-            omitKeys(
-              value,
-              // Always remove repeat and repeatKey from slots as they're not supported
-              ['repeat', 'repeatKey'],
-            ),
-            ['children', 'condition', 'events', 'name', 'slot'],
-          ) as NodeModel,
-        ]
-      }
-    }
-  })
+    },
+  )
 }
 
 type OptionalKeys<T extends object> = {

--- a/packages/ssr/src/utils/media.ts
+++ b/packages/ssr/src/utils/media.ts
@@ -17,7 +17,7 @@ export const transformRelativePaths =
         ...acc,
         [key]: {
           ...node,
-          ...(node.type === 'element'
+          ...(node?.type === 'element'
             ? {
                 attrs: Object.entries(node.attrs ?? {}).reduce(
                   (acc, [key, formula]) => {

--- a/packages/ssr/src/utils/tags.ts
+++ b/packages/ssr/src/utils/tags.ts
@@ -8,7 +8,7 @@ export const replaceTagInNodes =
   (oldTag: string, newTag: string) => (component: Component) => ({
     ...component,
     nodes: Object.entries(component.nodes ?? {}).reduce((acc, [key, node]) => {
-      if (node.type !== 'element') {
+      if (node?.type !== 'element') {
         return {
           ...acc,
           [key]: node,


### PR DESCRIPTION
If someone (usually the AI) created a node that was `null`, our runtime was unable to process that node. This changes the type of nodes to be partial, and updates code in all packages to check for nullish nodes.

Closes https://github.com/nordcraftengine/nordcraft/issues/1166