### PR TITLE
Fix subcomponent detection issue in packages

### DIFF
--- a/packages/core/src/component/ToddleComponent.subComponents.test.ts
+++ b/packages/core/src/component/ToddleComponent.subComponents.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from 'bun:test'
+import { ToddleComponent } from './ToddleComponent'
+import type { Component } from './component.types'
+
+describe('ToddleComponent.uniqueSubComponents', () => {
+  test('it should pass down the package name to sub-components', () => {
+    const packagedComp: Component = {
+      name: 'PackagedComp',
+      nodes: {
+        node1: {
+          type: 'component',
+          name: 'InternalComp',
+        },
+      },
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const internalComp: Component = {
+      name: 'InternalComp',
+      nodes: {},
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const root: Component = {
+      name: 'root',
+      nodes: {
+        node1: {
+          type: 'component',
+          name: 'PackagedComp',
+          package: 'my-package',
+        },
+      },
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const componentsMap: Record<string, Component> = {
+      'my-package/PackagedComp': packagedComp,
+      'my-package/InternalComp': internalComp,
+    }
+
+    const getComponent = (name: string, packageName?: string) => {
+      const key = packageName ? `${packageName}/${name}` : name
+      return componentsMap[key]
+    }
+
+    const demo = new ToddleComponent({
+      component: root,
+      getComponent,
+      packageName: undefined,
+      globalFormulas: { formulas: {}, packages: {} },
+    })
+
+    const subComponents = demo.uniqueSubComponents
+    expect(subComponents).toHaveLength(2)
+    expect(subComponents[0].name).toBe('PackagedComp')
+    expect(subComponents[0].packageName).toBe('my-package')
+    expect(subComponents[1].name).toBe('InternalComp')
+    expect(subComponents[1].packageName).toBe('my-package')
+  })
+
+  test('it should handle nested components and avoid duplicates', () => {
+    const compA: Component = {
+      name: 'CompA',
+      nodes: {
+        node1: {
+          type: 'component',
+          name: 'CompB',
+        },
+      },
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const compB: Component = {
+      name: 'CompB',
+      nodes: {},
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const root: Component = {
+      name: 'root',
+      nodes: {
+        node1: {
+          type: 'component',
+          name: 'CompA',
+        },
+        node2: {
+          type: 'component',
+          name: 'CompB',
+        },
+      },
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const componentsMap: Record<string, Component> = {
+      CompA: compA,
+      CompB: compB,
+    }
+
+    const getComponent = (name: string, packageName?: string) => {
+      const key = packageName ? `${packageName}/${name}` : name
+      return componentsMap[key]
+    }
+
+    const demo = new ToddleComponent({
+      component: root,
+      getComponent,
+      packageName: undefined,
+      globalFormulas: { formulas: {}, packages: {} },
+    })
+
+    const subComponents = demo.uniqueSubComponents
+    expect(subComponents).toHaveLength(2)
+    const names = subComponents.map((c) => c.name).sort()
+    expect(names).toEqual(['CompA', 'CompB'])
+  })
+
+  test('it should allow sub-components to override the package name', () => {
+    const pkgAComp: Component = {
+      name: 'PkgAComp',
+      nodes: {
+        node1: {
+          type: 'component',
+          name: 'PkgBComp',
+          package: 'package-b',
+        },
+      },
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const pkgBComp: Component = {
+      name: 'PkgBComp',
+      nodes: {
+        node1: {
+          type: 'component',
+          name: 'InternalComp',
+        },
+      },
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const internalComp: Component = {
+      name: 'InternalComp',
+      nodes: {},
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const root: Component = {
+      name: 'root',
+      nodes: {
+        node1: {
+          type: 'component',
+          name: 'PkgAComp',
+          package: 'package-a',
+        },
+      },
+      apis: {},
+      attributes: {},
+      variables: {},
+      workflows: {},
+    }
+
+    const componentsMap: Record<string, Component> = {
+      'package-a/PkgAComp': pkgAComp,
+      'package-b/PkgBComp': pkgBComp,
+      'package-b/InternalComp': internalComp,
+    }
+
+    const getComponent = (name: string, packageName?: string) => {
+      const key = packageName ? `${packageName}/${name}` : name
+      return componentsMap[key]
+    }
+
+    const demo = new ToddleComponent({
+      component: root,
+      getComponent,
+      packageName: undefined,
+      globalFormulas: { formulas: {}, packages: {} },
+    })
+
+    const subComponents = demo.uniqueSubComponents
+    expect(subComponents).toHaveLength(3)
+
+    const pA = subComponents.find((c) => c.name === 'PkgAComp')
+    expect(pA?.packageName).toBe('package-a')
+
+    const pB = subComponents.find((c) => c.name === 'PkgBComp')
+    expect(pB?.packageName).toBe('package-b')
+
+    const internal = subComponents.find((c) => c.name === 'InternalComp')
+    expect(internal?.packageName).toBe('package-b')
+  })
+})

--- a/packages/core/src/component/ToddleComponent.ts
+++ b/packages/core/src/component/ToddleComponent.ts
@@ -54,10 +54,8 @@ export class ToddleComponent<Handler> {
       if (components.has(node.name)) {
         return
       }
-      const component = this.getComponent(
-        node.name,
-        node.package ?? packageName,
-      )
+      const componentPackageName = node.package ?? packageName
+      const component = this.getComponent(node.name, componentPackageName)
       if (!component) {
         return
       }
@@ -66,13 +64,17 @@ export class ToddleComponent<Handler> {
         new ToddleComponent({
           component,
           getComponent: this.getComponent,
-          packageName: node.package ?? packageName,
+          packageName: componentPackageName,
           globalFormulas: this.globalFormulas,
         }),
       )
       Object.values(component.nodes ?? {}).forEach((node) => {
         if (isDefined(node)) {
-          visitNode((node as any).package ?? packageName)(node)
+          const nodePackageName =
+            (node.type === 'component' ? node.package : undefined) ??
+            componentPackageName ??
+            packageName
+          visitNode(nodePackageName)(node)
         }
       })
     }


### PR DESCRIPTION
This fixes an issue that would sometimes affect custom code generation for projects with nested components in package components. When a package component was visited, the package name would not be passed down to subcomponents, which would mean that actions/custom fomulas in package components would not be added to the generated custom code.