### PR TITLE
Use an internal path instead of reading on [data-id]

### DIFF
--- a/packages/core/src/styling/className.ts
+++ b/packages/core/src/styling/className.ts
@@ -4,7 +4,8 @@ import type {
   ElementNodeModel,
   NodeStyleModel,
 } from '../component/component.types'
-import type { Nullable } from '../types'
+import type { Nullable, Path } from '../types'
+import { pathToString } from '../utils/path'
 import { appendUnit } from './customProperty'
 import { generateAlphabeticName, hash } from './hash'
 import type { StyleVariant } from './variantSelector'
@@ -31,8 +32,8 @@ export const getClassName = (
   return className
 }
 
-export const getPathClassName = (path: string) =>
-  generateAlphabeticName(hash(path))
+export const getPathClassName = (path: Path) =>
+  generateAlphabeticName(hash(pathToString(path)))
 
 const getStaticCustomPropertyStyles = (
   customProperties: Record<`--${string}`, CustomProperty> | undefined,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -96,6 +96,15 @@ export type CustomFormulaHandler = (
 
 export type FormulaLookup = (name: string) => FormulaHandler | undefined
 
+export type PathElement = {
+  index: number
+  repeatIndex?: number
+  slotName?: string
+  slotComponentIndex?: number
+}
+
+export type Path = PathElement[]
+
 export interface Toddle<LocationSignal, ShowSignal> {
   project: string
   branch: string

--- a/packages/core/src/utils/getNodeSelector.test.ts
+++ b/packages/core/src/utils/getNodeSelector.test.ts
@@ -1,16 +1,17 @@
 import type { StyleVariant } from '../component/component.types'
 import { getPathClassName } from '../styling/className'
 import { getNodeSelector } from './getNodeSelector'
+import { stringToPath } from './path'
 
 describe('getNodeSelector', () => {
   test('should return a selector to a specific node when given a path', () => {
-    const path = '0.1.2'
+    const path = stringToPath('0.1.2')
     const selector = getNodeSelector(path)
     expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should return a selector to a specific node from a component instance', () => {
-    const path = '0.1.2'
+    const path = stringToPath('0.1.2')
     const componentName = 'test-component'
     const nodeId = 'test-node'
     const selector = getNodeSelector(path, { componentName, nodeId })
@@ -20,7 +21,7 @@ describe('getNodeSelector', () => {
   })
 
   test('should return a selector to a specific node variant when given a path and variant', () => {
-    const path = '0.1.2'
+    const path = stringToPath('0.1.2')
     const variant: StyleVariant = {
       hover: true,
       style: {},
@@ -31,7 +32,7 @@ describe('getNodeSelector', () => {
   })
 
   test('should return a selector to a specific node variant from a component instance', () => {
-    const path = '0.1.2'
+    const path = stringToPath('0.1.2')
     const componentName = 'test-component'
     const nodeId = 'test-node'
     const variant: StyleVariant = {
@@ -47,19 +48,19 @@ describe('getNodeSelector', () => {
   })
 
   test('should escape unescaped slashes in the path', () => {
-    const path = '0.1/2'
+    const path = stringToPath('0.1/2')
     const selector = getNodeSelector(path)
     expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should not escape already escaped slashes in the path', () => {
-    const path = '0.1\\/2'
+    const path = stringToPath('0.1\\/2')
     const selector = getNodeSelector(path)
     expect(selector).toBe(`.${getPathClassName(path)}`)
   })
 
   test('should prefix selector with an underscore if it starts with a number', () => {
-    const path = '0.1\\/2'
+    const path = stringToPath('0.1\\/2')
     const selector = getNodeSelector(path, {
       componentName: '404',
       nodeId: 'test-node',

--- a/packages/core/src/utils/getNodeSelector.ts
+++ b/packages/core/src/utils/getNodeSelector.ts
@@ -1,6 +1,6 @@
 import { getPathClassName } from '../styling/className'
 import { variantSelector, type StyleVariant } from '../styling/variantSelector'
-import type { Nullable } from '../types'
+import type { Nullable, Path } from '../types'
 
 type NodeSelectorOptions =
   | {
@@ -15,7 +15,7 @@ type NodeSelectorOptions =
     }
 
 export function getNodeSelector(
-  path: string,
+  path: Path,
   { componentName, nodeId, variant }: NodeSelectorOptions = {},
 ): string {
   let selector = `.${getPathClassName(path)}`

--- a/packages/core/src/utils/path.ts
+++ b/packages/core/src/utils/path.ts
@@ -1,0 +1,44 @@
+import type { Path } from '../types'
+
+export function pathToString(path: Path): string {
+  return path
+    .map((element) => {
+      let segment = element.index.toString()
+      if (element.slotName && element.slotName !== 'default') {
+        segment += `[${element.slotName}]`
+      }
+      if (element.slotComponentIndex && element.slotComponentIndex > 0) {
+        segment += `{${element.slotComponentIndex}}`
+      }
+      if (element.repeatIndex && element.repeatIndex > 0) {
+        segment += `(${element.repeatIndex})`
+      }
+      return segment
+    })
+    .join('.')
+}
+
+export function stringToPath(path: string): Path {
+  if (!path) return []
+
+  return path.split('.').map((segment) => {
+    const indexStr = segment.split(/[[({]/)[0]
+    const index = parseInt(indexStr!)
+
+    const slotMatch = segment.match(/\[(.*?)\]/)
+    const slotName = slotMatch ? slotMatch[1] : 'default'
+
+    const compMatch = segment.match(/\{(.*?)\}/)
+    const slotComponentIndex = compMatch ? parseInt(compMatch[1]!) : 0
+
+    const repeatMatch = segment.match(/\((.*?)\)/)
+    const repeatIndex = repeatMatch ? parseInt(repeatMatch[1]!) : 0
+
+    return {
+      index,
+      slotName,
+      slotComponentIndex,
+      repeatIndex,
+    } as Path[number]
+  })
+}

--- a/packages/runtime/src/components/createComponent.ts
+++ b/packages/runtime/src/components/createComponent.ts
@@ -23,7 +23,12 @@ import { registerComponentToLogState } from '../debug/logState'
 import { handleAction } from '../events/handleAction'
 import type { Signal } from '../signal/signal'
 import { signal } from '../signal/signal'
-import type { ComponentChild, ComponentContext, ContextApi } from '../types'
+import type {
+  ComponentChild,
+  ComponentContext,
+  ContextApi,
+  Path,
+} from '../types'
 import { createFormulaCache } from '../utils/createFormulaCache'
 import { formulaHasValue } from '../utils/formulaHasValue'
 import { getComponent } from '../utils/getComponent'
@@ -31,7 +36,7 @@ import { subscribeCustomProperty } from '../utils/subscribeCustomProperty'
 import { renderComponent } from './renderComponent'
 
 export type RenderComponentNodeProps = {
-  path: string
+  path: Path
   node: ComponentNodeModel
   dataSignal: Signal<ComponentData>
   ctx: ComponentContext
@@ -300,7 +305,10 @@ export function createComponent({
     children[slotName] = children[slotName] ?? []
     children[slotName].push({
       id: childId,
-      path: `${path}.${i}[${slotName}]`,
+      path: [
+        ...path,
+        { index: i, slotName, repeatIndex: 0, slotComponentIndex: 0 },
+      ],
       dataSignal,
       ctx: {
         ...ctx,

--- a/packages/runtime/src/components/createElement.ts
+++ b/packages/runtime/src/components/createElement.ts
@@ -13,7 +13,9 @@ import {
 } from '@nordcraft/core/dist/styling/className'
 import { appendUnit } from '@nordcraft/core/dist/styling/customProperty'
 import { getNodeSelector } from '@nordcraft/core/dist/utils/getNodeSelector'
+import { pathToString } from '@nordcraft/core/dist/utils/path'
 import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
+import { PATH } from '../constants'
 import { handleAction } from '../events/handleAction'
 import type { Signal } from '../signal/signal'
 import type { ComponentContext } from '../types'
@@ -66,11 +68,19 @@ export function createElement({
     reportFormulaEvaluation: ctx.reportFormulaEvaluation,
   }
 
+  // [data-node-id] is required for reset-style targeting. Remove if we can get rid of/change reset-style.
   elem.setAttribute('data-node-id', id)
   if (path) {
-    elem.setAttribute('data-id', path)
+    elem[PATH] = path
+    if (ctx.env.runtime === 'preview') {
+      elem.setAttribute('data-id', pathToString(path))
+    }
   }
-  if (ctx.isRootComponent === false && id !== 'root') {
+  if (
+    ctx.isRootComponent === false &&
+    id !== 'root' &&
+    ctx.env.runtime === 'preview'
+  ) {
     elem.setAttribute('data-component', ctx.component.name)
   }
   // class names are baked during preprocessing, except for in editor-preview where we generate them on the fly
@@ -188,7 +198,8 @@ export function createElement({
         selector:
           ctx.env.runtime === 'custom-element' &&
           ctx.isRootComponent &&
-          path === '0'
+          path.length === 1 &&
+          path[0].index === 0
             ? `${getNodeSelector(path)}, :host`
             : getNodeSelector(path),
         signal: dataSignal.map((data) => {
@@ -312,7 +323,7 @@ export function createElement({
         ...createNode({
           parentElement: elem,
           id: child,
-          path: path + '.' + i,
+          path: [...path, { index: i }],
           dataSignal,
           ctx: { ...ctx, jsonPath: ['nodes', child] },
           namespace,

--- a/packages/runtime/src/components/createNode.test.ts
+++ b/packages/runtime/src/components/createNode.test.ts
@@ -1,5 +1,6 @@
 import type { ComponentData } from '@nordcraft/core/dist/component/component.types'
 import type { ToddleEnv } from '@nordcraft/core/dist/formula/formula'
+import { stringToPath } from '@nordcraft/core/dist/utils/path'
 import { describe, expect, test } from 'bun:test'
 import '../happydom'
 import { signal } from '../signal/signal'
@@ -39,14 +40,14 @@ describe('createNode()', () => {
         Attributes: {},
         Variables: {},
       }),
-      path: 'test-node',
+      path: [{ index: 0 }],
       id: 'test-node-id',
       parentElement,
       instance: {},
     })
     expect(nodes.length).toBe(1)
     expect((nodes[0] as Element).outerHTML).toMatchInlineSnapshot(
-      `"<div data-node-id="test-node-id" data-id="test-node" data-component="My Component"><span data-node-id="test-node-id.0" data-id="test-node.0" data-component="My Component" data-node-type="text">Item 1</span><span data-node-id="test-node-id.1" data-id="test-node.1" data-component="My Component" data-node-type="text">Item 2</span></div>"`,
+      `"<div data-node-id="test-node-id" data-id="0" data-component="My Component"><span data-node-id="test-node-id.0" data-id="test-node.0" data-component="My Component" data-node-type="text">Item 1</span><span data-node-id="test-node-id.1" data-id="test-node.1" data-component="My Component" data-node-type="text">Item 2</span></div>"`,
     )
   })
 
@@ -107,7 +108,7 @@ describe('createNode()', () => {
       ctx,
       namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal,
-      path: '0.0.0',
+      path: stringToPath('0.0.0'),
       id: 'repeat-node-id',
       parentElement,
       instance: {},
@@ -255,7 +256,7 @@ describe('createNode()', () => {
       ctx,
       namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal,
-      path: 'cond',
+      path: stringToPath('cond'),
       id: 'conditional-node',
       parentElement,
       instance: {},
@@ -355,7 +356,7 @@ describe('createNode()', () => {
       ctx,
       namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal,
-      path: 'nested',
+      path: stringToPath('nested'),
       id: 'outer-repeat',
       parentElement,
       instance: {},
@@ -455,7 +456,7 @@ describe('createNode()', () => {
       ctx,
       namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal,
-      path: 'prepend',
+      path: stringToPath('prepend'),
       id: 'repeat',
       parentElement,
       instance: {},
@@ -524,7 +525,7 @@ describe('createNode()', () => {
       namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal,
       id: 'repeat',
-      path: '0',
+      path: stringToPath('0'),
       instance: {},
       parentElement,
     })
@@ -663,7 +664,7 @@ describe('createNode()', () => {
         Attributes: {},
         Variables: {},
       }),
-      path: '0',
+      path: stringToPath('0'),
       id: 'root',
       parentElement,
       instance: {},
@@ -722,7 +723,7 @@ describe('createNode()', () => {
       id: 'repeat',
       instance: {},
       parentElement,
-      path: '0',
+      path: stringToPath('0'),
     })
     parentElement.append(...nodes)
 
@@ -858,7 +859,7 @@ describe('createNode()', () => {
       ctx,
       namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal,
-      path: '0',
+      path: stringToPath('0'),
       id: 'repeat-node',
       parentElement,
       instance: {},

--- a/packages/runtime/src/components/createNode.ts
+++ b/packages/runtime/src/components/createNode.ts
@@ -8,10 +8,11 @@ import type {
   TextNodeModel,
 } from '@nordcraft/core/dist/component/component.types'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
+import { pathToString } from '@nordcraft/core/dist/utils/path'
 import { toBoolean } from '@nordcraft/core/dist/utils/util'
 import type { Signal } from '../signal/signal'
 import { signal } from '../signal/signal'
-import type { ComponentContext } from '../types'
+import type { ComponentContext, Path } from '../types'
 import { getComponent } from '../utils/getComponent'
 import { ensureEfficientOrdering, getNextSiblingElement } from '../utils/nodes'
 import { createComponent } from './createComponent'
@@ -31,7 +32,7 @@ export function createNode({
 }: {
   id: string
   dataSignal: Signal<ComponentData>
-  path: string
+  path: Path
   ctx: ComponentContext
   namespace?: SupportedNamespaces
   parentElement: Element | ShadowRoot
@@ -136,20 +137,6 @@ export function createNode({
           return
         }
 
-        if (!parentElement || ctx.root.contains(parentElement) === false) {
-          console.error(
-            `Conditional: Parent element does not exist for "${path}" This is likely due to the DOM being modified outside of Nordcraft.`,
-          )
-          return
-        }
-
-        if (parentElement.querySelector(`[data-id="${path}"]`)) {
-          console.warn(
-            `Conditional: Element with data-id="${path}" already exists. This is likely due to the DOM being modified outside of Nordcraft`,
-          )
-          return
-        }
-
         const nextPathElement = getNextSiblingElement(path, parentElement)
         for (const element of elements) {
           parentElement.insertBefore(element, nextPathElement)
@@ -169,7 +156,7 @@ export function createNode({
     if (ctx.env.runtime === 'preview' && ctx.toddle._preview) {
       ctx.toddle._preview.showSignal.subscribe(
         ({ displayedNodes, testMode }) => {
-          if (displayedNodes.includes(path) && !testMode) {
+          if (displayedNodes.includes(pathToString(path)) && !testMode) {
             // only override the default show if we are in design mode (not test mode)
             toggle(true)
           } else {
@@ -323,6 +310,16 @@ export function createNode({
 
             const repeatIndex =
               Key === '0' && !defaultElement ? undefined : ++lifetimeSize
+
+            let itemPath = path
+            if (repeatIndex) {
+              itemPath = [...path]
+              itemPath[itemPath.length - 1] = {
+                ...itemPath[itemPath.length - 1],
+                repeatIndex,
+              }
+            }
+
             const args = {
               node: node!,
               id,
@@ -333,7 +330,7 @@ export function createNode({
               // - Update list to [A, C, B]
               // Now C and B would have the same path `(1)` if we only used the index or Key, as B would have kept its reference, but the others would be recreated.
               // With lifetimeSize, the keys would be A(3), B(1), C(4) - all unique.
-              path: repeatIndex ? `${path}(${repeatIndex})` : path,
+              path: itemPath,
               ctx,
               namespace,
               parentElement,
@@ -361,7 +358,9 @@ export function createNode({
 
         if (!parentElement || ctx.root.contains(parentElement) === false) {
           console.error(
-            `Repeat: Parent element does not exist for ${path}. This is likely due to the DOM being modified outside of Nordcraft.`,
+            `Repeat: Parent element does not exist for ${pathToString(
+              path,
+            )}. This is likely due to the DOM being modified outside of Nordcraft.`,
           )
           return
         }
@@ -422,7 +421,7 @@ export type NodeRenderer<NodeType> = {
   node: NodeType
   dataSignal: Signal<ComponentData>
   id: string
-  path: string
+  path: Path
   ctx: ComponentContext
   namespace?: SupportedNamespaces
   parentElement: Element | ShadowRoot

--- a/packages/runtime/src/components/createSlot.ts
+++ b/packages/runtime/src/components/createSlot.ts
@@ -31,16 +31,21 @@ export function createSlot({
         ctx.component.nodes,
       )
 
-      let path = child.path
-      if (slotComponentIndex > 0) {
-        path += `{${slotComponentIndex}}`
-      }
-      if (slotRepeatIndex && slotRepeatIndex > 0) {
-        path += `(${slotRepeatIndex})`
+      const childPath = [...child.path]
+      if (slotComponentIndex > 0 || slotRepeatIndex) {
+        const lastPart = { ...childPath[childPath.length - 1] }
+        if (slotComponentIndex > 0) {
+          lastPart.slotComponentIndex = slotComponentIndex
+        }
+        if (slotRepeatIndex && slotRepeatIndex > 0) {
+          lastPart.repeatIndex = slotRepeatIndex
+        }
+        childPath[childPath.length - 1] = lastPart
       }
 
       return createNode({
         ...child,
+        path: childPath,
         dataSignal: childDataSignal,
         parentElement,
         ctx: {
@@ -50,7 +55,6 @@ export function createSlot({
         },
         instance,
         namespace,
-        path,
       })
     })
   } else {
@@ -58,7 +62,15 @@ export function createSlot({
     children = (node.children ?? []).flatMap((child, i) => {
       return createNode({
         id: child,
-        path: path + '.' + i,
+        path: [
+          ...path,
+          {
+            index: i,
+            repeatIndex: 0,
+            slotName: 'default',
+            slotComponentIndex: 0,
+          },
+        ],
         dataSignal,
         ctx: { ...ctx, jsonPath: ['nodes', child] },
         parentElement,

--- a/packages/runtime/src/components/createText.test.ts
+++ b/packages/runtime/src/components/createText.test.ts
@@ -10,11 +10,12 @@ describe('createText()', () => {
     let textElement = createText({
       ctx: {
         isRootComponent: false,
+        env: { runtime: 'preview' },
         component: { name: 'My Component' },
       } as Partial<ComponentContext> as any,
       namespace: 'http://www.w3.org/1999/xhtml',
       dataSignal: undefined as any,
-      path: 'test-text-element',
+      path: [{ index: 0 }],
       id: 'test-text-element-id',
       node: {
         type: 'text',
@@ -27,7 +28,7 @@ describe('createText()', () => {
     expect(textElement.getAttribute('data-node-id')).toBe(
       'test-text-element-id',
     )
-    expect(textElement.getAttribute('data-id')).toBe('test-text-element')
+    expect(textElement.getAttribute('data-id')).toBe('0')
     expect(textElement.getAttribute('data-component')).toBe('My Component')
     expect(textElement.children.length).toBe(0)
     expect(textElement.innerText).toBe('Hello world')
@@ -36,11 +37,12 @@ describe('createText()', () => {
     const textElement = createText({
       ctx: {
         isRootComponent: false,
+        env: { runtime: 'preview' },
         component: { name: 'My Component' },
       } as Partial<ComponentContext> as any,
       namespace: 'http://www.w3.org/2000/svg',
       dataSignal: undefined as any,
-      path: 'test-text-element',
+      path: [{ index: 0 }],
       id: 'test-text-element-id',
       node: {
         type: 'text',
@@ -54,9 +56,10 @@ describe('createText()', () => {
     const textElement = createText({
       ctx: {
         isRootComponent: true,
+        env: { runtime: 'preview' },
       } as Partial<ComponentContext> as any,
       dataSignal: undefined as any,
-      path: 'test-text-element',
+      path: [{ index: 0 }],
       id: 'test-text-element-id',
       node: {
         type: 'text',
@@ -70,9 +73,12 @@ describe('createText()', () => {
       Attributes: { text: 'Hello world' },
     })
     const textElement = createText({
-      ctx: { dataSignal } as Partial<ComponentContext> as any,
+      ctx: {
+        dataSignal,
+        env: { runtime: 'preview' },
+      } as Partial<ComponentContext> as any,
       dataSignal,
-      path: '',
+      path: [],
       id: '',
       node: {
         type: 'text',
@@ -88,9 +94,9 @@ describe('createText()', () => {
   })
   test('Show formulas are not respected for text elements', () => {
     const textElement = createText({
-      ctx: {} as Partial<ComponentContext> as any,
+      ctx: { env: { runtime: 'preview' } } as Partial<ComponentContext> as any,
       dataSignal: undefined as any,
-      path: '',
+      path: [],
       id: '',
       node: {
         type: 'text',
@@ -102,9 +108,9 @@ describe('createText()', () => {
   })
   test('Repeat formulas are not respected for text elements', () => {
     const textElement = createText({
-      ctx: {} as Partial<ComponentContext> as any,
+      ctx: { env: { runtime: 'preview' } } as Partial<ComponentContext> as any,
       dataSignal: undefined as any,
-      path: '',
+      path: [],
       id: '',
       node: {
         type: 'text',

--- a/packages/runtime/src/components/createText.ts
+++ b/packages/runtime/src/components/createText.ts
@@ -4,14 +4,16 @@ import type {
   TextNodeModel,
 } from '@nordcraft/core/dist/component/component.types'
 import { applyFormula } from '@nordcraft/core/dist/formula/formula'
+import { pathToString } from '@nordcraft/core/dist/utils/path'
+import { PATH } from '../constants'
 import type { Signal } from '../signal/signal'
-import type { ComponentContext } from '../types'
+import type { ComponentContext, Path } from '../types'
 
 export type RenderTextProps = {
   node: TextNodeModel
   dataSignal: Signal<ComponentData>
   id: string
-  path: string
+  path: Path
   namespace?: SupportedNamespaces
   ctx: ComponentContext
 }
@@ -32,18 +34,19 @@ export function createText({
 }: RenderTextProps): HTMLSpanElement | Text {
   // Span element is not valid outside of the default namespace
   if (namespace && namespace !== 'http://www.w3.org/1999/xhtml') {
-    return createTextNS({ node, dataSignal, ctx })
+    return createTextNS({ node, dataSignal, ctx, path })
   }
 
   const { value } = node
   const elem = document.createElement('span')
   elem.setAttribute('data-node-id', id)
-  if (typeof id === 'string') {
-    elem.setAttribute('data-id', path)
+  if (path && typeof id === 'string' && ctx.env.runtime === 'preview') {
+    elem.setAttribute('data-id', pathToString(path))
   }
   if (ctx.isRootComponent === false) {
     elem.setAttribute('data-component', ctx.component.name)
   }
+  // data-node-type is required for reset-style targeting. Remove if we can get rid of/change reset-style.
   elem.setAttribute('data-node-type', 'text')
   if (value.type !== 'value') {
     const sig = dataSignal.map((data) =>
@@ -87,9 +90,13 @@ export function createTextNS({
   node,
   dataSignal,
   ctx,
-}: Pick<RenderTextProps, 'node' | 'dataSignal' | 'ctx'>): Text {
+  path,
+}: Pick<RenderTextProps, 'node' | 'dataSignal' | 'ctx' | 'path'>): Text {
   const { value } = node
   const textNode = document.createTextNode('')
+  if (path) {
+    textNode[PATH] = path
+  }
   if (value.type !== 'value') {
     const sig = dataSignal.map((data) =>
       String(

--- a/packages/runtime/src/components/renderComponent.ts
+++ b/packages/runtime/src/components/renderComponent.ts
@@ -16,6 +16,7 @@ import type {
   ContextApi,
   FormulaCache,
   LocationSignal,
+  Path,
   PreviewShowSignal,
 } from '../types'
 import { BatchQueue } from '../utils/BatchQueue'
@@ -30,7 +31,7 @@ interface RenderComponentProps {
   onEvent: (event: string, data: unknown) => void
   isRootComponent: boolean
   formulaCache: FormulaCache
-  path: string
+  path: Path
   children: Record<string, Array<ComponentChild>>
   root: Document | ShadowRoot
   providers: Record<

--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -1,0 +1,1 @@
+export const PATH = Symbol.for('nc-path')

--- a/packages/runtime/src/custom-element/ToddleComponent.ts
+++ b/packages/runtime/src/custom-element/ToddleComponent.ts
@@ -206,7 +206,7 @@ export class ToddleComponent extends HTMLElement {
   render() {
     const elements = renderComponent({
       ...this.#ctx,
-      path: '0',
+      path: [{ index: 0 }],
       onEvent: this.dispatch.bind(this),
       parentElement: this.#shadowRoot,
       instance: { [this.#component.name]: 'root' },

--- a/packages/runtime/src/editor-preview.main.ts
+++ b/packages/runtime/src/editor-preview.main.ts
@@ -1629,7 +1629,7 @@ body[data-mode="design"] [data-id="${animationState.animatedElementId}"], body[d
       try {
         const rootElem = createNode({
           id: 'root',
-          path: '0',
+          path: [{ index: 0 }], // editor expects the root to be at index 0
           dataSignal: ctxDataSignal,
           ctx: { ...newCtx, jsonPath: ['nodes', 'root'] },
           parentElement: domNode,

--- a/packages/runtime/src/page.main.ts
+++ b/packages/runtime/src/page.main.ts
@@ -319,7 +319,7 @@ export const createRoot = (domNode: HTMLElement) => {
   const elements = renderComponent({
     ...ctx,
     providers,
-    path: '0',
+    path: [],
     package: undefined,
     onEvent: ctx.triggerEvent,
     parentElement: domNode,

--- a/packages/runtime/src/types.d.ts
+++ b/packages/runtime/src/types.d.ts
@@ -16,6 +16,7 @@ import type {
   ToddleInternals,
 } from '@nordcraft/core/dist/types'
 import type { ApiRequest } from './api/createAPI'
+import type { PATH } from './constants'
 import type { Signal } from './signal/signal'
 
 declare global {
@@ -24,7 +25,13 @@ declare global {
     __toddle: ToddleInternals
     toddle: NewToddle<LocationSignal, PreviewShowSignal>
   }
+
+  interface Node {
+    [PATH]?: Path
+  }
 }
+
+export type { Path, PathElement } from '@nordcraft/core/src/types'
 
 export type LocationSignal = Signal<Location>
 
@@ -51,7 +58,7 @@ interface ListItem {
 export interface ComponentChild {
   dataSignal: Signal<ComponentData>
   id: string
-  path: string
+  path: Path
   ctx: ComponentContext
 }
 

--- a/packages/runtime/src/utils/nodes.test.ts
+++ b/packages/runtime/src/utils/nodes.test.ts
@@ -1,4 +1,6 @@
+import { stringToPath } from '@nordcraft/core/dist/utils/path'
 import { describe, expect, it } from 'bun:test'
+import { PATH } from '../constants'
 import '../happydom'
 import {
   ensureEfficientOrdering,
@@ -9,57 +11,78 @@ import {
 describe('getNextSiblingElement', () => {
   it('should return null if there are no children', () => {
     const parent = document.createElement('div')
-    expect(getNextSiblingElement('0.1', parent)).toBeNull()
+    expect(getNextSiblingElement(stringToPath('0.1'), parent)).toBeNull()
   })
 
   it('should return the next sibling based on index', () => {
     const parent = document.createElement('div')
     const child1 = document.createElement('div')
     child1.setAttribute('data-id', '0.1')
+    child1[PATH] = stringToPath('0.1')
     const child2 = document.createElement('div')
     child2.setAttribute('data-id', '0.2')
+    child2[PATH] = stringToPath('0.2')
     parent.appendChild(child1)
     parent.appendChild(child2)
 
-    expect(getNextSiblingElement('0.0', parent)).toBe(child1)
-    expect(getNextSiblingElement('0.1', parent)).toBe(child2)
-    expect(getNextSiblingElement('0.2', parent)).toBeNull()
+    expect(getNextSiblingElement(stringToPath('0.0'), parent)).toBe(child1)
+    expect(getNextSiblingElement(stringToPath('0.1'), parent)).toBe(child2)
+    expect(getNextSiblingElement(stringToPath('0.2'), parent)).toBeNull()
   })
 
   it('should return the next sibling based on repeat index', () => {
     const parent = document.createElement('div')
     const child1 = document.createElement('div')
     child1.setAttribute('data-id', '0.1(0)')
+    child1[PATH] = stringToPath('0.1(0)')
     const child2 = document.createElement('div')
     child2.setAttribute('data-id', '0.1(1)')
+    child2[PATH] = stringToPath('0.1(1)')
     parent.appendChild(child1)
     parent.appendChild(child2)
 
-    expect(getNextSiblingElement('0.1(0)', parent)).toBe(child2)
-    expect(getNextSiblingElement('0.1(1)', parent)).toBeNull()
+    expect(getNextSiblingElement(stringToPath('0.1(0)'), parent)).toBe(child2)
+    expect(getNextSiblingElement(stringToPath('0.1(1)'), parent)).toBeNull()
+  })
+
+  it('should return text node as sibling', () => {
+    const parent = document.createElement('div')
+    const child1 = document.createTextNode('text')
+    child1[PATH] = stringToPath('0.1')
+    const child2 = document.createElement('div')
+    child2.setAttribute('data-id', '0.2')
+    child2[PATH] = stringToPath('0.2')
+    parent.appendChild(child1)
+    parent.appendChild(child2)
+
+    expect(getNextSiblingElement(stringToPath('0.0'), parent)).toBe(child1)
+    expect(getNextSiblingElement(stringToPath('0.1'), parent)).toBe(child2)
   })
 
   it('should skip children with lower indices', () => {
     const parent = document.createElement('div')
     const child1 = document.createElement('div')
     child1.setAttribute('data-id', '0.1')
+    child1[PATH] = stringToPath('0.1')
     const child2 = document.createElement('div')
     child2.setAttribute('data-id', '0.3')
+    child2[PATH] = stringToPath('0.3')
     parent.appendChild(child1)
     parent.appendChild(child2)
 
-    expect(getNextSiblingElement('0.2', parent)).toBe(child2)
+    expect(getNextSiblingElement(stringToPath('0.2'), parent)).toBe(child2)
   })
 
   it('should work with complex paths', () => {
     const parent = document.createElement('div')
     const child = document.createElement('div')
     child.setAttribute('data-id', '1.2.3(5)')
+    child[PATH] = stringToPath('1.2.3(5)')
     parent.appendChild(child)
 
-    expect(getNextSiblingElement('1.2.3(4)', parent)).toBe(child)
-    expect(getNextSiblingElement('1.2.3(5)', parent)).toBeNull()
-    expect(getNextSiblingElement('1.2.2', parent)).toBe(child)
+    expect(getNextSiblingElement(stringToPath('1.2.3(4)'), parent)).toBe(child)
+    expect(getNextSiblingElement(stringToPath('1.2.3(5)'), parent)).toBeNull()
+    expect(getNextSiblingElement(stringToPath('1.2.2'), parent)).toBe(child)
   })
 })
 
@@ -70,8 +93,10 @@ describe('ensureEfficientOrdering and getNextSiblingElement together', () => {
     // Initial state: [node-1, node-3]
     const node1 = document.createElement('div')
     node1.setAttribute('data-id', '0.1')
+    node1[PATH] = stringToPath('0.1')
     const node3 = document.createElement('div')
     node3.setAttribute('data-id', '0.3')
+    node3[PATH] = stringToPath('0.3')
 
     parent.appendChild(node1)
     parent.appendChild(node3)
@@ -79,9 +104,10 @@ describe('ensureEfficientOrdering and getNextSiblingElement together', () => {
     // We want to insert node-2 (data-id: 0.2)
     const node2 = document.createElement('div')
     node2.setAttribute('data-id', '0.2')
+    node2[PATH] = stringToPath('0.2')
 
     // Find where node2 should go
-    const nextSibling = getNextSiblingElement('0.2', parent)
+    const nextSibling = getNextSiblingElement(stringToPath('0.2'), parent)
     expect(nextSibling).toBe(node3)
 
     // Use ensureEfficientOrdering to place it using nextSibling as the anchor
@@ -97,19 +123,21 @@ describe('ensureEfficientOrdering and getNextSiblingElement together', () => {
 
     const node1_0 = document.createElement('div')
     node1_0.setAttribute('data-id', '0.1(0)')
+    node1_0[PATH] = stringToPath('0.1(0)')
     const node1_2 = document.createElement('div')
     node1_2.setAttribute('data-id', '0.1(2)')
+    node1_2[PATH] = stringToPath('0.1(2)')
 
     parent.appendChild(node1_0)
     parent.appendChild(node1_2)
 
     const node1_1 = document.createElement('div')
     node1_1.setAttribute('data-id', '0.1(1)')
+    node1_1[PATH] = stringToPath('0.1(1)')
 
-    const nextSibling = getNextSiblingElement('0.1(1)', parent)
+    const nextSibling = getNextSiblingElement(stringToPath('0.1(1)'), parent)
     expect(nextSibling).toBe(node1_2)
 
-    // Use ensureEfficientOrdering to place it using nextSibling as the anchor
     ensureEfficientOrdering(parent, [node1_0, node1_1], nextSibling)
 
     expect(parent.childNodes[0]).toBe(node1_0)

--- a/packages/runtime/src/utils/nodes.ts
+++ b/packages/runtime/src/utils/nodes.ts
@@ -1,8 +1,12 @@
+/* eslint-disable no-console */
 import type {
   Component,
   NodeModel,
 } from '@nordcraft/core/dist/component/component.types'
+import { pathToString, stringToPath } from '@nordcraft/core/dist/utils/path'
 import { isDefined } from '@nordcraft/core/dist/utils/util'
+import { PATH } from '../constants'
+import type { Path } from '../types'
 
 type NodeWithNodeId = NodeModel & { nodeId: string }
 
@@ -19,14 +23,13 @@ export const getNodeAndAncestors = (
   if (typeof id !== 'string' || id.length === 0) {
     return undefined
   }
-  const path = id.split('.')
-  const pathParsed = path.map((n) => parseInt(n))
+  const path = stringToPath(id)
   const ancestors: NodeWithNodeId[] = []
   // nodePath skips the root element as it's selected as the initial
   // value in the reduce below
-  const nodePath = pathParsed.slice(1)
+  const nodePath = path.slice(1)
   const node = nodePath.reduce(
-    (node: NodeModel | undefined | null, childIndex, i) => {
+    (node: NodeModel | undefined | null, pathElement, i) => {
       switch (node?.type) {
         // 'text' elements don't have any children
         case 'element':
@@ -37,10 +40,10 @@ export const getNodeAndAncestors = (
             ancestors.push({
               ...node,
               // Use the original path as origin to get correct nodeIds
-              nodeId: path.slice(0, i + 1).join('.'),
+              nodeId: pathToString(path.slice(0, i + 1)),
             })
           }
-          const index = node.children?.[childIndex]
+          const index = node.children?.[pathElement.index]
           if (index === undefined) {
             return undefined
           }
@@ -68,27 +71,28 @@ export const isNodeOrAncestorConditional = (
  * @returns The next sibling element or null if this is the last element. A nc sibling is a sibling with a higher index or the same index but a higher repeat index.
  */
 export const getNextSiblingElement = (
-  path: string,
+  path: Path,
   parentElement: Element | ShadowRoot,
-) => {
-  const pathParts = path.split('.')
-  const lastPathPart = pathParts.slice(-1)[0]
-  const index = parseInt(lastPathPart)
-  const repeatIndex = parseInt(String(lastPathPart.split('(')[1]))
+): Node | null => {
+  const lastPathPart = path[path.length - 1]
+  const index = lastPathPart.index
+  const repeatIndex = lastPathPart.repeatIndex ?? 0
 
   // Find the first child that either has a higher index or a similar index, but higher repeat index
-  for (const child of parentElement.children) {
-    const childPath = child.getAttribute('data-id')
-    const lastChildPathPart = childPath?.split('.').slice(-1)[0]
-    const childIndex = parseInt(String(lastChildPathPart))
-    if (
-      childIndex === index &&
-      parseInt(String(lastChildPathPart?.split('(')[1])) > repeatIndex
-    ) {
-      return child
+  for (const child of parentElement.childNodes) {
+    const childPath = child[PATH]
+    if (!childPath || !Array.isArray(childPath)) {
+      continue
     }
+    const lastChildPathPart = childPath[childPath.length - 1]
+    const childIndex = lastChildPathPart.index
 
-    if (childIndex > index) {
+    if (childIndex === index) {
+      const childRepeatIndex = lastChildPathPart.repeatIndex ?? 0
+      if (childRepeatIndex > repeatIndex) {
+        return child
+      }
+    } else if (childIndex > index) {
       return child
     }
   }
@@ -103,8 +107,8 @@ export const getNextSiblingElement = (
  */
 export function ensureEfficientOrdering(
   parentElement: Element | ShadowRoot,
-  items: ReadonlyArray<Element | Text>,
-  nextElement: Element | Text | null = null,
+  items: ReadonlyArray<Node>,
+  nextElement: Node | null = null,
 ) {
   // Identify the starting point for comparisons.
   let insertBeforeElement = nextElement // If insertBeforeElement is null, items will be appended at the end.
@@ -125,7 +129,16 @@ export function ensureEfficientOrdering(
     } else {
       // The item is either not in the DOM or not in the correct position.
       // Insert the item before the insertBeforeElement (or append it if insertBeforeElement is null).
-      parentElement.insertBefore(item, insertBeforeElement)
+      if (
+        item.parentNode === parentElement &&
+        'moveBefore' in Element.prototype
+      ) {
+        // `moveBefore` is not yet supported in Safari and some older browsers,
+        // moveBefore actually moves the element in the DOM instead of removing and reinserting it, which is more efficient and preserves animation-, transition- and focus states.
+        parentElement.moveBefore(item, insertBeforeElement)
+      } else {
+        parentElement.insertBefore(item, insertBeforeElement)
+      }
     }
 
     // Update insertBeforeElement to the current item for the next iteration, as we need to insert subsequent items before this one.

--- a/packages/ssr/src/rendering/components.test.ts
+++ b/packages/ssr/src/rendering/components.test.ts
@@ -360,7 +360,7 @@ describe('renderPageBody', () => {
     // Expect the nested child text node inside the package component to also render the formula value,
     // proving that the formula is evaluated correctly even when used inside a package component
     expect(html).toInclude(
-      '<span data-id="0.1" data-node-id="root" class="PageComponent:secondChild AxiNE"><span data-node-type="text" data-node-id="nestedChild">output-from-test-formula</span></span>',
+      '<span data-id="0.1" data-node-id="root" class="PageComponent:secondChild bxdLdg"><span data-node-type="text" data-node-id="nestedChild">output-from-test-formula</span></span>',
     )
   })
 

--- a/packages/ssr/src/rendering/components.ts
+++ b/packages/ssr/src/rendering/components.ts
@@ -24,10 +24,11 @@ import {
   toValidClassName,
 } from '@nordcraft/core/dist/styling/className'
 import { appendUnit } from '@nordcraft/core/dist/styling/customProperty'
-import type { Nullable } from '@nordcraft/core/dist/types'
+import type { Nullable, Path } from '@nordcraft/core/dist/types'
 import { filterObject, mapValues } from '@nordcraft/core/dist/utils/collections'
 import { getNodeSelector } from '@nordcraft/core/dist/utils/getNodeSelector'
 import { VOID_HTML_ELEMENTS } from '@nordcraft/core/dist/utils/html'
+import { pathToString } from '@nordcraft/core/dist/utils/path'
 import { isDefined, toBoolean } from '@nordcraft/core/dist/utils/util'
 import { escapeAttrValue } from 'xss'
 import type { ProjectFiles } from '../ssr.types'
@@ -58,7 +59,7 @@ const renderComponent = async ({
   addCustomProperty,
   namespace,
 }: {
-  path: string
+  path: Path
   apiCache: ApiCache
   children?: Record<string, SlottedContent>
   component: Component
@@ -93,7 +94,7 @@ const renderComponent = async ({
     namespace,
   }: {
     id: string
-    path: string
+    path: Path
     node: NodeModel | undefined | null
     data: ComponentData
     packageName: string | undefined
@@ -121,7 +122,10 @@ const renderComponent = async ({
         items.map((Item, Index) =>
           renderNode({
             id,
-            path: Index ? `${path}(${Index})` : path,
+            path: [
+              ...path.slice(0, -1),
+              { ...path[path.length - 1]!, repeatIndex: Index },
+            ],
             node: { ...node, repeat: undefined },
             data: {
               ...data,
@@ -161,10 +165,18 @@ const renderComponent = async ({
             : defaultChild
         } else {
           const slotChildren = await Promise.all(
-            (node.children ?? []).map((child) =>
+            (node.children ?? []).map((child, i) =>
               renderNode({
                 id: child,
-                path: `${path}[${node.name ?? 'default'}]`,
+                path: [
+                  ...path,
+                  {
+                    index: i,
+                    repeatIndex: 0,
+                    slotName: node.name ?? 'default',
+                    slotComponentIndex: 0,
+                  },
+                ],
                 node: component.nodes?.[child],
                 data,
                 packageName,
@@ -276,7 +288,15 @@ const renderComponent = async ({
                 node.children.map((child, i) =>
                   renderNode({
                     id: child,
-                    path: `${path}.${i}`,
+                    path: [
+                      ...path,
+                      {
+                        index: i,
+                        repeatIndex: 0,
+                        slotName: 'default',
+                        slotComponentIndex: 0,
+                      },
+                    ],
                     namespace,
                     node: component.nodes?.[child],
                     data,
@@ -302,7 +322,7 @@ const renderComponent = async ({
             : node.tag
         const attributes = [
           ...nodeAttrs,
-          `data-id="${path}"`,
+          `data-id="${pathToString(path)}"`,
           `data-node-id="${escapeAttrValue(id)}"`,
         ]
         if (classList.length > 0) {
@@ -425,7 +445,16 @@ const renderComponent = async ({
             return (contexts: Record<string, Record<string, unknown>>) => {
               return renderNode({
                 id: child,
-                path: `${path}.${i}[${slotName}]`,
+                // path: `${path}.${i}[${slotName}]`,
+                path: [
+                  ...path,
+                  {
+                    index: i,
+                    repeatIndex: 0,
+                    slotName,
+                    slotComponentIndex: 0,
+                  },
+                ],
                 namespace,
                 node: component.nodes?.[child],
                 data: {
@@ -641,7 +670,7 @@ const createComponent = async ({
   addCustomProperty,
   namespace,
 }: {
-  path: string
+  path: Path
   apiCache: ApiCache
   apis: Record<
     string,
@@ -798,7 +827,9 @@ export const renderPageBody = async ({
   formulaContext.data.Apis = apis
 
   const html = await renderComponent({
-    path: '0',
+    path: [
+      { index: 0, repeatIndex: 0, slotName: 'default', slotComponentIndex: 0 },
+    ],
     apiCache,
     component,
     data: formulaContext.data,


### PR DESCRIPTION
Work in progress. Consider merging after/with #1216 

This PR removes the `[data-id]` attribute from all rendered elements (when not in editor preview runtime – it is possible to remove it from editor runtime as well, but will require a bit more work).

This PR also change structure we store node paths internally by using a fixed structure rather than a query-string. This should have a positive impact on performance as repeat-node reordering has to do some string manipulation today.

## Note on `[data-node-id]`

It is very much possible to remove this attribute along with `[data-node-type]` & `[data-component-name]` from production output as well, but the reset stylesheet does require them today. By modifying (let users opt-out) of the reset stylesheet we are down to zero built-in attribute and render only what you see in the editor.