### PR TITLE
Omit unused variable name from ComponentVariable

### DIFF
--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -418,6 +418,9 @@ export interface ComponentEvent extends NordcraftMetadata {
 
 export interface ComponentVariable extends NordcraftMetadata {
   initialValue: Formula
+  // @deprecated - variables should be referenced by their key in component.variables
+  // name is only here to better reflect how variables are stored in legacy components
+  name?: never
 }
 
 export interface ComponentAttribute extends NordcraftMetadata {

--- a/packages/ssr/src/rendering/testData.ts
+++ b/packages/ssr/src/rendering/testData.ts
@@ -5,6 +5,7 @@ import type {
   Component,
   ComponentAttribute,
   ComponentFormula,
+  ComponentVariable,
   ComponentWorkflow,
   CustomActionArgument,
   CustomActionModel,
@@ -78,6 +79,18 @@ export const removeTestData = (component: Component): Component =>
                   formula: removeFormulaTestData(value.formula),
                 },
               ],
+            ),
+          }
+        : {}),
+      ...(component.variables
+        ? {
+            variables: mapObject(
+              filterObject<Nullable<ComponentVariable>, ComponentVariable>(
+                component.variables,
+                ([_, variable]) => isDefined(variable),
+              ),
+              // On legacy variables, the name was persisted as part of the variable itself, but it's redundant information and should be removed
+              ([key, variable]) => [key, omitKeys(variable, ['name'])],
             ),
           }
         : {}),


### PR DESCRIPTION
Variables are referenced by key - not by name. In the editor, we have been setting the name to the key, but this is not necessary and is confusing. The name property is now deprecated and should not be used.