### PR TITLE
Revert no reference workflow rule description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/search/src/rules/issues/workflows/noReferenceComponentWorkflowRule.ts
+++ b/packages/search/src/rules/issues/workflows/noReferenceComponentWorkflowRule.ts
@@ -81,7 +81,7 @@ export const noReferenceComponentWorkflowRule: IssueRule<{
       path,
       info: {
         title: 'Unused component workflow',
-        description: `The **${workflowName}** workflow has a legacy name field. Consider migrating the workflow to use standard keys by renaming it or applying the rename fix.`,
+        description: `**${value.name}** is never used by any workflow. Consider removing it.`,
       },
       details: { contextSubscribers, name: workflowName },
     })


### PR DESCRIPTION
The description for the `noReferenceComponentWorkflowRule` was accidentally modified in [this PR](https://github.com/nordcraftengine/nordcraft/pull/1199/changes). This reverts that change.