### PR TITLE
Omit empty style objects+fix classname consistency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,10 +211,10 @@ jobs:
       - name: Check custom element runtime file size
         run: |
           FILE=./dist/custom-element.main.esm.js
-          MAX_SIZE=128000
+          MAX_SIZE=130000
           ACTUAL_SIZE=$(stat -c%s "$FILE")
           if [ "$ACTUAL_SIZE" -gt "$MAX_SIZE" ]; then
-            echo "Error: $FILE is larger than 128KB ($ACTUAL_SIZE bytes)" >&2
+            echo "Error: $FILE is larger than 130KB ($ACTUAL_SIZE bytes)" >&2
             exit 1
           fi
   test-assets-server:

--- a/packages/core/src/styling/className.test.ts
+++ b/packages/core/src/styling/className.test.ts
@@ -19,7 +19,7 @@ describe('toValidClassName()', () => {
   })
 })
 
-describe.only('getClassName()', () => {
+describe('getClassName()', () => {
   test('it produces the same classname whether a nullish entry is provided or not', () => {
     expect(getClassName([null, undefined, { color: 'red' }])).toBe(
       getClassName([{ color: 'red' }]),

--- a/packages/core/src/styling/className.test.ts
+++ b/packages/core/src/styling/className.test.ts
@@ -1,4 +1,5 @@
-import { toValidClassName } from './className'
+import { describe, expect, test } from 'bun:test'
+import { getClassName, toValidClassName } from './className'
 
 describe('toValidClassName()', () => {
   test('it trims leading and trailing whitespace and replace the remaining whitespace with hyphens', () => {
@@ -15,5 +16,19 @@ describe('toValidClassName()', () => {
 
   test('it ensures the class name does not start with a number or special character', () => {
     expect(toValidClassName('1class')).toBe('_1class')
+  })
+})
+
+describe.only('getClassName()', () => {
+  test('it produces the same classname whether a nullish entry is provided or not', () => {
+    expect(getClassName([null, undefined, { color: 'red' }])).toBe(
+      getClassName([{ color: 'red' }]),
+    )
+  })
+
+  test('it produces the same classname whether an empty object is provided or not', () => {
+    expect(getClassName([{}, { color: 'red' }])).toBe(
+      getClassName([{ color: 'red' }]),
+    )
   })
 })

--- a/packages/core/src/styling/className.ts
+++ b/packages/core/src/styling/className.ts
@@ -1,9 +1,22 @@
+import type { NodeStyleModel } from '../component/component.types'
+import type { Nullable } from '../types'
 import { generateAlphabeticName, hash } from './hash'
+import type { StyleVariant } from './variantSelector'
 
 // Classnames are reused a lot, and JS hashing is expensive, so there is benefit in caching them in a native hashmap.
 const CLASSNAME_LOOKUP = new Map<string, string>()
-export const getClassName = (object: any) => {
-  const stringified = JSON.stringify(object)
+export const getClassName = (
+  object: Array<Nullable<NodeStyleModel> | Nullable<StyleVariant[]>>,
+) => {
+  const stringified = JSON.stringify(
+    object.filter(
+      (item) =>
+        item !== null && // Skip nullish values
+        item !== undefined &&
+        (Array.isArray(item) ? item.length > 0 : true) && // Skip empty arrays/objects
+        (typeof item === 'object' ? Object.keys(item).length > 0 : true),
+    ),
+  )
   if (CLASSNAME_LOOKUP.has(stringified)) {
     return CLASSNAME_LOOKUP.get(stringified)!
   }

--- a/packages/runtime/src/components/createNode.test.ts
+++ b/packages/runtime/src/components/createNode.test.ts
@@ -46,7 +46,7 @@ describe('createNode()', () => {
     })
     expect(nodes.length).toBe(1)
     expect((nodes[0] as Element).outerHTML).toMatchInlineSnapshot(
-      `"<div data-node-id="test-node-id" data-id="test-node" data-component="My Component" class="cYXIdv"><span data-node-id="test-node-id.0" data-id="test-node.0" data-component="My Component" data-node-type="text">Item 1</span><span data-node-id="test-node-id.1" data-id="test-node.1" data-component="My Component" data-node-type="text">Item 2</span></div>"`,
+      `"<div data-node-id="test-node-id" data-id="test-node" data-component="My Component" class="PKfF"><span data-node-id="test-node-id.0" data-id="test-node.0" data-component="My Component" data-node-type="text">Item 1</span><span data-node-id="test-node-id.1" data-id="test-node.1" data-component="My Component" data-node-type="text">Item 2</span></div>"`,
     )
   })
 

--- a/packages/ssr/src/rendering/components.test.ts
+++ b/packages/ssr/src/rendering/components.test.ts
@@ -66,7 +66,7 @@ describe('renderPageBody', () => {
       req: {} as any,
     })
     expect(html).toBe(
-      '<div data-test-attr="test" data-id="0" data-node-id="root" class="cTNpFk"></div>',
+      '<div data-test-attr="test" data-id="0" data-node-id="root" class="cUimVL"></div>',
     )
   })
 
@@ -360,7 +360,7 @@ describe('renderPageBody', () => {
     // Expect the nested child text node inside the package component to also render the formula value,
     // proving that the formula is evaluated correctly even when used inside a package component
     expect(html).toInclude(
-      '<span data-id="0.1" data-node-id="root" class="cYXIdv PageComponent:secondChild"><span data-node-type="text" data-node-id="nestedChild">output-from-test-formula</span></span>',
+      '<span data-id="0.1" data-node-id="root" class="PKfF PageComponent:secondChild"><span data-node-type="text" data-node-id="nestedChild">output-from-test-formula</span></span>',
     )
   })
 
@@ -961,7 +961,7 @@ describe('renderPageBody', () => {
 
     // Expect the ID formula to render with the correct order (0 in this case since it's the first formula rendered)
     expect(html).toBe(
-      `<div data-custom-id="custom_id_0_" data-id="0" data-node-id="root" class="ftaNwg"></div>`,
+      `<div data-custom-id="custom_id_0_" data-id="0" data-node-id="root" class="PKfF"></div>`,
     )
   })
 })

--- a/packages/ssr/src/rendering/testData.test.ts
+++ b/packages/ssr/src/rendering/testData.test.ts
@@ -350,7 +350,6 @@ describe('removeTestData', () => {
                 "trigger": "click",
               },
             },
-            "style": {},
             "tag": "div",
             "type": "element",
           },

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -201,6 +201,7 @@ const processNodes = (
               'repeatKey',
               'slot',
               'style-variables',
+              'style',
               'styleVariables',
             ]) as NodeModel,
           ]


### PR DESCRIPTION
Earlier, we tried to strip empty style objects from the serialized data, but this introduced some styling issues. This happened since the client-side classname generation would generate classnames based on the stripped data, while the stylesheet generation (server side) would use the unstripped/raw data. This meant that classnames could differ between the server and client, which caused styles to not be applied correctly.
This PR ensures that classnames are consistent whether empty style objects/null/undefined are provided or not. It treats empty arrays, empty objects, null, and undefined as the same when generating classnames.

Later, we'll stop generating classnames client-side entirely, but this should fix the first issue that we saw earlier.