### PR TITLE
Add 2 issue rules to flag invalid path formulas

### DIFF
--- a/packages/search/src/rules/issues/formulas/formulaRules.index.ts
+++ b/packages/search/src/rules/issues/formulas/formulaRules.index.ts
@@ -3,6 +3,7 @@ import { invalidPathRule } from './invalidPathRule'
 import { legacyFormulaRule } from './legacyFormulaRule'
 import { noReferenceComponentFormulaRule } from './noReferenceComponentFormulaRule'
 import { noReferenceProjectFormulaRule } from './noReferenceProjectFormulaRule'
+import { workflowParameterOutsideWorkflowRule } from './workflowParameterOutsideWorkflowRule'
 
 export default [
   duplicateFormulaArgumentNameRule,
@@ -10,6 +11,7 @@ export default [
   legacyFormulaRule,
   noReferenceComponentFormulaRule,
   noReferenceProjectFormulaRule,
+  workflowParameterOutsideWorkflowRule,
   // unknownComponentFormulaInputRule,
   // unknownProjectFormulaInputRule
 ]

--- a/packages/search/src/rules/issues/formulas/formulaRules.index.ts
+++ b/packages/search/src/rules/issues/formulas/formulaRules.index.ts
@@ -1,11 +1,13 @@
 import { duplicateFormulaArgumentNameRule } from './duplicateFormulaArgumentNameRule'
+import { invalidPathRule } from './invalidPathRule'
 import { legacyFormulaRule } from './legacyFormulaRule'
 import { noReferenceComponentFormulaRule } from './noReferenceComponentFormulaRule'
 import { noReferenceProjectFormulaRule } from './noReferenceProjectFormulaRule'
 
 export default [
-  legacyFormulaRule,
   duplicateFormulaArgumentNameRule,
+  invalidPathRule,
+  legacyFormulaRule,
   noReferenceComponentFormulaRule,
   noReferenceProjectFormulaRule,
   // unknownComponentFormulaInputRule,

--- a/packages/search/src/rules/issues/formulas/invalidPathRule.test.ts
+++ b/packages/search/src/rules/issues/formulas/invalidPathRule.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../../searchProject'
+import { invalidPathRule } from './invalidPathRule'
+
+describe('invalidPathRule', () => {
+  test('should detect path formulas starting with Formulas', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {
+                    'my-class': {
+                      formula: {
+                        type: 'path',
+                        path: ['Formulas', 'someFormula'],
+                      },
+                    },
+                  },
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [invalidPathRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid path formula')
+    expect(problems[0].info.title).toBe('Invalid path reference')
+  })
+
+  test('should detect path formulas starting with Workflows', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {
+                    'my-class': {
+                      formula: {
+                        type: 'path',
+                        path: ['Workflows', 'someWorkflow'],
+                      },
+                    },
+                  },
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [invalidPathRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid path formula')
+  })
+
+  test('should not detect valid path formulas', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {
+                    'my-class': {
+                      formula: {
+                        type: 'path',
+                        path: ['Variables', 'someVar'],
+                      },
+                    },
+                  },
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [invalidPathRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+})

--- a/packages/search/src/rules/issues/formulas/invalidPathRule.ts
+++ b/packages/search/src/rules/issues/formulas/invalidPathRule.ts
@@ -1,19 +1,12 @@
-import type {
-  Formula,
-  PathOperation,
-} from '@nordcraft/core/dist/formula/formula'
 import type { IssueRule } from '../../../types'
-
-function isPathOperation(formula: Formula): formula is PathOperation {
-  return formula.type === 'path'
-}
+import { isPathFormula } from '../../../util/formulas'
 
 export const invalidPathRule: IssueRule = {
   code: 'invalid path formula',
   level: 'error',
   category: 'Unknown Reference',
   visit: (report, { path, value, nodeType }) => {
-    if (nodeType !== 'formula' || !isPathOperation(value)) {
+    if (nodeType !== 'formula' || !isPathFormula(value)) {
       return
     }
 

--- a/packages/search/src/rules/issues/formulas/invalidPathRule.ts
+++ b/packages/search/src/rules/issues/formulas/invalidPathRule.ts
@@ -1,0 +1,44 @@
+import type {
+  Formula,
+  PathOperation,
+} from '@nordcraft/core/dist/formula/formula'
+import type { IssueRule } from '../../../types'
+
+function isPathOperation(formula: Formula): formula is PathOperation {
+  return formula.type === 'path'
+}
+
+export const invalidPathRule: IssueRule = {
+  code: 'invalid path formula',
+  level: 'error',
+  category: 'Unknown Reference',
+  visit: (report, { path, value, nodeType }) => {
+    if (nodeType !== 'formula' || !isPathOperation(value)) {
+      return
+    }
+
+    const firstElement = value.path.at(0)
+    if (typeof firstElement === 'string') {
+      switch (firstElement) {
+        case 'Formulas':
+          report({
+            path,
+            info: {
+              title: `Invalid path reference`,
+              description: `A path formula cannot reference formulas directly. Use an apply formula instead.`,
+            },
+          })
+          break
+        case 'Workflows':
+          report({
+            path,
+            info: {
+              title: `Invalid path reference`,
+              description: `A path formula cannot reference workflows directly. Use a workflow action instead.`,
+            },
+          })
+          break
+      }
+    }
+  },
+}

--- a/packages/search/src/rules/issues/formulas/workflowParameterOutsideWorkflowRule.test.ts
+++ b/packages/search/src/rules/issues/formulas/workflowParameterOutsideWorkflowRule.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../../searchProject'
+import { workflowParameterOutsideWorkflowRule } from './workflowParameterOutsideWorkflowRule'
+
+describe('workflowParameterOutsideWorkflowRule', () => {
+  test('should detect path formulas starting with Parameters outside a workflow', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {
+                    'my-class': {
+                      formula: {
+                        type: 'path',
+                        path: ['Parameters', 'someParam'],
+                      },
+                    },
+                  },
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [workflowParameterOutsideWorkflowRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(1)
+    expect(problems[0].code).toBe('invalid path formula')
+    expect(problems[0].info.title).toBe('Invalid workflow parameter reference')
+  })
+
+  test('should not detect path formulas starting with Parameters inside a workflow', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {},
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+              workflows: {
+                myWorkflow: {
+                  name: 'myWorkflow',
+                  parameters: [],
+                  actions: [
+                    {
+                      type: 'TriggerEvent',
+                      event: 'test',
+                      data: {
+                        type: 'path',
+                        path: ['Parameters', 'someParam'],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        rules: [workflowParameterOutsideWorkflowRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+
+  test('should not detect other path formulas outside a workflow', () => {
+    const problems = Array.from(
+      searchProject({
+        files: {
+          components: {
+            test: {
+              name: 'test',
+              nodes: {
+                root: {
+                  type: 'element',
+                  tag: 'div',
+                  attrs: {},
+                  classes: {
+                    'my-class': {
+                      formula: {
+                        type: 'path',
+                        path: ['Args', 'someArg'],
+                      },
+                    },
+                  },
+                  events: {},
+                  children: [],
+                  style: {},
+                },
+              },
+              formulas: {},
+              apis: {},
+              attributes: {},
+              variables: {},
+            },
+          },
+        },
+        rules: [workflowParameterOutsideWorkflowRule],
+      }),
+    )
+
+    expect(problems).toEqual([])
+  })
+})

--- a/packages/search/src/rules/issues/formulas/workflowParameterOutsideWorkflowRule.ts
+++ b/packages/search/src/rules/issues/formulas/workflowParameterOutsideWorkflowRule.ts
@@ -1,0 +1,23 @@
+import type { IssueRule } from '../../../types'
+import { isPathFormula } from '../../../util/formulas'
+
+export const workflowParameterOutsideWorkflowRule: IssueRule = {
+  code: 'invalid path formula',
+  level: 'error',
+  category: 'Unknown Reference',
+  visit: (report, { path, value, nodeType }) => {
+    if (nodeType !== 'formula' || !isPathFormula(value)) {
+      return
+    }
+
+    if (value.path.at(0) === 'Parameters' && !path.includes('workflows')) {
+      report({
+        path,
+        info: {
+          title: `Invalid workflow parameter reference`,
+          description: `A formula cannot reference workflow parameters (**Parameters**) outside of a workflow.`,
+        },
+      })
+    }
+  },
+}

--- a/packages/search/src/types.ts
+++ b/packages/search/src/types.ts
@@ -76,6 +76,7 @@ export type Code =
   | 'duplicate workflow parameter'
   | 'image without dimension'
   | 'invalid api parser mode'
+  | 'invalid path formula'
   | 'invalid api proxy body setting'
   | 'invalid api proxy cookie setting'
   | 'invalid component structure'

--- a/packages/search/src/util/formulas.ts
+++ b/packages/search/src/util/formulas.ts
@@ -1,0 +1,8 @@
+import type {
+  Formula,
+  PathOperation,
+} from '@nordcraft/core/dist/formula/formula'
+
+export const isPathFormula = (formula: Formula): formula is PathOperation => {
+  return formula.type === 'path'
+}


### PR DESCRIPTION
This PR introduces 2 new rules:
- 1 that detects invalid path formulas to formulas/workflows
- 1 that detects invalid references to workflow parameters in formulas that are not part of a workflow

Closes https://github.com/nordcraftengine/nordcraft/issues/1158