### PR TITLE
request resize canvas when data changes

### DIFF
--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1619,6 +1619,11 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       // Clear old root signal and create a new one to not keep old signals with previous root around
       ctxDataSignal?.destroy()
       ctxDataSignal = dataSignal.map((data) => data)
+      ctxDataSignal
+        .map((data) => data.Variables)
+        .subscribe(() => {
+          requestResizeCanvas(resizeCanvasOptions)
+        })
       try {
         const rootElem = createNode({
           id: 'root',

--- a/packages/runtime/src/editor/drag-drop/dragEnded.ts
+++ b/packages/runtime/src/editor/drag-drop/dragEnded.ts
@@ -29,6 +29,20 @@ export async function dragEnded(dragState: DragState, canceled: boolean) {
   dragState.repeatedNodes.filter(isElementInViewport).forEach((node, i) => {
     node.style.setProperty('view-transition-name', 'dropped-item-repeated-' + i)
   })
+
+  const style = document.createElement('style')
+  style.appendChild(
+    document.createTextNode(`
+      ::view-transition-group(*),
+      ::view-transition-old(*),
+      ::view-transition-new(*) {
+        animation-timing-function: linear(0 0%, 0.005 0.9404%, 0.0202 2.0376%, 0.0775 4.3887%, 0.5344 17.0846%, 0.6528 21.1599%, 0.7502 25.3918%, 0.8332 30.2508%, 0.8943 35.4232%, 0.9185 38.2445%, 0.9385 41.2226%, 0.9554 44.5141%, 0.9689 48.1191%, 0.9825 53.605%, 0.9876 56.7398%, 0.9913 59.8746%, 0.9944 63.6364%, 0.9966 67.7116%, 0.9992 78.6834%, 1 100% /*{"type":"spring","stiffness":50,"damping":30,"mass":5}*/) !important;
+        animation-duration: 0.4s !important;
+      }
+    `),
+  )
+  document.head.appendChild(style)
+
   await tryStartViewTransition(() => {
     if (canceled) {
       dragState.copy?.remove()
@@ -57,12 +71,13 @@ export async function dragEnded(dragState: DragState, canceled: boolean) {
       node.style.removeProperty('--drag-repeat-node-opacity')
     })
     removeDropHighlight()
-  }).finished.then(() => {
-    dragState.element.style.removeProperty('view-transition-name')
-    siblings.forEach((node) => {
-      if (node instanceof HTMLElement) {
-        node.style.removeProperty('view-transition-name')
-      }
-    })
+  }).finished
+
+  style.remove()
+  dragState.element.style.removeProperty('view-transition-name')
+  siblings.forEach((node) => {
+    if (node instanceof HTMLElement) {
+      node.style.removeProperty('view-transition-name')
+    }
   })
 }

--- a/packages/runtime/src/editor/drag-drop/dragHandlers.ts
+++ b/packages/runtime/src/editor/drag-drop/dragHandlers.ts
@@ -58,7 +58,7 @@ export const handleDragMouseMove = (
     dragState.offset.y -= (y - (rect.top + rect.height / 2)) * 0.1
   }
   if (draggingInsideContainer && !metaKey) {
-    dragReorder(dragState)
+    void dragReorder(dragState)
   } else {
     dragMove(
       dragState,

--- a/packages/runtime/src/editor/drag-drop/dragReorder.ts
+++ b/packages/runtime/src/editor/drag-drop/dragReorder.ts
@@ -8,7 +8,7 @@ import { setDropHighlight } from './dropHighlight'
 export const DRAG_REORDER_CLASSNAME = '__drag-mode--reorder'
 const OVERLAP_OFFSET_PX = 100
 
-export function dragReorder(dragState: DragState | null) {
+export async function dragReorder(dragState: DragState | null) {
   if (!dragState || dragState.isTransitioning) {
     return
   }
@@ -64,7 +64,21 @@ export function dragReorder(dragState: DragState | null) {
 
     const prevLeft = dragState.element.offsetLeft
     const prevTop = dragState.element.offsetTop
-    const transition = tryStartViewTransition(() => {
+
+    const style = document.createElement('style')
+    style.appendChild(
+      document.createTextNode(`
+      ::view-transition-group(*),
+      ::view-transition-old(*),
+      ::view-transition-new(*) {
+        animation-timing-function: linear(0 0%, 0.0054 1.2376%, 0.0185 2.4752%, 0.0736 5.4455%, 0.5418 22.0297%, 0.6654 27.4752%, 0.7624 32.9208%, 0.8437 39.1089%, 0.9056 46.0396%, 0.929 49.7525%, 0.9492 53.9604%, 0.965 58.4158%, 0.9773 63.3663%, 0.9875 69.802%, 0.9945 77.7228%, 0.9982 87.1287%, 0.9999 100% /*{"type":"spring","stiffness":75,"damping":36,"mass":5}*/) !important;
+        animation-duration: 0.2s !important;
+      }
+    `),
+    )
+    document.head.appendChild(style)
+
+    await tryStartViewTransition(() => {
       if (!dragState) {
         return
       }
@@ -85,20 +99,17 @@ export function dragReorder(dragState: DragState | null) {
         dragState.initialContainer,
         dragState.elementType === 'component' ? 'D946EF' : '2563EB',
       )
-    })
+    }).finished
 
-    transition.finished
-      .then(() => {
-        siblings.forEach((sibling) => {
-          if (sibling instanceof HTMLElement) {
-            sibling.style.removeProperty('view-transition-name')
-          }
-        })
-        if (dragState) {
-          dragState.isTransitioning = false
-        }
-      })
-      .catch(() => {})
+    style.remove()
+    siblings.forEach((sibling) => {
+      if (sibling instanceof HTMLElement) {
+        sibling.style.removeProperty('view-transition-name')
+      }
+    })
+    if (dragState) {
+      dragState.isTransitioning = false
+    }
   }
 }
 


### PR DESCRIPTION
There was an issue where the canvas would not always take the full size if the data changed during test-mode.

Also change the view transition during drag and drop to use a fixed one for all browsers and make it spring based rather than cubic-bezier.