### PR TITLE
Improved the CSS parser to better support variables in style property values

### DIFF
--- a/packages/css-parser/src/background/parseBackground.ts
+++ b/packages/css-parser/src/background/parseBackground.ts
@@ -11,6 +11,7 @@ import {
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
   parse,
@@ -192,39 +193,34 @@ const parseBackground = (args: backgroundArguments) => {
     allValues.forEach((value) => {
       const val = value.trim()
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedUsedVariable =
-          usedVariable.unit && usedVariable.unit !== ''
-            ? parse({ input: `${usedVariable.value}${usedVariable.unit}` })
-            : parse({ input: usedVariable.value })
-
-        const parsedUsedVariableVal = getValue(parsedUsedVariable[0])
-
-        if (parsedUsedVariableVal.length > 1) {
+        if (parsedVariable === 'invalid') {
           invalidValue = true
-        } else {
-          const parsedVariable = parseMultipleValues(parsedUsedVariableVal)
-          if (parsedVariable[0]?.type !== 'functionArguments') {
-            const newProp = parseBackground({
-              variables,
-              image,
-              valueToCheck: parsedVariable[0],
-              positionSet,
-              valueToReturn: returnValue,
-            })
+          return
+        }
 
-            if (newProp.color) {
-              color = newProp.color
-              return
-            } else {
-              image = { ...image, ...newProp.image }
-            }
+        if (parsedVariable.type !== 'functionArguments') {
+          const newProp = parseBackground({
+            variables,
+            image,
+            valueToCheck: parsedVariable,
+            positionSet,
+            valueToReturn: returnValue,
+          })
+
+          if (newProp.color) {
+            color = newProp.color
+            return
+          } else {
+            image = { ...image, ...newProp.image }
           }
         }
       } else {
@@ -306,25 +302,24 @@ const parsePosition = (args: {
     allValues.forEach((value) => {
       const val = value.trim()
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedUsedVariable =
-          usedVariable.unit && usedVariable.unit !== ''
-            ? parse({ input: `${usedVariable.value}${usedVariable.unit}` })
-            : parse({ input: usedVariable.value })
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
 
-        const parsedUsedVariableVal = getValue(parsedUsedVariable[0])
-        const parsedVariable = parseMultipleValues(parsedUsedVariableVal)
-
-        if (parsedVariable[0]?.type !== 'functionArguments') {
+        if (parsedVariable.type !== 'functionArguments') {
           const newProp = parsePosition({
             variables,
-            valueToCheck: parsedVariable[0],
+            valueToCheck: parsedVariable,
             valueToReturn: valueToCheck,
           })
 

--- a/packages/css-parser/src/background/parseConicGradient.ts
+++ b/packages/css-parser/src/background/parseConicGradient.ts
@@ -5,10 +5,9 @@ import {
   rectangularColorSpace,
 } from '../const'
 import {
-  getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
-  parse,
   parseMultipleValues,
 } from '../shared'
 import type {
@@ -246,45 +245,35 @@ const checkVariableValueConic = (args: {
       if (angleToBeSet) {
         angle = returnValue
       } else {
-        const usedVariable = args.variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables: args.variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedUsedVariable =
-          usedVariable.unit &&
-          usedVariable.unit !== '' &&
-          !usedVariable.value.endsWith(usedVariable.unit)
-            ? parse({ input: `${usedVariable.value}${usedVariable.unit}` })
-            : parse({ input: usedVariable.value })
-
-        if (isDefined(parsedUsedVariable[0])) {
-          const parsedUsedVariableVal = getValue(parsedUsedVariable[0])
-          const parsedVariable = parseMultipleValues(parsedUsedVariableVal)[0]
-          if (!isDefined(parsedVariable)) {
-            return
-          }
-
-          const newValues = checkConicFuncValue({
-            parsedVariable,
-            returnValue,
-            previousVal: args.previousVal,
-            lastPositionVal: args.lastPositionVal,
-            position: newPosition,
-            angleToBeSet,
-            stops: newStops,
-            variables: args.variables,
-          })
-
-          angle = newValues.newAngle
-          newPosition = newValues.newPosition
-          newStops = newValues.newStops
-          invalidValues.push(...newValues.invalidValues)
-        } else {
+        if (parsedVariable === 'invalid') {
           invalidValues.push(returnValue)
+          return
         }
+
+        const newValues = checkConicFuncValue({
+          parsedVariable,
+          returnValue,
+          previousVal: args.previousVal,
+          lastPositionVal: args.lastPositionVal,
+          position: newPosition,
+          angleToBeSet,
+          stops: newStops,
+          variables: args.variables,
+        })
+
+        angle = newValues.newAngle
+        newPosition = newValues.newPosition
+        newStops = newValues.newStops
+        invalidValues.push(...newValues.invalidValues)
       }
     } else {
       const parsedVariable = parseMultipleValues([

--- a/packages/css-parser/src/background/parseImageSet.ts
+++ b/packages/css-parser/src/background/parseImageSet.ts
@@ -1,10 +1,9 @@
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import { radialGradientShape, radialGradientSize } from '../const'
 import {
-  getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
-  parse,
   parseMultipleValues,
 } from '../shared'
 import type {
@@ -211,21 +210,17 @@ const checkVariableValueRadial = (args: {
 
   allValues.forEach((val) => {
     if (isVariable(val)) {
-      const usedVariable = args.variables.find((v) =>
-        v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-      )
-      if (!usedVariable) {
+      const parsedVariable = getVariableValueByName({
+        variableName: val,
+        variables: args.variables,
+      })
+
+      if (!isDefined(parsedVariable)) {
         return
       }
 
-      const parsedUsedVariable =
-        usedVariable.unit && usedVariable.unit !== ''
-          ? parse({ input: `${usedVariable.value}${usedVariable.unit}` })
-          : parse({ input: usedVariable.value })
-
-      const parsedUsedVariableVal = getValue(parsedUsedVariable[0])
-      const parsedVariable = parseMultipleValues(parsedUsedVariableVal)[0]
-      if (!isDefined(parsedVariable)) {
+      if (parsedVariable === 'invalid') {
+        invalidValues.push(returnValue)
         return
       }
 
@@ -376,68 +371,61 @@ const checkValue = ({
         if (value.type !== 'functionArguments') {
           const val = value.value
           if (isVariable(val)) {
-            const usedVariable = variables.find((v) =>
-              v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-            )
-            if (!usedVariable) {
+            const parsedVariable = getVariableValueByName({
+              variableName: val,
+              variables,
+            })
+
+            if (!isDefined(parsedVariable)) {
               return
             }
 
-            const parsedUsedVariable =
-              usedVariable.unit && usedVariable.unit !== ''
-                ? parse({
-                    input: `${usedVariable.value}${usedVariable.unit}`,
-                  })
-                : parse({ input: usedVariable.value })
+            if (parsedVariable === 'invalid') {
+              return
+            }
 
-            const parsedUsedVariableVal = getValue(parsedUsedVariable[0])
-
-            const parsedVariable = parseMultipleValues(parsedUsedVariableVal)[0]
-
-            if (isDefined(parsedVariable)) {
-              const valueToReturn = returnValue ?? {
-                type: 'function',
-                name: 'var',
-                value: valueToCheck.arguments
-                  .map((a) => {
-                    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
-                    switch (a.type) {
-                      case 'angle':
-                      case 'length':
-                      case 'time':
-                      case 'resolution': {
-                        return `${a.value}${a.unit}`
-                      }
-                      case 'keyword':
-                      case 'number':
-                      case 'string':
-                      case 'hex': {
-                        return `${a.value}`
-                      }
-                      case 'function': {
-                        return `${a.name}(${a.value})`
-                      }
-                      case 'functionArguments': {
-                        return ``
-                      }
+            const valueToReturn = returnValue ?? {
+              type: 'function',
+              name: 'var',
+              value: valueToCheck.arguments
+                .map((a) => {
+                  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+                  switch (a.type) {
+                    case 'angle':
+                    case 'length':
+                    case 'time':
+                    case 'resolution': {
+                      return `${a.value}${a.unit}`
                     }
-                  })
-                  .join(', '),
-              }
+                    case 'keyword':
+                    case 'number':
+                    case 'string':
+                    case 'hex': {
+                      return `${a.value}`
+                    }
+                    case 'function': {
+                      return `${a.name}(${a.value})`
+                    }
+                    case 'functionArguments': {
+                      return ``
+                    }
+                  }
+                })
+                .join(', '),
+            }
 
-              const newProp = checkValue({
-                valueToCheck: parsedVariable,
-                returnValue: valueToReturn,
-                images: imagesSet,
-                variables,
-              })
+            const newProp = checkValue({
+              valueToCheck: parsedVariable,
+              returnValue: valueToReturn,
+              images: imagesSet,
+              variables,
+            })
 
-              if (newProp.imagesSet.length > 0) {
-                imagesSet = newProp.imagesSet
-              }
-              if (isDefined(newProp.invalidValue)) {
-                invalidValue = newProp.invalidValue
-              }
+            if (newProp.imagesSet.length > 0) {
+              imagesSet = newProp.imagesSet
+            }
+            if (isDefined(newProp.invalidValue)) {
+              invalidValue = newProp.invalidValue
             }
           } else {
             const parsedVariable = parseMultipleValues([

--- a/packages/css-parser/src/background/parseLinearGradient.ts
+++ b/packages/css-parser/src/background/parseLinearGradient.ts
@@ -5,10 +5,9 @@ import {
   rectangularColorSpace,
 } from '../const'
 import {
-  getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
-  parse,
   parseMultipleValues,
 } from '../shared'
 import type {
@@ -161,39 +160,30 @@ const checkVariableValueLinear = (args: {
 
   allValues.forEach((val) => {
     if (isVariable(val)) {
-      const usedVariable = args.variables.find((v) =>
-        v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-      )
-      if (!usedVariable) {
+      const parsedVariable = getVariableValueByName({
+        variableName: val,
+        variables: args.variables,
+      })
+
+      if (!isDefined(parsedVariable)) {
         return
       }
 
-      const parsedUsedVariable =
-        usedVariable.unit &&
-        usedVariable.unit !== '' &&
-        !usedVariable.value.endsWith(usedVariable.unit)
-          ? parse({ input: `${usedVariable.value}${usedVariable.unit}` })
-          : parse({ input: usedVariable.value })
-      if (isDefined(parsedUsedVariable[0])) {
-        const parsedUsedVariableVal = getValue(parsedUsedVariable[0])
-        const parsedVariable = parseMultipleValues(parsedUsedVariableVal)[0]
-        if (!isDefined(parsedVariable)) {
-          return
-        }
-
-        const newValues = checkValue({
-          value: parsedVariable,
-          returnValue,
-          stops: newStops,
-          variables: args.variables,
-        })
-
-        direction = newValues.newDirection
-        newStops = newValues.newStops
-        invalidValues.push(...newValues.invalidValues)
-      } else {
+      if (parsedVariable === 'invalid') {
         invalidValues.push(returnValue)
+        return
       }
+
+      const newValues = checkValue({
+        value: parsedVariable,
+        returnValue,
+        stops: newStops,
+        variables: args.variables,
+      })
+
+      direction = newValues.newDirection
+      newStops = newValues.newStops
+      invalidValues.push(...newValues.invalidValues)
     } else {
       const parsedVariable = parseMultipleValues([
         { type: 'word', value: val },

--- a/packages/css-parser/src/background/parseRadialGradient.ts
+++ b/packages/css-parser/src/background/parseRadialGradient.ts
@@ -7,10 +7,9 @@ import {
   rectangularColorSpace,
 } from '../const'
 import {
-  getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
-  parse,
   parseMultipleValues,
 } from '../shared'
 import type {
@@ -230,45 +229,35 @@ const checkVariableValueRadial = (args: {
 
   allValues.forEach((val) => {
     if (isVariable(val)) {
-      const usedVariable = args.variables.find((v) =>
-        v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-      )
-      if (!usedVariable) {
+      const parsedVariable = getVariableValueByName({
+        variableName: val,
+        variables: args.variables,
+      })
+
+      if (!isDefined(parsedVariable)) {
         return
       }
 
-      const parsedUsedVariable =
-        usedVariable.unit &&
-        usedVariable.unit !== '' &&
-        !usedVariable.value.endsWith(usedVariable.unit)
-          ? parse({ input: `${usedVariable.value}${usedVariable.unit}` })
-          : parse({ input: usedVariable.value })
-
-      if (isDefined(parsedUsedVariable[0])) {
-        const parsedUsedVariableVal = getValue(parsedUsedVariable[0])
-        const parsedVariable = parseMultipleValues(parsedUsedVariableVal)[0]
-        if (!isDefined(parsedVariable)) {
-          return
-        }
-
-        const newValues = checkRadialFuncValue({
-          parsedVariable,
-          returnValue,
-          previousVal: args.previousVal,
-          lastPositionVal: args.lastPositionVal,
-          position: newPosition,
-          stops: newStops,
-          variables: args.variables,
-        })
-
-        shape = newValues.newShape
-        size = newValues.newSize
-        newPosition = newValues.newPosition
-        newStops = newValues.newStops
-        invalidValues.push(...newValues.invalidValues)
-      } else {
+      if (parsedVariable === 'invalid') {
         invalidValues.push(returnValue)
+        return
       }
+
+      const newValues = checkRadialFuncValue({
+        parsedVariable,
+        returnValue,
+        previousVal: args.previousVal,
+        lastPositionVal: args.lastPositionVal,
+        position: newPosition,
+        stops: newStops,
+        variables: args.variables,
+      })
+
+      shape = newValues.newShape
+      size = newValues.newSize
+      newPosition = newValues.newPosition
+      newStops = newValues.newStops
+      invalidValues.push(...newValues.invalidValues)
     } else {
       const parsedVariable = parseMultipleValues([
         { type: 'word', value: val },

--- a/packages/css-parser/src/background/shared.ts
+++ b/packages/css-parser/src/background/shared.ts
@@ -164,7 +164,7 @@ export const getNextKnowStopPosition = (
   }
 }
 
-export const getStopValue = ({
+const getStopValue = ({
   parsedValue,
   variables,
 }: {

--- a/packages/css-parser/src/box-shadow/parseBoxShadow.test.ts
+++ b/packages/css-parser/src/box-shadow/parseBoxShadow.test.ts
@@ -141,4 +141,35 @@ describe('parseBoxShadow', () => {
       },
     ])
   })
+
+  test('Use defined variable as blur value', () => {
+    expect(
+      getParsedBoxShadow(
+        {
+          'box-shadow': '0px 0px var(--test) 0px #000000',
+        },
+        [
+          {
+            syntax: {
+              type: 'primitive',
+              name: 'length',
+            },
+            formula: { type: 'value', value: 4 },
+            name: '--test',
+            description: undefined,
+            unit: 'px',
+            value: '4px',
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        horizontal: { type: 'length', value: '0', unit: 'px' },
+        vertical: { type: 'length', value: '0', unit: 'px' },
+        blur: { type: 'function', name: 'var', value: '--test' },
+        spread: { type: 'length', value: '0', unit: 'px' },
+        color: { type: 'hex', value: '#000000' },
+      },
+    ])
+  })
 })

--- a/packages/css-parser/src/box-shadow/parseBoxShadow.ts
+++ b/packages/css-parser/src/box-shadow/parseBoxShadow.ts
@@ -3,6 +3,7 @@ import { colorFunction, globalValues } from '../const'
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
   parse,
@@ -171,27 +172,23 @@ const parseBoxShadow = (args: {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const value =
-          usedVariable.unit && usedVariable.unit !== ''
-            ? getValue(
-                parse({
-                  input: `${usedVariable.value}${usedVariable.unit}`,
-                })[0],
-              )
-            : getValue(parse({ input: usedVariable.value })[0])
-
-        const parsedVariable = parseMultipleValues(value)
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
 
         const newProp = parseBoxShadow({
           boxShadow,
-          valueToCheck: parsedVariable[0],
+          valueToCheck: parsedVariable,
           valueToReturn: valueToCheck,
           variables,
         })

--- a/packages/css-parser/src/parseAnimation.ts
+++ b/packages/css-parser/src/parseAnimation.ts
@@ -2,6 +2,7 @@ import { isDefined } from '@nordcraft/core/dist/utils/util'
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isVariable,
   parse,
   parseMultipleValues,
@@ -560,34 +561,23 @@ const parseAnimation = ({
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const valueWithoutUnit = usedVariable.unit
-          ? usedVariable.value.replaceAll(usedVariable.unit, '')
-          : usedVariable.value
-
-        if (valueWithoutUnit === '') {
+        if (parsedVariable === 'invalid') {
           invalidValue = true
           return
         }
 
-        const valueWithUnit = usedVariable.value
-
-        const parsedVariable = parseMultipleValues([
-          {
-            type: 'word',
-            value: valueWithUnit,
-          },
-        ])
-
-        if (isDefined(parsedVariable[0])) {
+        if (isDefined(parsedVariable)) {
           const newProp = parseAnimation({
-            valueToCheck: parsedVariable[0],
+            valueToCheck: parsedVariable,
             valueToReturn: valueToCheck,
             durationSet,
             nameSet,
@@ -709,37 +699,34 @@ const isValidTimeValue = ({
           const allValues = val.value.split(',').map((v) => v.trim())
           allValues.forEach((val) => {
             if (isVariable(val)) {
-              const usedVariable = variables.find((v) =>
-                v.name.startsWith('--')
-                  ? v.name === val
-                  : `--${v.name}` === val,
-              )
-              if (!usedVariable) {
+              const parsedVariable = getVariableValueByName({
+                variableName: val,
+                variables,
+              })
+
+              if (!isDefined(parsedVariable)) {
                 return
               }
 
-              const valueWithoutUnit = usedVariable.unit
-                ? usedVariable.value.replaceAll(usedVariable.unit, '')
-                : usedVariable.value
-
-              const pars = parse({ input: valueWithoutUnit })
-              const va = getValue(pars[0])
-              const parsedVariable = parseMultipleValues(va)
+              if (parsedVariable === 'invalid') {
+                validValue = false
+                return
+              }
 
               if (
-                isDefined(parsedVariable[0]) &&
-                parsedVariable[0].type === 'function' &&
-                (CSS_FUNCTIONS.includes(parsedVariable[0].name) ||
-                  parsedVariable[0].name === 'var')
+                isDefined(parsedVariable) &&
+                parsedVariable.type === 'function' &&
+                (CSS_FUNCTIONS.includes(parsedVariable.name) ||
+                  parsedVariable.name === 'var')
               ) {
                 validValue = isValidTimeValue({
-                  valueToCheck: parsedVariable[0].value,
+                  valueToCheck: parsedVariable.value,
                   variables,
-                  isCalc: parsedVariable[0].name === 'calc',
+                  isCalc: parsedVariable.name === 'calc',
                 })
               } else if (
-                isDefined(parsedVariable[0]) &&
-                parsedVariable[0].type !== 'time'
+                isDefined(parsedVariable) &&
+                parsedVariable.type !== 'time'
               ) {
                 validValue = false
               }

--- a/packages/css-parser/src/parseBorderOrOutline.ts
+++ b/packages/css-parser/src/parseBorderOrOutline.ts
@@ -1,10 +1,9 @@
 import { isDefined } from '@nordcraft/core/dist/utils/util'
 import { colorFunction, lineStyle, outlineStyle } from './const'
 import {
-  getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
-  parse,
   parseMultipleValues,
 } from './shared'
 import type { CSSStyleToken, ParsedValueType } from './types'
@@ -58,25 +57,21 @@ export const parseBorderOrOutline = (args: {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const value =
-          usedVariable.unit && usedVariable.unit !== ''
-            ? getValue(
-                parse({
-                  input: `${usedVariable.value}${usedVariable.unit}`,
-                })[0],
-              )
-            : getValue(parse({ input: usedVariable.value })[0])
-
-        const parsedVariable = parseMultipleValues(value)
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
         const newProp = parseBorderOrOutline({
-          valueToCheck: parsedVariable[0],
+          valueToCheck: parsedVariable,
           property,
           variables,
           valueToReturn: valueToCheck,

--- a/packages/css-parser/src/parseBorderRadius.ts
+++ b/packages/css-parser/src/parseBorderRadius.ts
@@ -2,6 +2,7 @@ import { isDefined } from '@nordcraft/core/dist/utils/util'
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isVariable,
   parse,
   parseMultipleValues,
@@ -466,24 +467,21 @@ const parseBorderRadius = (args: {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedVariable = parseMultipleValues([
-          {
-            type: 'word',
-            value:
-              usedVariable.unit && usedVariable.unit !== ''
-                ? `${usedVariable.value}${usedVariable.unit}`
-                : usedVariable.value,
-          },
-        ])
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
         const newProp = parseBorderRadius({
-          valueToCheck: parsedVariable[0],
+          valueToCheck: parsedVariable,
           horizontalSet,
           valueToReturn: valueToCheck,
           variables,

--- a/packages/css-parser/src/parseFlex.ts
+++ b/packages/css-parser/src/parseFlex.ts
@@ -2,6 +2,7 @@ import { isDefined } from '@nordcraft/core/dist/utils/util'
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isVariable,
   parse,
   parseMultipleValues,
@@ -258,27 +259,22 @@ const parseFlex = (args: {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedVariable = parseMultipleValues([
-          {
-            type: 'word',
-            value:
-              usedVariable.unit &&
-              usedVariable.unit !== '' &&
-              usedVariable.unit !== ''
-                ? `${usedVariable.value}${usedVariable.unit}`
-                : usedVariable.value,
-          },
-        ])
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
         const newProp = parseFlex({
           flex,
-          valueToCheck: parsedVariable[0],
+          valueToCheck: parsedVariable,
           valueToReturn: valueToCheck,
           variables,
         })

--- a/packages/css-parser/src/parseFont.ts
+++ b/packages/css-parser/src/parseFont.ts
@@ -8,6 +8,7 @@ import {
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isVariable,
   parse,
   parseMultipleValues,
@@ -533,27 +534,24 @@ const parseFont = (args: {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedVariable = parseMultipleValues([
-          {
-            type: 'word',
-            value:
-              usedVariable.unit && usedVariable.unit !== ''
-                ? `${usedVariable.value}${usedVariable.unit}`
-                : usedVariable.value,
-          },
-        ])
-        if (parsedVariable[0]?.type !== 'functionArguments') {
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
+        if (parsedVariable.type !== 'functionArguments') {
           const newProp = parseFont({
             font,
             isLastItem,
-            valueToCheck: parsedVariable[0],
+            valueToCheck: parsedVariable,
             lineHeightToBeSet,
             valueToReturn: valueToCheck,
             variables,

--- a/packages/css-parser/src/parseTextDecoration.ts
+++ b/packages/css-parser/src/parseTextDecoration.ts
@@ -7,6 +7,7 @@ import {
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
   parse,
@@ -321,24 +322,21 @@ const parseDecoration = (args: {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedVariable = parseMultipleValues([
-          {
-            type: 'word',
-            value:
-              usedVariable.unit && usedVariable.unit !== ''
-                ? `${usedVariable.value}${usedVariable.unit}`
-                : usedVariable.value,
-          },
-        ])
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
         const newProp = parseDecoration({
-          valueToCheck: parsedVariable[0],
+          valueToCheck: parsedVariable,
           valueToReturn: valueToCheck,
           variables,
         })

--- a/packages/css-parser/src/parseTransition.ts
+++ b/packages/css-parser/src/parseTransition.ts
@@ -3,6 +3,7 @@ import { timingFunctions } from './const'
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isVariable,
   parse,
   parseMultipleValues,
@@ -66,22 +67,24 @@ export const parseTransition = (args: transitionArguments) => {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
 
-        if (!usedVariable) {
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const parsedValue = parse({ input: usedVariable.value })
-        const value = getValue(parsedValue[0])
-        const parsedVariable = parseMultipleValues(value)
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
 
         const newProp = parseTransition({
           variables,
           transition,
-          valueToCheck: parsedVariable[0],
+          valueToCheck: parsedVariable,
           valueToReturn: valueToCheck,
         })
 

--- a/packages/css-parser/src/shared.ts
+++ b/packages/css-parser/src/shared.ts
@@ -29,30 +29,50 @@ export const getVariableValue = ({
       return null
     }
 
-    const usedVariable = variables.find((variable) =>
-      variable.name.startsWith('--')
-        ? variable.name === name
-        : `--${variable.name}` === name,
-    )
+    const val = getVariableValueByName({ variableName: name, variables })
 
-    if (usedVariable) {
-      const value =
-        parseMultipleValues([
-          {
-            type: 'word',
-            value: usedVariable?.unit
-              ? `${usedVariable.value}${usedVariable.unit}`
-              : usedVariable.value,
-          },
-        ])[0] ?? null
-
-      return value
-    }
-
-    return null
+    return val === 'invalid' ? null : val
   }
 
   return value
+}
+
+export const getVariableValueByName = ({
+  variableName,
+  variables,
+}: {
+  variableName: string
+  parsedVariable?: ParsedValueType
+  variables: CSSStyleToken[]
+}): ParsedValueType | null | 'invalid' => {
+  const usedVariable = variables.find((v) =>
+    v.name.startsWith('--')
+      ? v.name === variableName
+      : `--${v.name}` === variableName,
+  )
+
+  if (usedVariable) {
+    const valueWithoutUnit = usedVariable.unit
+      ? usedVariable.value.replaceAll(usedVariable.unit, '')
+      : usedVariable.value
+
+    if (valueWithoutUnit === '') {
+      return 'invalid'
+    }
+
+    const valueWithUnit = usedVariable.value
+
+    const parsedValue = parse({ input: valueWithUnit })
+    const value = getValue(parsedValue[0])
+    if (value.length > 1) {
+      return 'invalid'
+    }
+    const parsedVariable = parseMultipleValues(value)[0] ?? null
+
+    return parsedVariable
+  }
+
+  return null
 }
 
 export const getValue = (

--- a/packages/css-parser/src/text-shadow/parseTextShadow.ts
+++ b/packages/css-parser/src/text-shadow/parseTextShadow.ts
@@ -3,6 +3,7 @@ import { colorFunction, globalValues } from '../const'
 import {
   checkIfNoUnknownVariables,
   getValue,
+  getVariableValueByName,
   isColor,
   isVariable,
   parse,
@@ -148,27 +149,23 @@ const parseTextShadow = (args: {
     const allValues = valueToCheck.value.split(', ')
     allValues.forEach((val) => {
       if (isVariable(val)) {
-        const usedVariable = variables.find((v) =>
-          v.name.startsWith('--') ? v.name === val : `--${v.name}` === val,
-        )
-        if (!usedVariable) {
+        const parsedVariable = getVariableValueByName({
+          variableName: val,
+          variables,
+        })
+
+        if (!isDefined(parsedVariable)) {
           return
         }
 
-        const value =
-          usedVariable.unit && usedVariable.unit !== ''
-            ? getValue(
-                parse({
-                  input: `${usedVariable.value}${usedVariable.unit}`,
-                })[0],
-              )
-            : getValue(parse({ input: usedVariable.value })[0])
-
-        const parsedVariable = parseMultipleValues(value)
+        if (parsedVariable === 'invalid') {
+          invalidValue = true
+          return
+        }
 
         const newProp = parseTextShadow({
           textShadow,
-          valueToCheck: parsedVariable[0],
+          valueToCheck: parsedVariable,
           valueToReturn: valueToCheck,
           variables,
         })


### PR DESCRIPTION
Update the way how we get the value for a variable and use the same way everywhere for each css property.

To test: For example add a variable of type length and add a value 5 and unit px. Then use this variable in the box-shadow as a blur. Verify that the variable will be shown in the style panel in the blur input.