### PR TITLE
Add issue rules for unnecessary name properties

### DIFF
--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -211,7 +211,7 @@ export interface Component {
 }
 
 export interface ComponentFormula extends NordcraftMetadata {
-  name: string
+  name?: string
   arguments?: Nullable<Array<{ name: string; testValue: any }>>
   memoize?: Nullable<boolean>
   exposeInContext?: Nullable<boolean>
@@ -219,7 +219,7 @@ export interface ComponentFormula extends NordcraftMetadata {
 }
 
 export interface ComponentWorkflow extends NordcraftMetadata {
-  name: string
+  name?: string
   parameters: Array<{ name: string; testValue: any }>
   callbacks?: Nullable<Array<{ name: string; testValue: any }>>
   actions: ActionModel[]

--- a/packages/search/src/rules/issues/formulas/formulaRules.index.ts
+++ b/packages/search/src/rules/issues/formulas/formulaRules.index.ts
@@ -1,6 +1,7 @@
 import { duplicateFormulaArgumentNameRule } from './duplicateFormulaArgumentNameRule'
 import { invalidPathRule } from './invalidPathRule'
 import { legacyFormulaRule } from './legacyFormulaRule'
+import { namedComponentFormulaRule } from './namedComponentFormulaRule'
 import { noReferenceComponentFormulaRule } from './noReferenceComponentFormulaRule'
 import { noReferenceProjectFormulaRule } from './noReferenceProjectFormulaRule'
 import { workflowParameterOutsideWorkflowRule } from './workflowParameterOutsideWorkflowRule'
@@ -9,6 +10,7 @@ export default [
   duplicateFormulaArgumentNameRule,
   invalidPathRule,
   legacyFormulaRule,
+  namedComponentFormulaRule,
   noReferenceComponentFormulaRule,
   noReferenceProjectFormulaRule,
   workflowParameterOutsideWorkflowRule,

--- a/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.fix.ts
+++ b/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.fix.ts
@@ -1,0 +1,110 @@
+import { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
+import { get } from '@nordcraft/core/dist/utils/collections'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import type { ComponentFormulaNode, FixFunction } from '../../../types'
+
+export const renameNamedComponentFormulaFix: FixFunction<
+  ComponentFormulaNode,
+  { name: string; formulaKey: string | number }
+> = ({ data, details }) => {
+  if (!details) {
+    return
+  }
+
+  const { path, files } = data
+  const { name: newKey, formulaKey: oldKey } = details
+  const componentName = String(path[1])
+
+  const updatedFiles = structuredClone(files) as ProjectFiles
+  const component = updatedFiles.components[componentName]
+
+  if (!component?.formulas) {
+    return
+  }
+
+  // 1. Update the formula key and remove the name property
+  const formula = component.formulas[oldKey]
+  if (formula) {
+    component.formulas[newKey] = { ...formula }
+    delete component.formulas[newKey].name
+    delete component.formulas[oldKey]
+  }
+
+  const getComponent = (name: string) => updatedFiles.components[name]
+  const globalFormulas = {
+    formulas: updatedFiles.formulas,
+    packages: updatedFiles.packages,
+  }
+
+  // 2. Update all references within the same component
+  const toddleComponent = new ToddleComponent({
+    component,
+    getComponent,
+    packageName: undefined,
+    globalFormulas,
+  })
+
+  for (const {
+    path: formulaPath,
+    formula: f,
+  } of toddleComponent.formulasInComponent()) {
+    if (f.type === 'apply' && f.name === String(oldKey)) {
+      // Disregard own formula reference if it was already updated or at least identify it
+      // formulasInComponent returns the formula objects, so we can mutate them in place in our cloned object
+      // But we need the actual path in the component object to be sure
+      const fullPath = ['components', componentName, ...formulaPath]
+      const currentFormula = get(updatedFiles, fullPath)
+      if (
+        currentFormula?.type === 'apply' &&
+        currentFormula.name === String(oldKey)
+      ) {
+        currentFormula.name = newKey
+      }
+    }
+  }
+
+  // 3. Update context consumer references
+  for (const [otherComponentName, otherComponent] of Object.entries(
+    updatedFiles.components,
+  )) {
+    const context = otherComponent?.contexts?.[componentName]
+    const formulaIndex = context?.formulas.indexOf(String(oldKey))
+    if (!context || formulaIndex === undefined || formulaIndex === -1) {
+      continue
+    }
+
+    // Update context subscriptions
+    context.formulas[formulaIndex] = newKey
+
+    // Update path formulas referencing the context
+    const otherToddleComponent = new ToddleComponent({
+      component: otherComponent,
+      getComponent,
+      packageName: undefined,
+      globalFormulas,
+    })
+
+    for (const {
+      path: formulaPath,
+      formula: f,
+    } of otherToddleComponent.formulasInComponent()) {
+      if (
+        f.type === 'path' &&
+        f.path[0] === 'Contexts' &&
+        f.path[1] === componentName &&
+        f.path[2] === String(oldKey)
+      ) {
+        const fullPath = ['components', otherComponentName, ...formulaPath]
+        const currentFormula = get(updatedFiles, fullPath)
+        if (
+          currentFormula?.type === 'path' &&
+          currentFormula.path[2] === String(oldKey)
+        ) {
+          currentFormula.path[2] = newKey
+        }
+      }
+    }
+  }
+
+  return updatedFiles
+}

--- a/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.test.ts
+++ b/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.test.ts
@@ -1,0 +1,175 @@
+import type {
+  Component,
+  ComponentFormula,
+  ElementNodeModel,
+} from '@nordcraft/core/dist/component/component.types'
+import { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
+import type {
+  ApplyOperation,
+  PathOperation,
+} from '@nordcraft/core/dist/formula/formula'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../../searchProject'
+import type { IssueResult } from '../../../types'
+import { namedComponentFormulaRule } from './namedComponentFormulaRule'
+import { renameNamedComponentFormulaFix } from './namedComponentFormulaRule.fix'
+
+describe('namedComponentFormulaRule', () => {
+  const formula: ComponentFormula = {
+    name: 'newName', // deprecated
+    formula: { type: 'value', value: 123 },
+    arguments: [],
+  }
+
+  const component: Component = {
+    name: 'MyComponent',
+    nodes: {
+      root: {
+        type: 'element',
+        tag: 'div',
+        attrs: {
+          text: {
+            type: 'apply',
+            name: 'oldKey',
+            arguments: [],
+          },
+        },
+      },
+    },
+    formulas: {
+      oldKey: formula,
+    },
+  }
+
+  const files: ProjectFiles = {
+    components: {
+      MyComponent: component,
+      Consumer: {
+        name: 'Consumer',
+        contexts: {
+          MyComponent: {
+            formulas: ['oldKey'],
+            workflows: [],
+          },
+        },
+        nodes: {
+          root: {
+            type: 'element',
+            tag: 'span',
+            attrs: {
+              content: {
+                type: 'path',
+                path: ['Contexts', 'MyComponent', 'oldKey'],
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+
+  test('reports when formula has a name property', () => {
+    const problems = Array.from(
+      searchProject({
+        files,
+        rules: [namedComponentFormulaRule],
+      }),
+    )
+
+    const issues = problems as IssueResult[]
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe('named component formula')
+    expect(issues[0].path).toEqual([
+      'components',
+      'MyComponent',
+      'formulas',
+      'oldKey',
+    ])
+    expect(issues[0].details).toEqual({
+      name: 'newName',
+      formulaKey: 'oldKey',
+    })
+  })
+
+  test('does not report when formula does not have a name property', () => {
+    const filesWithoutName: ProjectFiles = {
+      components: {
+        MyComponent: {
+          name: 'MyComponent',
+          nodes: {},
+          formulas: {
+            formulaName: {
+              formula: { type: 'value', value: 123 },
+              arguments: [],
+            },
+          },
+        },
+      },
+    }
+
+    const problems = Array.from(
+      searchProject({
+        files: filesWithoutName,
+        rules: [namedComponentFormulaRule],
+      }),
+    )
+
+    expect(problems).toHaveLength(0)
+  })
+
+  test('fix updates key and references', () => {
+    const problems = Array.from(
+      searchProject({
+        files,
+        rules: [namedComponentFormulaRule],
+      }),
+    )
+    const issue = problems[0] as IssueResult
+
+    const updatedFiles = renameNamedComponentFormulaFix({
+      data: {
+        nodeType: 'component-formula',
+        path: issue.path,
+        files,
+        value: formula,
+        component: new ToddleComponent<Function>({
+          component,
+          getComponent: (name) => files.components[name],
+          packageName: undefined,
+          globalFormulas: {
+            formulas: {},
+            packages: {},
+          },
+        }),
+        memo: () => ({}) as any,
+      },
+      details: issue.details,
+    })
+
+    expect(updatedFiles).toBeDefined()
+    const myComp = updatedFiles!.components.MyComponent!
+    // Key updated
+    expect(myComp.formulas?.newName).toBeDefined()
+    expect(myComp.formulas?.oldKey).toBeUndefined()
+    // Name removed
+    expect(myComp.formulas?.newName?.name).toBeUndefined()
+
+    // Internal reference updated
+    const node = myComp.nodes?.['root'] as ElementNodeModel
+    const nodePathFormula = node.attrs?.text as ApplyOperation
+    expect(nodePathFormula.name).toBe('newName')
+
+    // Context consumer updated
+    const consumer = updatedFiles!.components.Consumer as Component
+    expect(consumer.contexts?.MyComponent.formulas).toContain('newName')
+    expect(consumer.contexts?.MyComponent.formulas).not.toContain('oldKey')
+    const consumerNode = consumer.nodes?.['root'] as ElementNodeModel
+    const consumerNodePathFormula = consumerNode.attrs?.content as PathOperation
+    expect(consumerNodePathFormula.path).toEqual([
+      'Contexts',
+      'MyComponent',
+      'newName',
+    ])
+  })
+})

--- a/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.ts
+++ b/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.ts
@@ -1,0 +1,40 @@
+import type { ComponentFormulaNode, IssueRule } from '../../../types'
+import { renameNamedComponentFormulaFix } from './namedComponentFormulaRule.fix'
+
+export const namedComponentFormulaRule: IssueRule<
+  { name: string; formulaKey: string | number },
+  ComponentFormulaNode
+> = {
+  code: 'named component formula',
+  level: 'info',
+  category: 'Quality',
+  visit: (report, { nodeType, value, path }) => {
+    const formulaKey = path.at(-1)
+    if (
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      nodeType !== 'component-formula' ||
+      typeof value.name !== 'string' ||
+      typeof formulaKey !== 'string'
+    ) {
+      return
+    }
+
+    report({
+      path,
+      info: {
+        title: 'Formula has name property',
+        description: `The name for the **${value.name}** formula is declared directly on the formula. Consider moving the name to the formula key to reduce complexity in your project and help the AI perform better.`,
+      },
+      details: {
+        name: value.name,
+        formulaKey,
+      },
+      fixes: ['rename-named-component-formula'],
+    })
+  },
+  fixes: {
+    'rename-named-component-formula': renameNamedComponentFormulaFix,
+  },
+}
+
+export type NamedComponentFormulaRuleFix = 'rename-named-component-formula'

--- a/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.ts
+++ b/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.ts
@@ -23,7 +23,7 @@ export const namedComponentFormulaRule: IssueRule<
       path,
       info: {
         title: 'Formula has name property',
-        description: `The name for the **${value.name}** formula is declared directly on the formula. Consider moving the name to the formula key to reduce complexity in your project and help the AI perform better.`,
+        description: `The **${value.name}** formula has a legacy name field. Consider migrating the formula to use standard keys by renaming it or applying the rename fix.`,
       },
       details: {
         name: value.name,

--- a/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.ts
+++ b/packages/search/src/rules/issues/formulas/namedComponentFormulaRule.ts
@@ -7,7 +7,7 @@ export const namedComponentFormulaRule: IssueRule<
 > = {
   code: 'named component formula',
   level: 'info',
-  category: 'Quality',
+  category: 'Deprecation',
   visit: (report, { nodeType, value, path }) => {
     const formulaKey = path.at(-1)
     if (

--- a/packages/search/src/rules/issues/formulas/noReferenceComponentFormulaRule.ts
+++ b/packages/search/src/rules/issues/formulas/noReferenceComponentFormulaRule.ts
@@ -86,7 +86,7 @@ export const noReferenceComponentFormulaRule: IssueRule<{
       },
       details: {
         contextSubscribers,
-        name: value.name,
+        name: value.name ?? String(formulaKey),
       },
       fixes: ['delete-component-formula'],
     })

--- a/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.fix.ts
+++ b/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.fix.ts
@@ -1,0 +1,110 @@
+import { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
+import { get } from '@nordcraft/core/dist/utils/collections'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import type { ComponentWorkflowNode, FixFunction } from '../../../types'
+
+export const renameNamedComponentWorkflowFix: FixFunction<
+  ComponentWorkflowNode,
+  { name: string; workflowKey: string | number }
+> = ({ data, details }) => {
+  if (!details) {
+    return
+  }
+
+  const { path, files } = data
+  const { name: newKey, workflowKey: oldKey } = details
+  const componentName = String(path[1])
+
+  const updatedFiles = structuredClone(files) as ProjectFiles
+  const component = updatedFiles.components[componentName]
+
+  if (!component?.workflows) {
+    return
+  }
+
+  // 1. Update the workflow key and remove the name property
+  const workflow = component.workflows[oldKey]
+  if (workflow) {
+    component.workflows[newKey] = { ...workflow }
+    delete component.workflows[newKey].name
+    delete component.workflows[oldKey]
+  }
+
+  const getComponent = (name: string) => updatedFiles.components[name]
+  const globalFormulas = {
+    formulas: updatedFiles.formulas,
+    packages: updatedFiles.packages,
+  }
+
+  // 2. Update all references within the same component
+  const toddleComponent = new ToddleComponent({
+    component,
+    getComponent,
+    packageName: undefined,
+    globalFormulas,
+  })
+
+  for (const [
+    actionPath,
+    action,
+  ] of toddleComponent.actionModelsInComponent()) {
+    if (
+      action.type === 'TriggerWorkflow' &&
+      action.workflow === String(oldKey)
+    ) {
+      const fullPath = ['components', componentName, ...actionPath]
+      const currentAction = get(updatedFiles, fullPath)
+      if (
+        currentAction?.type === 'TriggerWorkflow' &&
+        currentAction.workflow === String(oldKey)
+      ) {
+        currentAction.workflow = newKey
+      }
+    }
+  }
+
+  // 3. Update context consumer references
+  for (const [otherComponentName, otherComponent] of Object.entries(
+    updatedFiles.components,
+  )) {
+    const context = otherComponent?.contexts?.[componentName]
+    const workflowIndex = context?.workflows.indexOf(String(oldKey))
+    if (!context || workflowIndex === undefined || workflowIndex === -1) {
+      continue
+    }
+
+    // Update context subscriptions
+    context.workflows[workflowIndex] = newKey
+
+    // Update TriggerWorkflow actions referencing this context provider
+    const otherToddleComponent = new ToddleComponent({
+      component: otherComponent,
+      getComponent,
+      packageName: undefined,
+      globalFormulas,
+    })
+
+    for (const [
+      actionPath,
+      action,
+    ] of otherToddleComponent.actionModelsInComponent()) {
+      if (
+        action.type === 'TriggerWorkflow' &&
+        action.contextProvider === componentName &&
+        action.workflow === String(oldKey)
+      ) {
+        const fullPath = ['components', otherComponentName, ...actionPath]
+        const currentAction = get(updatedFiles, fullPath)
+        if (
+          currentAction?.type === 'TriggerWorkflow' &&
+          currentAction.contextProvider === componentName &&
+          currentAction.workflow === String(oldKey)
+        ) {
+          currentAction.workflow = newKey
+        }
+      }
+    }
+  }
+
+  return updatedFiles
+}

--- a/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.test.ts
+++ b/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.test.ts
@@ -1,0 +1,139 @@
+import type {
+  Component,
+  WorkflowActionModel,
+} from '@nordcraft/core/dist/component/component.types'
+import { ToddleComponent } from '@nordcraft/core/dist/component/ToddleComponent'
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../../searchProject'
+import type { IssueResult } from '../../../types'
+import { namedComponentWorkflowRule } from './namedComponentWorkflowRule'
+import { renameNamedComponentWorkflowFix } from './namedComponentWorkflowRule.fix'
+
+describe('namedComponentWorkflowRule', () => {
+  const workflow = {
+    name: 'newName',
+    actions: [
+      {
+        type: 'TriggerWorkflow',
+        workflow: 'oldKey',
+      },
+    ],
+    parameters: [],
+    callbacks: [],
+  }
+
+  const component: Component = {
+    name: 'MyComponent',
+    nodes: {},
+    workflows: {
+      oldKey: workflow as any,
+    },
+  }
+
+  const files: ProjectFiles = {
+    components: {
+      MyComponent: component,
+      Consumer: {
+        name: 'Consumer',
+        contexts: {
+          MyComponent: {
+            formulas: [],
+            workflows: ['oldKey'],
+          },
+        },
+        nodes: {
+          root: {
+            type: 'element',
+            tag: 'button',
+            events: {
+              click: {
+                actions: [
+                  {
+                    type: 'TriggerWorkflow',
+                    contextProvider: 'MyComponent',
+                    workflow: 'oldKey',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  }
+
+  test('reports when workflow has a name property', () => {
+    const problems = Array.from(
+      searchProject({
+        files,
+        rules: [namedComponentWorkflowRule],
+      }),
+    )
+
+    const issues = problems as IssueResult[]
+    expect(issues).toHaveLength(1)
+    expect(issues[0].code).toBe('named component workflow')
+    expect(issues[0].path).toEqual([
+      'components',
+      'MyComponent',
+      'workflows',
+      'oldKey',
+    ])
+    expect(issues[0].details).toEqual({
+      name: 'newName',
+      workflowKey: 'oldKey',
+    })
+  })
+
+  test('fix updates keys and references', () => {
+    const problems = Array.from(
+      searchProject({
+        files,
+        rules: [namedComponentWorkflowRule],
+      }),
+    )
+    const issue = problems[0] as IssueResult
+
+    const updatedFiles = renameNamedComponentWorkflowFix({
+      data: {
+        nodeType: 'component-workflow',
+        path: issue.path,
+        files,
+        value: workflow as any,
+        component: new ToddleComponent<Function>({
+          component,
+          getComponent: (name) => files.components[name],
+          packageName: undefined,
+          globalFormulas: {
+            formulas: {},
+            packages: {},
+          },
+        }),
+        memo: () => ({}) as any,
+      },
+      details: issue.details,
+    })
+
+    expect(updatedFiles).toBeDefined()
+    const myComp = updatedFiles!.components.MyComponent!
+    // Key updated
+    expect(myComp.workflows?.newName).toBeDefined()
+    expect(myComp.workflows?.oldKey).toBeUndefined()
+    // Name removed
+    expect(myComp.workflows?.newName?.name).toBeUndefined()
+
+    // Internal reference updated
+    const internalAction = myComp.workflows?.newName
+      ?.actions[0] as WorkflowActionModel
+    expect(internalAction.workflow).toBe('newName')
+
+    // Context consumer updated
+    const consumer = updatedFiles!.components.Consumer as Component
+    expect(consumer.contexts?.MyComponent.workflows).toContain('newName')
+    expect(consumer.contexts?.MyComponent.workflows).not.toContain('oldKey')
+    const consumerAction = consumer.nodes?.root?.events?.click
+      ?.actions?.[0] as WorkflowActionModel
+    expect(consumerAction.workflow).toBe('newName')
+  })
+})

--- a/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.ts
+++ b/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.ts
@@ -7,7 +7,7 @@ export const namedComponentWorkflowRule: IssueRule<
 > = {
   code: 'named component workflow',
   level: 'info',
-  category: 'Quality',
+  category: 'Deprecation',
   visit: (report, { nodeType, value, path }) => {
     const workflowKey = path.at(-1)
     if (

--- a/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.ts
+++ b/packages/search/src/rules/issues/workflows/namedComponentWorkflowRule.ts
@@ -1,0 +1,40 @@
+import type { ComponentWorkflowNode, IssueRule } from '../../../types'
+import { renameNamedComponentWorkflowFix } from './namedComponentWorkflowRule.fix'
+
+export const namedComponentWorkflowRule: IssueRule<
+  { name: string; workflowKey: string | number },
+  ComponentWorkflowNode
+> = {
+  code: 'named component workflow',
+  level: 'info',
+  category: 'Quality',
+  visit: (report, { nodeType, value, path }) => {
+    const workflowKey = path.at(-1)
+    if (
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      nodeType !== 'component-workflow' ||
+      typeof value.name !== 'string' ||
+      typeof workflowKey !== 'string'
+    ) {
+      return
+    }
+
+    report({
+      path,
+      info: {
+        title: 'Workflow has name property',
+        description: `The name for the **${value.name}** workflow is declared directly on the workflow. Consider moving the name to the workflow key to reduce complexity in your project and help the AI perform better.`,
+      },
+      details: {
+        name: value.name,
+        workflowKey,
+      },
+      fixes: ['rename-named-component-workflow'],
+    })
+  },
+  fixes: {
+    'rename-named-component-workflow': renameNamedComponentWorkflowFix,
+  },
+}
+
+export type NamedComponentWorkflowRuleFix = 'rename-named-component-workflow'

--- a/packages/search/src/rules/issues/workflows/noReferenceComponentWorkflowRule.ts
+++ b/packages/search/src/rules/issues/workflows/noReferenceComponentWorkflowRule.ts
@@ -76,14 +76,14 @@ export const noReferenceComponentWorkflowRule: IssueRule<{
         }
       }
     }
-
+    const workflowName = value.name ?? String(workflowKey)
     report({
       path,
       info: {
         title: 'Unused component workflow',
-        description: `**${value.name}** is never used by any workflow. Consider removing it.`,
+        description: `**${workflowName}** is never used by any workflow. Consider removing it.`,
       },
-      details: { contextSubscribers, name: value.name },
+      details: { contextSubscribers, name: workflowName },
     })
   },
 }

--- a/packages/search/src/rules/issues/workflows/noReferenceComponentWorkflowRule.ts
+++ b/packages/search/src/rules/issues/workflows/noReferenceComponentWorkflowRule.ts
@@ -81,7 +81,7 @@ export const noReferenceComponentWorkflowRule: IssueRule<{
       path,
       info: {
         title: 'Unused component workflow',
-        description: `**${workflowName}** is never used by any workflow. Consider removing it.`,
+        description: `The **${workflowName}** workflow has a legacy name field. Consider migrating the workflow to use standard keys by renaming it or applying the rename fix.`,
       },
       details: { contextSubscribers, name: workflowName },
     })

--- a/packages/search/src/rules/issues/workflows/workflowRules.index.ts
+++ b/packages/search/src/rules/issues/workflows/workflowRules.index.ts
@@ -1,4 +1,5 @@
 import { duplicateWorkflowParameterRule } from './duplicateWorkflowParameterRule'
+import { namedComponentWorkflowRule } from './namedComponentWorkflowRule'
 import { noPostNavigateAction } from './noPostNavigateAction'
 import { noReferenceComponentWorkflowRule } from './noReferenceComponentWorkflowRule'
 import { unknownTriggerWorkflowParameterRule } from './unknownTriggerWorkflowParameterRule'
@@ -9,6 +10,7 @@ export default [
   duplicateWorkflowParameterRule,
   noPostNavigateAction,
   noReferenceComponentWorkflowRule,
+  namedComponentWorkflowRule,
   unknownTriggerWorkflowParameterRule,
   unknownTriggerWorkflowRule,
   unknownWorkflowParameterRule,

--- a/packages/search/src/types.ts
+++ b/packages/search/src/types.ts
@@ -51,6 +51,7 @@ import type { NoReferenceContextWorkflowRuleFix } from './rules/issues/context/n
 import type { UnknownContextFormulaRuleFix } from './rules/issues/context/unknownContextFormulaRule'
 import type { NoReferenceEventRuleFix } from './rules/issues/events/noReferenceEventRule'
 import type { LegacyFormulaRuleFix } from './rules/issues/formulas/legacyFormulaRule'
+import type { NamedComponentFormulaRuleFix } from './rules/issues/formulas/namedComponentFormulaRule'
 import type { NoReferenceComponentFormulaRuleFix } from './rules/issues/formulas/noReferenceComponentFormulaRule'
 import type { NoReferenceProjectFormulaRuleFix } from './rules/issues/formulas/noReferenceProjectFormulaRule'
 import type { NoStaticNodeConditionRuleFix } from './rules/issues/logic/noStaticNodeCondition'
@@ -64,6 +65,7 @@ import type {
   AddToThemeFix,
 } from './rules/issues/style/unknownCSSVariable'
 import type { NoReferenceVariableRuleFix } from './rules/issues/variables/noReferenceVariableRule'
+import type { NamedComponentWorkflowRuleFix } from './rules/issues/workflows/namedComponentWorkflowRule'
 import type { NoPostNavigateActionRuleFix } from './rules/issues/workflows/noPostNavigateAction'
 import type { UnknownContextWorkflowRuleFix } from './rules/issues/workflows/unknownContextWorkflowRule'
 
@@ -88,6 +90,8 @@ export type Code =
   | 'legacy formula'
   | 'legacy style variable'
   | 'legacy theme'
+  | 'named component formula'
+  | 'named component workflow'
   | 'no context consumers'
   | 'no post navigate action'
   | 'no-console'
@@ -275,7 +279,7 @@ export type ComponentAPIInputNode = {
 export type ComponentWorkflowNode = {
   nodeType: 'component-workflow'
   value: {
-    name: string
+    name?: string
     parameters?: Nullable<
       {
         name: string
@@ -297,7 +301,7 @@ export type ComponentWorkflowNode = {
 export type ComponentFormulaNode = {
   nodeType: 'component-formula'
   value: {
-    name: string
+    name?: string
     arguments?: Nullable<
       {
         name: string
@@ -494,6 +498,8 @@ export type FixType =
   | NoReferenceApiRuleFix
   | NoReferenceApiServiceRuleFix
   | NoReferenceAttributeRuleFix
+  | NamedComponentFormulaRuleFix
+  | NamedComponentWorkflowRuleFix
   | NoReferenceComponentFormulaRuleFix
   | NoReferenceComponentRuleFix
   | NoReferenceContextFormulaRuleFix


### PR DESCRIPTION
The `name` property for component formulas and workflows are no longer necessary and should be removed throughout Nordcraft projects. This PR adds rules to detect and report these unnecessary properties, as well as fixes to remove them when found.

Getting rid of the `name` property will:
- Improve the AI's ability to work with projects
- Make it easier to read the raw project structure
- Avoid multiple sources of truth
- Make it easier to understand broken references