### PR TITLE
Allow custom headers + status code in SSR response

### DIFF
--- a/packages/backend/src/routes/nordcraftPage.ts
+++ b/packages/backend/src/routes/nordcraftPage.ts
@@ -1,4 +1,5 @@
 import type { PageComponent } from '@nordcraft/core/dist/component/component.types'
+import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import {
   theme as defaultTheme,
   THEME_DATA_ATTRIBUTE,
@@ -20,6 +21,7 @@ import {
   getHtmlLanguage,
   getTheme,
 } from '@nordcraft/ssr/dist/rendering/html'
+import { evaluateResponseHeaders } from '@nordcraft/ssr/dist/rendering/response'
 import type { ToddleProject } from '@nordcraft/ssr/dist/ssr.types'
 import {
   REDIRECT_API_NAME_HEADER,
@@ -187,6 +189,20 @@ export const nordcraftPage = async ({
 
   head = `${head}\n${additionalHeadScripts.join('\n')}`
 
+  const responseHeaders = evaluateResponseHeaders({
+    formulaContext,
+    responseHeaders: page.route.response?.headers,
+  })
+
+  const customStatusCode = applyFormula(
+    page.route.response?.status,
+    formulaContext,
+  )
+  const statusCode =
+    typeof customStatusCode === 'number'
+      ? (customStatusCode as any as ContentfulStatusCode)
+      : status
+
   return hono.html(
     html`<!doctype html>
       <html lang="${language}" ${htmlAttributes}>
@@ -197,9 +213,10 @@ export const nordcraftPage = async ({
           <div id="App">${raw(body)}</div>
         </body>
       </html>`,
-    status,
+    statusCode,
     {
       'Content-Type': `text/html; charset=${charset}`,
+      ...responseHeaders,
     },
   )
 }

--- a/packages/core/src/component/component.types.ts
+++ b/packages/core/src/component/component.types.ts
@@ -241,7 +241,17 @@ export interface RouteDeclaration {
   query: Record<string, { name: string; testValue: any }>
 }
 
+export interface ResponseHeaders {
+  [key: string]: Nullable<Formula | string>
+}
+
 export interface PageRoute extends RouteDeclaration {
+  response?: Nullable<{
+    // Allow overriding response headers for a page render. For example to set a custom cache-control header for a page
+    // or specify a Location along with a 3xx status code to redirect the user to another page
+    headers?: Nullable<ResponseHeaders>
+    status?: Nullable<Formula>
+  }>
   // Information for the <head> element
   // only relevant for pages - not for regular
   // components

--- a/packages/ssr/src/rendering/response.test.ts
+++ b/packages/ssr/src/rendering/response.test.ts
@@ -1,0 +1,97 @@
+import type { FormulaContext } from '@nordcraft/core/dist/formula/formula'
+import { describe, expect, test } from 'bun:test'
+import { evaluateResponseHeaders } from './response'
+
+describe('evaluateResponseHeaders', () => {
+  const mockFormulaContext = {
+    data: {
+      Page: {
+        Theme: 'dark',
+      },
+    },
+    reportFormulaEvaluation: () => {},
+  } as unknown as FormulaContext
+
+  test('it returns an empty object if responseHeaders is null', () => {
+    expect(
+      evaluateResponseHeaders({
+        formulaContext: mockFormulaContext,
+        responseHeaders: null,
+      }),
+    ).toEqual({})
+  })
+
+  test('it returns an empty object if responseHeaders is empty', () => {
+    expect(
+      evaluateResponseHeaders({
+        formulaContext: mockFormulaContext,
+        responseHeaders: {},
+      }),
+    ).toEqual({})
+  })
+
+  test('it evaluates static string headers', () => {
+    expect(
+      evaluateResponseHeaders({
+        formulaContext: mockFormulaContext,
+        responseHeaders: {
+          'X-Custom-Header': 'static-value',
+        } as any,
+      }),
+    ).toEqual({
+      'X-Custom-Header': 'static-value',
+    })
+  })
+
+  test('it evaluates formula headers', () => {
+    expect(
+      evaluateResponseHeaders({
+        formulaContext: mockFormulaContext,
+        responseHeaders: {
+          'X-Theme': {
+            type: 'path',
+            path: ['Page', 'Theme'],
+          },
+          'X-Static': 'value',
+        } as any,
+      }),
+    ).toEqual({
+      'X-Theme': 'dark',
+      'X-Static': 'value',
+    })
+  })
+
+  test('it returns an empty object if responseHeaders is undefined', () => {
+    expect(
+      evaluateResponseHeaders({
+        formulaContext: mockFormulaContext,
+        responseHeaders: undefined,
+      }),
+    ).toEqual({})
+  })
+
+  test('it ignores formula headers that do not evaluate to a string', () => {
+    expect(
+      evaluateResponseHeaders({
+        formulaContext: mockFormulaContext,
+        responseHeaders: {
+          'X-Not-A-String': {
+            type: 'value',
+            value: 123,
+          },
+        } as any,
+      }),
+    ).toEqual({})
+  })
+
+  test('it ignores non-string and non-formula values', () => {
+    expect(
+      evaluateResponseHeaders({
+        formulaContext: mockFormulaContext,
+        responseHeaders: {
+          'X-Invalid': 123 as any,
+        },
+      }),
+    ).toEqual({})
+  })
+})

--- a/packages/ssr/src/rendering/response.ts
+++ b/packages/ssr/src/rendering/response.ts
@@ -1,0 +1,30 @@
+import type { ResponseHeaders } from '@nordcraft/core/dist/component/component.types'
+import {
+  applyFormula,
+  isFormula,
+  type FormulaContext,
+} from '@nordcraft/core/dist/formula/formula'
+import type { Nullable } from '@nordcraft/core/dist/types'
+
+export const evaluateResponseHeaders = ({
+  formulaContext,
+  responseHeaders,
+}: {
+  formulaContext: FormulaContext
+  responseHeaders: Nullable<Partial<ResponseHeaders>>
+}) => {
+  if (!responseHeaders) {
+    return {}
+  }
+  const evaluatedHeaders: Record<string, string> = {}
+  for (const [headerName, headerValue] of Object.entries(responseHeaders)) {
+    if (typeof headerValue !== 'string' && !isFormula(headerValue)) {
+      continue
+    }
+    const formulaValue = applyFormula(headerValue, formulaContext)
+    if (typeof formulaValue === 'string') {
+      evaluatedHeaders[headerName] = formulaValue
+    }
+  }
+  return evaluatedHeaders
+}


### PR DESCRIPTION
Expand the `PageRoute` type to include information about response headers and status code. This allows users to customize the SSR response for specific routes, enabling better control over caching, security headers, and response status codes. This also allows page level redirects instead of API specific redirect rules that we support today.

**NOTE** this is an experimental feature and is not fully supported in the editor and hosted environment