### PR TITLE
Fix the way how mutliple animations are parsed

### DIFF
--- a/packages/css-parser/src/parseAnimation.test.ts
+++ b/packages/css-parser/src/parseAnimation.test.ts
@@ -867,4 +867,131 @@ describe('parseAnimation', () => {
       },
     ])
   })
+
+  test('Single properties defined for multiple animations', () => {
+    expect(
+      getParsedAnimation(
+        {
+          'animation-duration': '5s, 3s, 2s',
+          'animation-timing-function': 'ease',
+          'animation-delay': '2s, 100ms',
+          'animation-iteration-count': '15, 1, infinite',
+          'animation-direction': 'reverse',
+          'animation-name': 'animation-1, animation-2, animation-3',
+          'animation-fill-mode': 'backwards',
+          'animation-play-state': 'paused, running',
+        },
+        [],
+      ),
+    ).toEqual([
+      {
+        duration: {
+          type: 'time',
+          value: '5',
+          unit: 's',
+        },
+        timing: {
+          type: 'keyword',
+          value: 'ease',
+        },
+        delay: {
+          type: 'time',
+          value: '2',
+          unit: 's',
+        },
+        direction: {
+          type: 'keyword',
+          value: 'reverse',
+        },
+        iterationCount: {
+          type: 'number',
+          value: '15',
+        },
+        name: {
+          type: 'keyword',
+          value: 'animation-1',
+        },
+        fillMode: {
+          type: 'keyword',
+          value: 'backwards',
+        },
+        playState: {
+          type: 'keyword',
+          value: 'paused',
+        },
+      },
+      {
+        duration: {
+          type: 'time',
+          value: '3',
+          unit: 's',
+        },
+        timing: {
+          type: 'keyword',
+          value: 'ease',
+        },
+        delay: {
+          type: 'time',
+          value: '100',
+          unit: 'ms',
+        },
+        iterationCount: {
+          type: 'number',
+          value: '1',
+        },
+        direction: {
+          type: 'keyword',
+          value: 'reverse',
+        },
+        name: {
+          type: 'keyword',
+          value: 'animation-2',
+        },
+        fillMode: {
+          type: 'keyword',
+          value: 'backwards',
+        },
+        playState: {
+          type: 'keyword',
+          value: 'running',
+        },
+      },
+      {
+        duration: {
+          type: 'time',
+          value: '2',
+          unit: 's',
+        },
+        timing: {
+          type: 'keyword',
+          value: 'ease',
+        },
+        delay: {
+          type: 'time',
+          value: '2',
+          unit: 's',
+        },
+        direction: {
+          type: 'keyword',
+          value: 'reverse',
+        },
+        iterationCount: {
+          type: 'keyword',
+          value: 'infinite',
+        },
+        name: {
+          type: 'keyword',
+          value: 'animation-3',
+        },
+        fillMode: {
+          type: 'keyword',
+          value: 'backwards',
+        },
+        playState: {
+          type: 'keyword',
+          value: 'paused',
+        },
+      },
+    ])
+  })
 })

--- a/packages/css-parser/src/parseAnimation.ts
+++ b/packages/css-parser/src/parseAnimation.ts
@@ -163,7 +163,12 @@ export const getParsedAnimation = (
           styleKeys.indexOf('animation') ||
           (isDefined(invalidValues[index]) && invalidValues[index].length > 0))
       ) {
-        const animationDurationValue = getValue(animationDuration[index])
+        const propertyLength = animationDuration.length
+        const cycle = Math.floor(index / propertyLength)
+
+        const animationDurationValue = getValue(
+          animationDuration[index - cycle * propertyLength],
+        )
         const parsedProperty = parseMultipleValues(animationDurationValue)[0]
 
         if (isDefined(parsedProperty)) {
@@ -195,8 +200,11 @@ export const getParsedAnimation = (
           styleKeys.indexOf('animation') ||
           (isDefined(invalidValues[index]) && invalidValues[index]?.length > 0))
       ) {
+        const propertyLength = animationTimingFunction.length
+        const cycle = Math.floor(index / propertyLength)
+
         const animationTimingFunctionValue = getValue(
-          animationTimingFunction[index],
+          animationTimingFunction[index - cycle * propertyLength],
         )
         const parsedProperty = parseMultipleValues(
           animationTimingFunctionValue,
@@ -231,7 +239,12 @@ export const getParsedAnimation = (
           styleKeys.indexOf('animation') ||
           (isDefined(invalidValues[index]) && invalidValues[index]?.length > 0))
       ) {
-        const animationDelayValue = getValue(animationDelay[index])
+        const propertyLength = animationDelay.length
+        const cycle = Math.floor(index / propertyLength)
+
+        const animationDelayValue = getValue(
+          animationDelay[index - cycle * propertyLength],
+        )
         const parsedProperty = parseMultipleValues(animationDelayValue)[0]
 
         if (isDefined(parsedProperty)) {
@@ -263,8 +276,11 @@ export const getParsedAnimation = (
           styleKeys.indexOf('animation') ||
           (isDefined(invalidValues[index]) && invalidValues[index]?.length > 0))
       ) {
+        const propertyLength = animationIterationCount.length
+        const cycle = Math.floor(index / propertyLength)
+
         const animationIterationCountValue = getValue(
-          animationIterationCount[index],
+          animationIterationCount[index - cycle * propertyLength],
         )
         const parsedProperty = parseMultipleValues(
           animationIterationCountValue,
@@ -299,7 +315,12 @@ export const getParsedAnimation = (
           styleKeys.indexOf('animation') ||
           (isDefined(invalidValues[index]) && invalidValues[index]?.length > 0))
       ) {
-        const animationDirectionValue = getValue(animationDirection[index])
+        const propertyLength = animationDirection.length
+        const cycle = Math.floor(index / propertyLength)
+
+        const animationDirectionValue = getValue(
+          animationDirection[index - cycle * propertyLength],
+        )
 
         const parsedProperty = parseMultipleValues(animationDirectionValue)[0]
 
@@ -332,7 +353,12 @@ export const getParsedAnimation = (
           styleKeys.indexOf('animation') ||
           (isDefined(invalidValues[index]) && invalidValues[index]?.length > 0))
       ) {
-        const animationFillModeValue = getValue(animationFillMode[index])
+        const propertyLength = animationFillMode.length
+        const cycle = Math.floor(index / propertyLength)
+
+        const animationFillModeValue = getValue(
+          animationFillMode[index - cycle * propertyLength],
+        )
 
         const parsedProperty = parseMultipleValues(animationFillModeValue)[0]
 
@@ -365,7 +391,12 @@ export const getParsedAnimation = (
           styleKeys.indexOf('animation') ||
           (isDefined(invalidValues[index]) && invalidValues[index]?.length > 0))
       ) {
-        const animationPlayStateValue = getValue(animationPlayState[index])
+        const propertyLength = animationPlayState.length
+        const cycle = Math.floor(index / propertyLength)
+
+        const animationPlayStateValue = getValue(
+          animationPlayState[index - cycle * propertyLength],
+        )
 
         const parsedProperty = parseMultipleValues(animationPlayStateValue)[0]
 
@@ -421,6 +452,8 @@ export const getParsedAnimation = (
               parsedAnimation[index].name = newProp.name
             }
           }
+        } else {
+          parsedAnimation[index].name = { type: 'keyword', value: 'none' }
         }
       }
     })


### PR DESCRIPTION
When we have multiple animations defined using the single properties we need to get the right value. For example if we have this:
animation-name: fadeInOut, moveLeft300px, bounce;
animation-duration: 2.5s, 5s;
animation-iteration-count: 2, 1;

The duration will be 2.5s for fadeInOut, 5s for moveLeft300px and 2.5s for bounce
The iteration count will be 2 for fadeInOut, 1 for moveLeft300px and 2 for bounce