### PR TITLE
Use class selector for dynamic style variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/core/src/styling/className.test.ts
+++ b/packages/core/src/styling/className.test.ts
@@ -21,14 +21,14 @@ describe('toValidClassName()', () => {
 
 describe('getClassName()', () => {
   test('it produces the same classname whether a nullish entry is provided or not', () => {
-    expect(getClassName([null, undefined, { color: 'red' }])).toBe(
-      getClassName([{ color: 'red' }]),
+    expect(getClassName([null, undefined, { color: 'red' }] as any)).toBe(
+      getClassName([{ color: 'red' }] as any),
     )
   })
 
   test('it produces the same classname whether an empty object is provided or not', () => {
-    expect(getClassName([{}, { color: 'red' }])).toBe(
-      getClassName([{ color: 'red' }]),
+    expect(getClassName([{}, { color: 'red' }] as any)).toBe(
+      getClassName([{ color: 'red' }] as any),
     )
   })
 })

--- a/packages/core/src/styling/className.ts
+++ b/packages/core/src/styling/className.ts
@@ -31,6 +31,9 @@ export const getClassName = (
   return className
 }
 
+export const getPathClassName = (path: string) =>
+  generateAlphabeticName(hash(path))
+
 const getStaticCustomPropertyStyles = (
   customProperties: Record<`--${string}`, CustomProperty> | undefined,
 ) =>
@@ -62,10 +65,9 @@ export const getStaticStyleAndVariants = (
     (node.style?.variants as unknown as StyleVariant[] | undefined)
 
   const staticStyle = mergeStaticStyle(node.style, node.customProperties ?? {})
-
-  const mappedVariants = variants?.map(({ customProperties, ...rest }) => ({
-    ...rest,
-    style: mergeStaticStyle(rest.style, customProperties ?? {}),
+  const mappedVariants = variants?.map((variant) => ({
+    ...variant,
+    style: mergeStaticStyle(variant.style, variant.customProperties ?? {}),
   }))
 
   return [

--- a/packages/core/src/styling/style.css.ts
+++ b/packages/core/src/styling/style.css.ts
@@ -313,7 +313,7 @@ export const getAllFonts = (components: Component[]) => {
               node.style?.fontFamily,
               node.style?.['font-family'],
               ...(node.variants?.map(
-                (v) => v.style.fontFamily ?? v.style['font-family'],
+                (v) => v.style?.fontFamily ?? v.style?.['font-family'],
               ) ?? []),
             ].filter(isDefined)
           }

--- a/packages/core/src/styling/style.css.ts
+++ b/packages/core/src/styling/style.css.ts
@@ -72,8 +72,8 @@ const SIZE_PROPERTIES = new Set([
   'outline-width',
 ])
 
-export const styleToCss = (style: NodeStyleModel) => {
-  return Object.entries(style)
+export const styleToCss = (style: Nullable<NodeStyleModel>) => {
+  return Object.entries(style ?? {})
     .map(([property, value]) => {
       if (!isDefined(value)) {
         // ignore undefined/null values
@@ -101,10 +101,10 @@ export const getNodeStyles = (
     const style = omitKeys(_style ?? {}, ['variants', 'breakpoints', 'shadows'])
     const renderVariant = (
       selector: string,
-      style: NodeStyleModel,
+      style: Nullable<NodeStyleModel>,
       options?: Nullable<{ startingStyle?: Nullable<boolean> }>,
     ) => {
-      const scrollbarStyles = Object.entries(style).filter(
+      const scrollbarStyles = Object.entries(style ?? {}).filter(
         ([key]) => key === 'scrollbar-width',
       )
       // If selectorCss is empty, we don't need to render the selector

--- a/packages/core/src/styling/variantSelector.ts
+++ b/packages/core/src/styling/variantSelector.ts
@@ -56,7 +56,7 @@ export interface StyleVariant {
   mediaQuery?: Nullable<MediaQuery>
   pseudoElement?: Nullable<string>
   startingStyle?: Nullable<boolean>
-  style: NodeStyleModel
+  style: Nullable<NodeStyleModel>
   visited?: Nullable<boolean>
 }
 

--- a/packages/core/src/utils/getNodeSelector.test.ts
+++ b/packages/core/src/utils/getNodeSelector.test.ts
@@ -1,11 +1,12 @@
 import type { StyleVariant } from '../component/component.types'
+import { getPathClassName } from '../styling/className'
 import { getNodeSelector } from './getNodeSelector'
 
 describe('getNodeSelector', () => {
   test('should return a selector to a specific node when given a path', () => {
     const path = '0.1.2'
     const selector = getNodeSelector(path)
-    expect(selector).toBe('[data-id="0.1.2"]')
+    expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should return a selector to a specific node from a component instance', () => {
@@ -13,7 +14,9 @@ describe('getNodeSelector', () => {
     const componentName = 'test-component'
     const nodeId = 'test-node'
     const selector = getNodeSelector(path, { componentName, nodeId })
-    expect(selector).toBe('[data-id="0.1.2"].test-component\\:test-node')
+    expect(selector).toBe(
+      `.${getPathClassName(path)}.test-component\\:test-node`,
+    )
   })
 
   test('should return a selector to a specific node variant when given a path and variant', () => {
@@ -24,7 +27,7 @@ describe('getNodeSelector', () => {
       breakpoint: 'medium',
     }
     const selector = getNodeSelector(path, { variant })
-    expect(selector).toBe('[data-id="0.1.2"]:hover')
+    expect(selector).toBe(`.${getPathClassName(path)}:hover`)
   })
 
   test('should return a selector to a specific node variant from a component instance', () => {
@@ -39,20 +42,20 @@ describe('getNodeSelector', () => {
     }
     const selector = getNodeSelector(path, { componentName, nodeId, variant })
     expect(selector).toBe(
-      '[data-id="0.1.2"].test-component\\:test-node.test-class:active',
+      `.${getPathClassName(path)}.test-component\\:test-node.test-class:active`,
     )
   })
 
   test('should escape unescaped slashes in the path', () => {
     const path = '0.1/2'
     const selector = getNodeSelector(path)
-    expect(selector).toBe('[data-id="0.1\\/2"]')
+    expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should not escape already escaped slashes in the path', () => {
     const path = '0.1\\/2'
     const selector = getNodeSelector(path)
-    expect(selector).toBe('[data-id="0.1\\/2"]')
+    expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should prefix selector with an underscore if it starts with a number', () => {
@@ -61,6 +64,6 @@ describe('getNodeSelector', () => {
       componentName: '404',
       nodeId: 'test-node',
     })
-    expect(selector).toBe('[data-id="0.1\\/2"]._404\\:test-node')
+    expect(selector).toBe(`.${getPathClassName(path)}._404\\:test-node`)
   })
 })

--- a/packages/core/src/utils/getNodeSelector.ts
+++ b/packages/core/src/utils/getNodeSelector.ts
@@ -1,3 +1,4 @@
+import { getPathClassName } from '../styling/className'
 import { variantSelector, type StyleVariant } from '../styling/variantSelector'
 import type { Nullable } from '../types'
 
@@ -17,7 +18,7 @@ export function getNodeSelector(
   path: string,
   { componentName, nodeId, variant }: NodeSelectorOptions = {},
 ): string {
-  let selector = `[data-id="${path}"]`
+  let selector = `.${getPathClassName(path)}`
   if (componentName) {
     // Do not allow classes to start with a number, for example a page named "404" would result in a selector starting with a number which is invalid in CSS.
     selector += startsWithNumber(componentName)

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -74,7 +74,7 @@ export function createElement({
     elem.setAttribute('data-component', ctx.component.name)
   }
   // class names are baked during preprocessing, except for in editor-preview where we generate them on the fly
-  if (ctx.env.runtime === 'preview') {
+  if (node.style || node.variants?.some((v) => v.style)) {
     const classHash = getClassName([node.style, node.variants])
     elem.classList.add(classHash)
   }

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -8,6 +8,7 @@ import type {
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import {
   getClassName,
+  getPathClassName,
   toValidClassName,
 } from '@nordcraft/core/dist/styling/className'
 import { appendUnit } from '@nordcraft/core/dist/styling/customProperty'
@@ -72,15 +73,10 @@ export function createElement({
   if (ctx.isRootComponent === false && id !== 'root') {
     elem.setAttribute('data-component', ctx.component.name)
   }
-  if (node.style || node.variants) {
-    // style and variants are not available except in the editor's runtime
+  // class names are baked during preprocessing, except for in editor-preview where we generate them on the fly
+  if (ctx.env.runtime === 'preview') {
     const classHash = getClassName([node.style, node.variants])
     elem.classList.add(classHash)
-  }
-  if (instance && id === 'root') {
-    Object.entries(instance).forEach(([key, value]) => {
-      elem.classList.add(toValidClassName(`${key}:${value}`))
-    })
   }
   if (node.classes) {
     Object.entries(node.classes)?.forEach(([className, { formula }]) => {
@@ -101,6 +97,12 @@ export function createElement({
       } else {
         elem.classList.add(className)
       }
+    })
+  }
+
+  if (instance && id === 'root') {
+    Object.entries(instance).forEach(([key, value]) => {
+      elem.classList.add(toValidClassName(`${key}:${value}`))
     })
   }
 
@@ -167,9 +169,11 @@ export function createElement({
     signal.subscribe((value) => elem.style.setProperty(`--${name}`, value))
   })
 
+  let hasDynamicCustomProperties = false
   Object.entries(node.customProperties ?? {})
     .filter(([_, { formula }]) => formulaHasValue(formula))
     .forEach(([customPropertyName, { formula, unit }]) => {
+      hasDynamicCustomProperties = true
       const cpPath = [
         'nodes',
         id,
@@ -205,6 +209,7 @@ export function createElement({
     Object.entries(variant.customProperties ?? {})
       .filter(([_, { formula }]) => formulaHasValue(formula))
       .forEach(([customPropertyName, { formula, unit }]) => {
+        hasDynamicCustomProperties = true
         const variantCpPath = [
           'nodes',
           id,
@@ -236,6 +241,10 @@ export function createElement({
         })
       })
   })
+
+  if (path && hasDynamicCustomProperties) {
+    elem.classList.add(getPathClassName(path))
+  }
 
   const eventHandlers: [string, (e: Event) => boolean][] = []
   Object.values(node.events ?? {}).forEach((event) => {

--- a/packages/runtime/src/components/createNode.test.ts
+++ b/packages/runtime/src/components/createNode.test.ts
@@ -117,9 +117,7 @@ describe('createNode()', () => {
     const sheet = customPropertiesStylesheets.get(document)?.getStyleSheet()
     expect(sheet).toBeTruthy()
     expect(sheet?.cssRules.length).toBe(3)
-    expect(sheet?.cssRules[0].cssText).toBe(
-      '[data-id="0.0.0"] { --color: red; }',
-    )
+    expect(sheet?.cssRules[0].cssText).toBe('.pGfTH { --color: red; }')
 
     parentElement.append(...nodes)
 
@@ -186,12 +184,8 @@ describe('createNode()', () => {
     expect(sheet?.cssRules.length).toBe(2)
 
     // The rules should be correct for the remaining elements
-    expect(sheet?.cssRules[0].cssText).toBe(
-      '[data-id="0.0.0"] { --color: red; }',
-    )
-    expect(sheet?.cssRules[1].cssText).toBe(
-      '[data-id="0.0.0(2)"] { --color: red; }',
-    )
+    expect(sheet?.cssRules[0].cssText).toBe('.pGfTH { --color: red; }')
+    expect(sheet?.cssRules[1].cssText).toBe('.YomHY { --color: red; }')
 
     // Add the same item multiple times
     dataSignal.update((data) => {
@@ -678,9 +672,9 @@ describe('createNode()', () => {
     const sheet = customPropertiesStylesheets.get(ctx.root)?.getStyleSheet()
     // Test that the order makes sense
     expect(Array.from(sheet?.cssRules ?? []).map((r) => r.cssText)).toEqual([
-      `[data-id="0"] { --color: ${innermostColor}; }`,
-      `[data-id="0"].first_wrapper\\:root { --color: ${middleColor}; }`,
-      `[data-id="0"].My_Component\\:root { --color: ${outermostColor}; }`,
+      `.bnID { --color: ${innermostColor}; }`,
+      `.bnID.first_wrapper\\:root { --color: ${middleColor}; }`,
+      `.bnID.My_Component\\:root { --color: ${outermostColor}; }`,
     ])
   })
 

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1235,11 +1235,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
                     applyFormula(
                       customProperty.formula,
                       {
-                        data: {
-                          Attributes: dataSignal.get().Attributes,
-                          Variables: dataSignal.get().Variables,
-                          Contexts: ctxDataSignal?.get().Contexts ?? {},
-                        },
+                        data: dataSignal.get(),
                         component: getCurrentComponent(),
                         root: ctx?.root,
                         formulaCache: {},

--- a/packages/runtime/src/editor/style.ts
+++ b/packages/runtime/src/editor/style.ts
@@ -10,6 +10,7 @@ import {
 } from '@nordcraft/core/dist/styling/className'
 import { kebabCase } from '@nordcraft/core/dist/styling/style.css'
 import { variantSelector } from '@nordcraft/core/dist/styling/variantSelector'
+import type { Nullable } from '@nordcraft/core/dist/types'
 import { omitKeys } from '@nordcraft/core/dist/utils/collections'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import { CSS_VAR_SCROLL_HEIGHT, CSS_VAR_VIEWPORT_HEIGHT } from './const'
@@ -200,16 +201,16 @@ ${
 
 const renderVariant = (
   selector: string,
-  style: NodeStyleModel,
+  style: Nullable<NodeStyleModel>,
   options?: {
     startingStyle?: boolean
   },
 ) => {
-  const scrollbarStyles = Object.entries(style).filter(
+  const scrollbarStyles = Object.entries(style ?? {}).filter(
     ([key]) => key === 'scrollbar-width',
   )
 
-  let styles = styleToCss(style)
+  let styles = styleToCss(style ?? {})
   if (options?.startingStyle) {
     styles = `@starting-style {
       ${styles}

--- a/packages/ssr/src/rendering/classes.test.ts
+++ b/packages/ssr/src/rendering/classes.test.ts
@@ -1,0 +1,144 @@
+import type { Component } from '@nordcraft/core/dist/component/component.types'
+import {
+  pathFormula,
+  valueFormula,
+} from '@nordcraft/core/dist/formula/formulaUtils'
+import { describe, expect, test } from 'bun:test'
+import { resolveClasses } from './classes'
+
+describe('resolveClasses', () => {
+  test('should convert static styles to classes and strip style property', () => {
+    const component: Component = {
+      name: 'Test',
+      nodes: {
+        root: {
+          id: 'root',
+          type: 'element',
+          tag: 'div',
+          style: { color: 'red' },
+          children: [],
+        },
+      },
+    }
+
+    const resolved = resolveClasses(component)
+    const node = resolved.nodes?.root as any
+
+    expect(node.style).toBeUndefined()
+    expect(node.classes).toBeDefined()
+    // The hash depends on the implementation of getClassName,
+    // but we expect at least one class with a true formula.
+    const classHashes = Object.keys(node.classes)
+    expect(classHashes.length).toBe(1)
+    expect(node.classes[classHashes[0]!]).toEqual({
+      formula: valueFormula(true),
+    })
+  })
+
+  test('should keep dynamic custom properties in variants and strip static ones', () => {
+    const component: Component = {
+      name: 'Test',
+      nodes: {
+        root: {
+          id: 'root',
+          type: 'element',
+          tag: 'div',
+          variants: [
+            {
+              hover: true,
+              style: { color: 'blue' },
+              customProperties: {
+                '--static': { formula: valueFormula('10px') },
+                '--dynamic': { formula: pathFormula(['variables', 'width']) },
+              },
+            },
+          ],
+          children: [],
+        },
+      },
+    }
+
+    const resolved = resolveClasses(component)
+    const node = resolved.nodes?.root as any
+
+    expect(node.variants).toBeDefined()
+    expect(node.variants.length).toBe(1)
+
+    const variant = node.variants[0]
+    expect(variant.style).toEqual({})
+    expect(variant.customProperties).toEqual({
+      '--dynamic': { formula: pathFormula(['variables', 'width']) },
+    })
+    // Static property should be filtered out
+    expect(variant.customProperties['--static']).toBeUndefined()
+  })
+
+  test('should remove variants if they have no dynamic custom properties after filtering', () => {
+    const component: Component = {
+      name: 'Test',
+      nodes: {
+        root: {
+          id: 'root',
+          type: 'element',
+          tag: 'div',
+          variants: [
+            {
+              hover: true,
+              style: { color: 'blue' },
+              customProperties: {
+                '--static': { formula: valueFormula('10px') },
+              },
+            },
+          ],
+          children: [],
+        },
+      },
+    }
+
+    const resolved = resolveClasses(component)
+    const node = resolved.nodes?.root as any
+
+    expect(node.variants).toBeUndefined()
+  })
+
+  test('should keep dynamic custom properties on the node itself', () => {
+    const component: Component = {
+      name: 'Test',
+      nodes: {
+        root: {
+          id: 'root',
+          type: 'element',
+          tag: 'div',
+          customProperties: {
+            '--node-static': { formula: valueFormula('red') },
+            '--node-dynamic': { formula: pathFormula(['variables', 'bg']) },
+          },
+          children: [],
+        },
+      },
+    }
+
+    const resolved = resolveClasses(component)
+    const node = resolved.nodes?.root as any
+
+    expect(node.customProperties).toEqual({
+      '--node-dynamic': { formula: pathFormula(['variables', 'bg']) },
+    })
+    expect(node.customProperties['--node-static']).toBeUndefined()
+  })
+
+  test('should skip non-element nodes', () => {
+    const component: Component = {
+      name: 'Test',
+      nodes: {
+        root: {
+          type: 'text',
+          value: valueFormula('Hello'),
+        },
+      },
+    }
+
+    const resolved = resolveClasses(component)
+    expect(resolved.nodes?.root).toEqual(component.nodes?.root)
+  })
+})

--- a/packages/ssr/src/rendering/classes.test.ts
+++ b/packages/ssr/src/rendering/classes.test.ts
@@ -65,7 +65,7 @@ describe('resolveClasses', () => {
     expect(node.variants.length).toBe(1)
 
     const variant = node.variants[0]
-    expect(variant.style).toEqual({})
+    expect(variant.style).toEqual(undefined)
     expect(variant.customProperties).toEqual({
       '--dynamic': { formula: pathFormula(['variables', 'width']) },
     })

--- a/packages/ssr/src/rendering/classes.ts
+++ b/packages/ssr/src/rendering/classes.ts
@@ -36,7 +36,7 @@ export const resolveClasses = (component: Component) => ({
         )
         hasVariantCustomProperties ||= Object.keys(customProperties).length > 0
         // For dynamic properties, we need details on the variant to be able to resolve them at runtime.
-        return { ...variant, style: {}, customProperties }
+        return { ...variant, customProperties, style: undefined }
       })
 
       return [

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -19,6 +19,7 @@ import type {
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
 import {
   getClassName,
+  getPathClassName,
   getStaticStyleAndVariants,
   toValidClassName,
 } from '@nordcraft/core/dist/styling/className'
@@ -218,12 +219,14 @@ const renderComponent = async ({
             ),
           )
         }
+        let hasDynamicCustomProperties = false
         Object.entries(node.customProperties ?? {})
           .filter(
             // Only prerender dynamic properties here as static properties are already part of class-styling.
             ([_, customProperty]) => customProperty.formula?.type !== 'value',
           )
           .forEach(([customPropertyName, customProperty]) => {
+            hasDynamicCustomProperties = true
             const value = appendUnit(
               applyFormula(customProperty.formula, formulaContext),
               customProperty.unit,
@@ -242,6 +245,7 @@ const renderComponent = async ({
               ([_, customProperty]) => customProperty.formula?.type !== 'value',
             )
             .forEach(([customPropertyName, customProperty]) => {
+              hasDynamicCustomProperties = true
               // style-variables on variants are always version 2
               const value = appendUnit(
                 applyFormula(customProperty.formula, formulaContext),
@@ -256,6 +260,10 @@ const renderComponent = async ({
               }
             })
         })
+
+        if (hasDynamicCustomProperties) {
+          classList.push(getPathClassName(path))
+        }
 
         let innerHTML = ''
 


### PR DESCRIPTION
This change also makes dynamic CSS variables use class selectors rather than attribute selectors. This brings us one important step closer to getting rid of the `data-node-id` and `data-id` selectors on all elements, making for a much cleaner output.