### PR TITLE
Better custom element preprocessing of classes and style variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nordcraft",
   "type": "module",
   "license": "Apache-2.0",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "homepage": "https://github.com/nordcraftengine/nordcraft",
   "private": "false",
   "workspaces": [

--- a/packages/backend/src/routes/customElement.ts
+++ b/packages/backend/src/routes/customElement.ts
@@ -8,6 +8,7 @@ import { removeTestData } from '@nordcraft/ssr/dist/rendering/testData'
 import { transformRelativePaths } from '@nordcraft/ssr/dist/utils/media'
 import type { ProjectFilesWithCustomCode } from '@nordcraft/ssr/dist/utils/routes'
 import { replaceTagInNodes } from '@nordcraft/ssr/dist/utils/tags'
+import { resolveClasses } from '@nordcraft/ssr/src/rendering/classes'
 import type { Context } from 'hono'
 import type { HonoEnv, HonoProject } from '../../hono'
 import type { PageLoader } from '../loaders/types'
@@ -199,7 +200,8 @@ defineComponents(${JSON.stringify([component.name])}, ${JSON.stringify({
         components: includedComponents
           .map(replaceTagInNodes(safeCustomElementName(component.name), 'div'))
           .map(removeTestData)
-          .map(transformRelativePaths(url.origin)),
+          .map(transformRelativePaths(url.origin))
+          .map(resolveClasses({ clearStyle: false })),
       })}, toddle);
 `
       ctx.header('Cache-Control', 'no-cache')

--- a/packages/backend/src/routes/nordcraftPage.ts
+++ b/packages/backend/src/routes/nordcraftPage.ts
@@ -149,8 +149,8 @@ export const nordcraftPage = async ({
         ...apiCache,
       },
     },
-    component: resolveClasses(page),
-    components: includedComponents.map(resolveClasses),
+    component: resolveClasses()(page),
+    components: includedComponents.map(resolveClasses()),
     isPageLoaded: false,
     cookies: Object.keys(formulaContext.env.request.cookies),
   }

--- a/packages/ssr/src/rendering/classes.test.ts
+++ b/packages/ssr/src/rendering/classes.test.ts
@@ -162,7 +162,7 @@ describe('resolveClasses', () => {
     expect(node.style).toBeUndefined()
   })
 
-  test('should preserve static custom properties if clearStyle is false', () => {
+  test('should move static custom properties to the node style itself', () => {
     const component: Component = {
       name: 'Test',
       nodes: {
@@ -181,8 +181,6 @@ describe('resolveClasses', () => {
     const resolved = resolveClasses({ clearStyle: false })(component)
     const node = resolved.nodes?.root as any
 
-    expect(node.customProperties).toEqual({
-      '--static': { formula: valueFormula('red') },
-    })
+    expect(node.style).toEqual({ '--static': 'red' })
   })
 })

--- a/packages/ssr/src/rendering/classes.test.ts
+++ b/packages/ssr/src/rendering/classes.test.ts
@@ -21,7 +21,7 @@ describe('resolveClasses', () => {
       },
     }
 
-    const resolved = resolveClasses(component)
+    const resolved = resolveClasses()(component)
     const node = resolved.nodes?.root as any
 
     expect(node.style).toBeUndefined()
@@ -58,7 +58,7 @@ describe('resolveClasses', () => {
       },
     }
 
-    const resolved = resolveClasses(component)
+    const resolved = resolveClasses()(component)
     const node = resolved.nodes?.root as any
 
     expect(node.variants).toBeDefined()
@@ -95,7 +95,7 @@ describe('resolveClasses', () => {
       },
     }
 
-    const resolved = resolveClasses(component)
+    const resolved = resolveClasses()(component)
     const node = resolved.nodes?.root as any
 
     expect(node.variants).toBeUndefined()
@@ -118,7 +118,7 @@ describe('resolveClasses', () => {
       },
     }
 
-    const resolved = resolveClasses(component)
+    const resolved = resolveClasses()(component)
     const node = resolved.nodes?.root as any
 
     expect(node.customProperties).toEqual({
@@ -138,7 +138,51 @@ describe('resolveClasses', () => {
       },
     }
 
-    const resolved = resolveClasses(component)
+    const resolved = resolveClasses()(component)
     expect(resolved.nodes?.root).toEqual(component.nodes?.root)
+  })
+
+  test('should handle component nodes', () => {
+    const component: Component = {
+      name: 'Test',
+      nodes: {
+        root: {
+          id: 'root',
+          type: 'component',
+          name: 'MyComponent',
+          style: { color: 'red' },
+          children: [],
+        },
+      },
+    }
+
+    const resolved = resolveClasses()(component)
+    const node = resolved.nodes?.root as any
+
+    expect(node.style).toBeUndefined()
+  })
+
+  test('should preserve static custom properties if clearStyle is false', () => {
+    const component: Component = {
+      name: 'Test',
+      nodes: {
+        root: {
+          id: 'root',
+          type: 'element',
+          tag: 'div',
+          customProperties: {
+            '--static': { formula: valueFormula('red') },
+          },
+          children: [],
+        },
+      },
+    }
+
+    const resolved = resolveClasses({ clearStyle: false })(component)
+    const node = resolved.nodes?.root as any
+
+    expect(node.customProperties).toEqual({
+      '--static': { formula: valueFormula('red') },
+    })
   })
 })

--- a/packages/ssr/src/rendering/classes.ts
+++ b/packages/ssr/src/rendering/classes.ts
@@ -13,51 +13,67 @@ import { mapObject } from '@nordcraft/core/dist/utils/collections'
 
 /**
  * Function to strip styles and variants from a Component's nodes and convert them to static class names
+ *
+ * @param options - Options to control the behavior of the function
+ *  - clearStyle: For pages, the classes are baked in so styles are not needed. For custom-elements and editor-preview, the styles are needed to be able to generate the classes and class hashes.
+ * When clearStyle is false, the style is kept, but static custom properties are moved from custom properties to the style object. Dynamic custom properties are kept in the customProperties object for both cases.
  */
-export const resolveClasses = (component: Component) => ({
-  ...component,
-  nodes: mapObject<Nullable<NodeModel>, Nullable<NodeModel>>(
-    component.nodes ?? {},
-    ([key, node]) => {
-      if (node?.type !== 'element') {
-        return [key, node]
-      }
+export const resolveClasses =
+  (options = { clearStyle: true }) =>
+  (component: Component) => ({
+    ...component,
+    nodes: mapObject<Nullable<NodeModel>, Nullable<NodeModel>>(
+      component.nodes ?? {},
+      ([key, node]) => {
+        if (node?.type !== 'element' && node?.type !== 'component') {
+          return [key, node]
+        }
 
-      const [nodeStyle, nodeVariants] = getStaticStyleAndVariants(node)
-      const classHash =
-        nodeStyle || nodeVariants
-          ? getClassName([nodeStyle, nodeVariants])
-          : undefined
+        const [nodeStyle, nodeVariants] = getStaticStyleAndVariants(node)
+        const classHash =
+          nodeStyle || nodeVariants
+            ? getClassName([nodeStyle, nodeVariants])
+            : undefined
 
-      let hasVariantCustomProperties = false
-      const variants = nodeVariants?.map((variant) => {
-        const customProperties = filterDynamicProperties(
-          variant.customProperties,
-        )
-        hasVariantCustomProperties ||= Object.keys(customProperties).length > 0
-        // For dynamic properties, we need details on the variant to be able to resolve them at runtime.
-        return { ...variant, customProperties, style: undefined }
-      })
+        let hasVariantCustomProperties = false
+        const variants = nodeVariants?.map((variant) => {
+          const customProperties = filterDynamicProperties(
+            variant.customProperties,
+          )
+          hasVariantCustomProperties ||=
+            Object.keys(customProperties ?? {}).length > 0
+          // For dynamic properties, we need details on the variant to be able to resolve them at runtime.
+          return {
+            ...variant,
+            customProperties,
+            style: options.clearStyle ? undefined : variant.style,
+          }
+        })
 
-      return [
-        key,
-        {
-          ...node,
-          classes:
-            classHash !== undefined
-              ? {
-                  ...node.classes,
-                  [classHash]: { formula: valueFormula(true) },
-                }
-              : node.classes,
-          style: undefined,
-          customProperties: filterDynamicProperties(node.customProperties),
-          variants: hasVariantCustomProperties ? variants : undefined,
-        },
-      ]
-    },
-  ),
-})
+        return [
+          key,
+          {
+            ...node,
+            ...(node.type === 'element' && {
+              classes:
+                options.clearStyle && classHash !== undefined
+                  ? {
+                      ...node.classes,
+                      [classHash]: { formula: valueFormula(true) },
+                    }
+                  : node.classes,
+            }),
+            style: options.clearStyle ? undefined : nodeStyle,
+            customProperties: filterDynamicProperties(node.customProperties),
+            variants:
+              hasVariantCustomProperties || !options.clearStyle
+                ? variants
+                : undefined,
+          },
+        ] as [string, NodeModel]
+      },
+    ),
+  })
 
 function filterDynamicProperties(
   customProperties: Nullable<Record<`--${string}`, CustomProperty>>,

--- a/packages/ssr/src/rendering/classes.ts
+++ b/packages/ssr/src/rendering/classes.ts
@@ -70,7 +70,7 @@ export const resolveClasses =
                 ? variants
                 : undefined,
           },
-        ] as [string, NodeModel]
+        ]
       },
     ),
   })
@@ -84,5 +84,6 @@ function filterDynamicProperties(
       dynamicCustomProperties[key as `--${string}`] = customProperty
     }
   }
+
   return dynamicCustomProperties
 }


### PR DESCRIPTION
Fixes an issue where the class hashes for custom elements would not always match the generated classes.

This require some changes to internal, similar to `routes/customElement.ts`.