### PR TITLE
Query syntax search added to search worker

### DIFF
--- a/packages/search/src/findSearch.ts
+++ b/packages/search/src/findSearch.ts
@@ -1,5 +1,6 @@
 import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
 import { createFieldSearchRule } from './rules/search/fieldSearchRule'
+import { querySearchRules } from './rules/search/searchRegistry'
 import { searchProject } from './searchProject'
 import type {
   SearchArgs,
@@ -42,20 +43,29 @@ export async function findSearch(
   }
 
   const rules: SearchRule[] = []
-  rules.push(
-    createFieldSearchRule({
-      query,
-      withDetails: options.withDetails ?? true,
-      skippedFields:
-        (query.startsWith('<') && query.includes('>')) ||
-        (query.startsWith('"') && query.endsWith('"'))
-          ? {}
-          : {
-              // Random generated ids are disabled for non-programmatic or exact matching
-              'component-node': ['children'],
-            },
-    }),
-  )
+  for (const registeredRule of querySearchRules) {
+    if (registeredRule.shouldRun(query)) {
+      rules.push(registeredRule.create(query))
+    }
+  }
+
+  // If no rules matched the query, we default to a field search rule
+  if (rules.length === 0) {
+    rules.push(
+      createFieldSearchRule({
+        query,
+        withDetails: options.withDetails ?? true,
+        skippedFields:
+          (query.startsWith('<') && query.includes('>')) ||
+          (query.startsWith('"') && query.endsWith('"'))
+            ? {}
+            : {
+                // Random generated ids are disabled
+                'component-node': ['children'],
+              },
+      }),
+    )
+  }
 
   let batch: SearchResult[] = []
   let fileType: string | number | undefined

--- a/packages/search/src/rules/search/componentRefSearchRule.ts
+++ b/packages/search/src/rules/search/componentRefSearchRule.ts
@@ -1,0 +1,75 @@
+import type { NodeModel } from '@nordcraft/core/dist/component/component.types'
+import type { SearchRule } from '../../types'
+import { matchAndSplitWildcard } from '../../util/matchWildcard'
+import { getNodeAncestorsContext } from '../../util/searchContext'
+
+const COMPONENT_REF_REGEX = /^ref:component:\s*(.+)$/i
+
+export function shouldRun(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.startsWith('/') && trimmed.endsWith('/') && trimmed.length > 2) {
+    return false
+  }
+  return COMPONENT_REF_REGEX.test(trimmed)
+}
+
+export function createComponentRefSearchRule({
+  query,
+}: {
+  query: string
+}): SearchRule {
+  const match = query.trim().match(COMPONENT_REF_REGEX)
+  const pattern = match ? match[1] : ''
+
+  return {
+    visit: (report, { path, value, nodeType, files }) => {
+      if (nodeType !== 'component-node') {
+        return
+      }
+
+      if (value?.type === 'component' && value?.name) {
+        const split = matchAndSplitWildcard(value.name, pattern)
+        if (split) {
+          const componentName = path[1] as string
+          const componentObj = files?.components?.[componentName]
+          const nodes = componentObj?.nodes
+          const nodeId = path[3] as string
+          const ancestors = getNodeAncestorsContext(nodes, nodeId)
+          const mappedAncestors = ancestors.map(printNodeDescriptor).join(' > ')
+          const beforeContext = mappedAncestors ? `${mappedAncestors} > ` : ''
+
+          report({
+            path,
+            details: {
+              nodeType: 'component-node',
+              context: {
+                before: beforeContext + split.before,
+                matched: split.matched,
+                after: split.after,
+              },
+            },
+          })
+        }
+      }
+    },
+  }
+}
+
+const printNodeDescriptor = (node: NodeModel): string => {
+  switch (node.type) {
+    case 'element': {
+      const classes = Object.entries(node.classes ?? {})
+        .filter(
+          ([_, c]) =>
+            !c.formula ||
+            (c.formula.type === 'value' && c.formula.value === true),
+        )
+        .map(([className]) => className)
+      return `${node.tag}${classes.length > 0 ? `.${classes.join('.')}` : ''}`
+    }
+    case 'component':
+      return node.name
+    default:
+      return node.type
+  }
+}

--- a/packages/search/src/rules/search/componentSearchRule.ts
+++ b/packages/search/src/rules/search/componentSearchRule.ts
@@ -1,0 +1,43 @@
+import type { SearchRule } from '../../types'
+import { matchAndSplitWildcard } from '../../util/matchWildcard'
+
+const COMPONENT_REGEX = /^component:\s*(.+)$/i
+
+export function shouldRun(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.startsWith('/') && trimmed.endsWith('/') && trimmed.length > 2) {
+    return false
+  }
+  return COMPONENT_REGEX.test(trimmed)
+}
+
+export function createComponentSearchRule({
+  query,
+}: {
+  query: string
+}): SearchRule {
+  const match = query.trim().match(COMPONENT_REGEX)
+  const pattern = match ? match[1] : ''
+
+  return {
+    visit: (report, { path, value, nodeType }) => {
+      if (nodeType !== 'component') {
+        return
+      }
+
+      const componentName = value.name || (path[1] as string)
+      if (componentName) {
+        const split = matchAndSplitWildcard(componentName, pattern)
+        if (split) {
+          report({
+            path,
+            details: {
+              nodeType: 'component',
+              context: split,
+            },
+          })
+        }
+      }
+    },
+  }
+}

--- a/packages/search/src/rules/search/elementSearchRule.test.ts
+++ b/packages/search/src/rules/search/elementSearchRule.test.ts
@@ -1,0 +1,211 @@
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../searchProject'
+import {
+  createElementSearchRule,
+  parseCssQuery,
+  shouldRun,
+} from './elementSearchRule'
+
+describe('parseCssQuery Predicate & Parser', () => {
+  test('should detect valid queries', () => {
+    expect(shouldRun('node:div.my-class')).toBe(true)
+    expect(shouldRun('node:.fill[path="my-path"]')).toBe(true)
+    expect(shouldRun('node:[disabled]')).toBe(true)
+    expect(shouldRun('node:button[type="submit"]')).toBe(true)
+    expect(shouldRun('node:svg.icon.small[width="32"]')).toBe(true)
+  })
+
+  test('should ignore non-css queries', () => {
+    expect(shouldRun('div.my-class')).toBe(false)
+    expect(shouldRun('.fill[path="my-path"]')).toBe(false)
+    expect(shouldRun('component:my-comp')).toBe(false)
+    expect(shouldRun('ref:component:my-comp')).toBe(false)
+    expect(shouldRun('workflow:save')).toBe(false)
+    expect(shouldRun('formula:foo')).toBe(false)
+    expect(shouldRun('/regex/')).toBe(false)
+  })
+
+  test('should parse correctly', () => {
+    expect(parseCssQuery('node:div.my-class')).toEqual({
+      tag: 'div',
+      classes: ['my-class'],
+      attrs: [],
+    })
+
+    expect(parseCssQuery('div.my-class')).toEqual({
+      tag: 'div',
+      classes: ['my-class'],
+      attrs: [],
+    })
+
+    expect(parseCssQuery('node:.fill[path="my-path"]')).toEqual({
+      tag: undefined,
+      classes: ['fill'],
+      attrs: [{ name: 'path', value: 'my-path' }],
+    })
+
+    expect(parseCssQuery('[disabled]')).toEqual({
+      tag: undefined,
+      classes: [],
+      attrs: [{ name: 'disabled', value: undefined }],
+    })
+
+    expect(parseCssQuery('node:svg.icon.small[width="32"]')).toEqual({
+      tag: 'svg',
+      classes: ['icon', 'small'],
+      attrs: [{ name: 'width', value: '32' }],
+    })
+  })
+})
+
+describe('Element Search Rule', () => {
+  const files: ProjectFiles = {
+    formulas: {},
+    components: {
+      'test-component': {
+        name: 'test-component',
+        nodes: {
+          root: {
+            type: 'element',
+            tag: 'div',
+            classes: {
+              container: { formula: { type: 'value', value: true } },
+              active: {
+                formula: { type: 'apply', name: 'isActive', arguments: [] },
+              },
+            },
+            attrs: {
+              id: { type: 'value', value: 'main-container' },
+            },
+            children: ['btn'],
+          },
+          btn: {
+            type: 'element',
+            tag: 'button',
+            classes: {
+              btn: { formula: { type: 'value', value: true } },
+              'btn-primary': { formula: { type: 'value', value: true } },
+            },
+            attrs: {
+              type: { type: 'value', value: 'submit' },
+              disabled: { type: 'value', value: true },
+            },
+            children: [],
+          },
+          sub: {
+            type: 'component',
+            name: 'other-comp',
+            children: [],
+          },
+        },
+        formulas: {},
+        apis: {},
+        attributes: {},
+        variables: {},
+        route: { path: [], query: {} },
+        workflows: {},
+      },
+    },
+  }
+
+  test('find elements by tag only', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createElementSearchRule({ query: 'node:button' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'test-component',
+      'nodes',
+      'btn',
+    ])
+    expect(results[0].details?.context).toEqual({
+      before: 'div > ',
+      matched: 'button.btn.btn-primary',
+      after: '',
+    })
+  })
+
+  test('find elements by class (including conditional ones)', () => {
+    // Finds active class even if it is dynamic/conditional
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createElementSearchRule({ query: 'node:.active' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'test-component',
+      'nodes',
+      'root',
+    ])
+  })
+
+  test('find elements with nested classes', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createElementSearchRule({ query: 'node:button.btn.btn-primary' }),
+        ],
+      }),
+    )
+    expect(results).toHaveLength(1)
+  })
+
+  test('find elements by attribute existence', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createElementSearchRule({ query: 'node:[disabled]' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'test-component',
+      'nodes',
+      'btn',
+    ])
+  })
+
+  test('find elements by attribute value', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createElementSearchRule({ query: 'node:div[id="main-container"]' }),
+        ],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'test-component',
+      'nodes',
+      'root',
+    ])
+  })
+
+  test('find elements with wildcards in attributes/classes', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createElementSearchRule({ query: 'node:button.btn-*' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'test-component',
+      'nodes',
+      'btn',
+    ])
+  })
+})

--- a/packages/search/src/rules/search/elementSearchRule.ts
+++ b/packages/search/src/rules/search/elementSearchRule.ts
@@ -1,0 +1,220 @@
+import type { SearchRule } from '../../types'
+import { getNodeAncestorsContext } from '../../util/searchContext'
+
+// Matches syntax like node: followed by a CSS query like:
+// - `node:div.my-class` or `node:.my-class`
+// - `node:div[attr="val"]` or `node:[attr="val"]`
+// - `node:.fill[path="my-path"]`
+// We support tag (optional), classes (multiple), and attributes (multiple selectors).
+// We also support wildcards (*) in tags, classes, and attribute values.
+
+const NODE_REGEX = /^node:\s*(.+)$/i
+
+interface parsedCssQuery {
+  tag?: string // e.g. "div", can have "*" wildcards
+  classes: string[] // e.g. ["foo", "bar"], can have "*" wildcards
+  attrs: Array<{
+    name: string
+    value?: string // if present, can have "*" wildcards
+  }>
+}
+
+export function parseCssQuery(query: string): parsedCssQuery | null {
+  let trimmed = query.trim()
+  const prefixMatch = trimmed.match(NODE_REGEX)
+  if (prefixMatch) {
+    trimmed = prefixMatch[1].trim()
+  }
+
+  if (!trimmed) {
+    return null
+  }
+
+  // Parse CSS query:
+  // tag name: optional alphanumeric or '-' or '*'
+  // followed by a sequence of .class or [attr=val]
+  let tag: string | undefined = undefined
+  const classes: string[] = []
+  const attrs: Array<{ name: string; value?: string }> = []
+
+  let rest = trimmed
+
+  // Extract tag name if exists
+  const tagMatch = rest.match(/^([a-zA-Z0-9-*]+)/)
+  if (tagMatch) {
+    tag = tagMatch[1]
+    rest = rest.slice(tag.length)
+  }
+
+  // We should require at least a tag name, a class selector, or an attribute selector
+  if (!tag && !rest.startsWith('.') && !rest.startsWith('[')) {
+    return null
+  }
+
+  while (rest.length > 0) {
+    if (rest.startsWith('.')) {
+      const classMatch = rest.match(/^\.([a-zA-Z0-9_*-]+)/)
+      if (!classMatch) {
+        return null // invalid syntax
+      }
+      classes.push(classMatch[1])
+      rest = rest.slice(classMatch[0].length)
+    } else if (rest.startsWith('[')) {
+      const attrMatch = rest.match(
+        /^\[([a-zA-Z0-9_-]+)(?:=(?:"([^"]*)"|'([^']*)'|([^\]'"]*)))?\]/,
+      )
+      if (!attrMatch) {
+        return null // invalid syntax
+      }
+      const attrName = attrMatch[1]
+      const attrVal = attrMatch[2] ?? attrMatch[3] ?? attrMatch[4]
+      attrs.push({
+        name: attrName,
+        value: attrVal,
+      })
+      rest = rest.slice(attrMatch[0].length)
+    } else {
+      // Any other characters mean it's not a valid CSS element query for our rules
+      return null
+    }
+  }
+
+  return { tag, classes, attrs }
+}
+
+export function shouldRun(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.startsWith('/') && trimmed.endsWith('/') && trimmed.length > 2) {
+    return false
+  }
+  return NODE_REGEX.test(trimmed) && parseCssQuery(trimmed) !== null
+}
+
+function matchValueWithWildcard(value: string, pattern: string): boolean {
+  const lowercaseValue = value.toLowerCase()
+  const lowercasePattern = pattern.toLowerCase()
+  if (lowercasePattern === '*') {
+    return true
+  }
+  const regexPattern =
+    '^' +
+    lowercasePattern
+      .replace(/[-/\\^$+.()|[\]{}]/g, '\\$&')
+      .replace(/\*/g, '.*') +
+    '$'
+  return new RegExp(regexPattern).test(lowercaseValue)
+}
+
+export function createElementSearchRule({
+  query,
+}: {
+  query: string
+}): SearchRule {
+  const parsed = parseCssQuery(query)
+
+  return {
+    visit: (report, { path, value, nodeType, files }) => {
+      if (nodeType !== 'component-node') {
+        return
+      }
+
+      // We only match elements
+      if (value?.type !== 'element') {
+        return
+      }
+
+      if (!parsed) {
+        return
+      }
+
+      // 1. Tag match
+      if (parsed.tag && parsed.tag !== '*') {
+        if (!matchValueWithWildcard(value.tag, parsed.tag)) {
+          return
+        }
+      }
+
+      // 2. Class match - search finds all classes no matter if conditional or not.
+      // node.classes is Record<string, { formula?: Formula }>
+      const elementClasses = Object.keys(value.classes ?? {})
+      for (const expectedClass of parsed.classes) {
+        let classFound = false
+        for (const ec of elementClasses) {
+          if (matchValueWithWildcard(ec, expectedClass)) {
+            classFound = true
+            break
+          }
+        }
+        if (!classFound) {
+          return
+        }
+      }
+
+      // 3. Attribute match
+      // node.attrs is Record<string, Formula>
+      for (const expectedAttr of parsed.attrs) {
+        const attributeFormula = value.attrs?.[expectedAttr.name]
+        if (!attributeFormula) {
+          return // Attr doesn't exist
+        }
+
+        if (expectedAttr.value !== undefined) {
+          // If we have a specific expected value (e.g. [path="my-path"]), we inspect the formula
+          // If it's a value formula, we check the exact / wildcard value
+          if (attributeFormula.type === 'value') {
+            if (
+              !matchValueWithWildcard(
+                String(attributeFormula.value),
+                expectedAttr.value,
+              )
+            ) {
+              return
+            }
+          } else {
+            // Non-static / non-value formula attribute but we expected a specific value.
+            // We can check if the formula string matches, or just skip if it's dynamic.
+            // To be robust, let's say dynamic attributes don't match specific static values, unless they match a wildcard like "*"
+            if (expectedAttr.value !== '*') {
+              return
+            }
+          }
+        }
+      }
+
+      // All criteria matched!
+      // Compute ancestor before context
+      const componentName = path[1] as string
+      const componentObj = files?.components?.[componentName]
+      const nodes = componentObj?.nodes
+      const nodeId = path[3] as string
+      const ancestors = getNodeAncestorsContext(nodes, nodeId)
+      const mappedAncestors = ancestors
+        .map((a) =>
+          a.type === 'component'
+            ? a.name
+            : a.type === 'element'
+              ? a.tag
+              : '<unknown>',
+        )
+        .join(' > ')
+      const beforeContext = mappedAncestors ? `${mappedAncestors} > ` : ''
+
+      // Highlight target node
+      const classesString =
+        elementClasses.length > 0 ? `.${elementClasses.join('.')}` : ''
+      const matchedString = `${value.tag}${classesString}`
+
+      report({
+        path,
+        details: {
+          nodeType: 'component-node',
+          context: {
+            before: beforeContext,
+            matched: matchedString,
+            after: '',
+          },
+        },
+      })
+    },
+  }
+}

--- a/packages/search/src/rules/search/formulaRefSearchRule.ts
+++ b/packages/search/src/rules/search/formulaRefSearchRule.ts
@@ -1,0 +1,103 @@
+import type { SearchRule } from '../../types'
+import { matchAndSplitWildcard } from '../../util/matchWildcard'
+import { getFormulaPathContext } from '../../util/searchContext'
+
+const FORMULA_REF_REGEX = /^ref:formula:\s*(.+)$/i
+
+export function shouldRun(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.startsWith('/') && trimmed.endsWith('/') && trimmed.length > 2) {
+    return false
+  }
+  return FORMULA_REF_REGEX.test(trimmed)
+}
+
+export function createFormulaRefSearchRule({
+  query,
+}: {
+  query: string
+}): SearchRule {
+  const match = query.trim().match(FORMULA_REF_REGEX)
+  const pattern = match ? match[1] : ''
+
+  return {
+    visit: (report, { path, value, nodeType, files }) => {
+      if (nodeType === 'formula') {
+        if (value.type === 'apply' && value.name) {
+          const split = matchAndSplitWildcard(value.name, pattern)
+          if (split) {
+            report({
+              path,
+              details: {
+                nodeType: 'formula',
+                context: {
+                  before: getFormulaPathContext(path, files) + split.before,
+                  matched: split.matched,
+                  after: split.after,
+                },
+              },
+            })
+          }
+        } else if (value.type === 'function' && value.name) {
+          const split = matchAndSplitWildcard(value.name, pattern)
+          if (split) {
+            report({
+              path,
+              details: {
+                nodeType: 'formula',
+                context: {
+                  before: getFormulaPathContext(path, files) + split.before,
+                  matched: split.matched,
+                  after: split.after,
+                },
+              },
+            })
+          }
+        } else if (
+          value.type === 'path' &&
+          value.path?.[0] === 'Contexts' &&
+          value.path?.[2]
+        ) {
+          const contextFormulaName = value.path[2]
+          const split = matchAndSplitWildcard(
+            String(contextFormulaName),
+            pattern,
+          )
+          if (split) {
+            report({
+              path,
+              details: {
+                nodeType: 'formula',
+                context: {
+                  before: getFormulaPathContext(path, files) + split.before,
+                  matched: split.matched,
+                  after: split.after,
+                },
+              },
+            })
+          }
+        }
+      } else if (nodeType === 'component-context') {
+        if (Array.isArray(value.formulas)) {
+          for (const f of value.formulas) {
+            const split = matchAndSplitWildcard(f, pattern)
+            if (split) {
+              report({
+                path,
+                details: {
+                  nodeType: 'component-context',
+                  context: {
+                    before: getFormulaPathContext(path, files) + split.before,
+                    matched: split.matched,
+                    after: split.after,
+                  },
+                },
+              })
+              break // report once of the context is standard
+            }
+          }
+        }
+      }
+    },
+  }
+}

--- a/packages/search/src/rules/search/formulaSearchRule.ts
+++ b/packages/search/src/rules/search/formulaSearchRule.ts
@@ -1,0 +1,55 @@
+import type { SearchRule } from '../../types'
+import { matchAndSplitWildcard } from '../../util/matchWildcard'
+
+const FORMULA_REGEX = /^formula:\s*(.+)$/i
+
+export function shouldRun(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.startsWith('/') && trimmed.endsWith('/') && trimmed.length > 2) {
+    return false
+  }
+  return FORMULA_REGEX.test(trimmed)
+}
+
+export function createFormulaSearchRule({
+  query,
+}: {
+  query: string
+}): SearchRule {
+  const match = query.trim().match(FORMULA_REGEX)
+  const pattern = match ? match[1] : ''
+
+  return {
+    visit: (report, { path, value, nodeType }) => {
+      if (nodeType === 'component-formula') {
+        const formulaName = value.name || (path[path.length - 1] as string)
+        if (formulaName) {
+          const split = matchAndSplitWildcard(formulaName, pattern)
+          if (split) {
+            report({
+              path,
+              details: {
+                nodeType: 'component-formula',
+                context: split,
+              },
+            })
+          }
+        }
+      } else if (nodeType === 'project-formula') {
+        const formulaName = value.name || (path[path.length - 1] as string)
+        if (formulaName) {
+          const split = matchAndSplitWildcard(formulaName, pattern)
+          if (split) {
+            report({
+              path,
+              details: {
+                nodeType: 'project-formula',
+                context: split,
+              },
+            })
+          }
+        }
+      }
+    },
+  }
+}

--- a/packages/search/src/rules/search/queryLikeSearch.test.ts
+++ b/packages/search/src/rules/search/queryLikeSearch.test.ts
@@ -1,0 +1,565 @@
+import type { ProjectFiles } from '@nordcraft/ssr/dist/ssr.types'
+import { describe, expect, test } from 'bun:test'
+import { searchProject } from '../../searchProject'
+import {
+  createComponentRefSearchRule,
+  shouldRun as shouldRunComponentRef,
+} from './componentRefSearchRule'
+import {
+  createComponentSearchRule,
+  shouldRun as shouldRunComponent,
+} from './componentSearchRule'
+import {
+  createFormulaRefSearchRule,
+  shouldRun as shouldRunFormulaRef,
+} from './formulaRefSearchRule'
+import {
+  createFormulaSearchRule,
+  shouldRun as shouldRunFormula,
+} from './formulaSearchRule'
+import {
+  createWorkflowRefSearchRule,
+  shouldRun as shouldRunWorkflowRef,
+} from './workflowRefSearchRule'
+import {
+  createWorkflowSearchRule,
+  shouldRun as shouldRunWorkflow,
+} from './workflowSearchRule'
+
+describe('Query-like Search Predicates', () => {
+  test('component predicate', () => {
+    expect(shouldRunComponent('component:my-component')).toBe(true)
+    expect(shouldRunComponent('component:my-*')).toBe(true)
+    expect(shouldRunComponent('ref:component:my-component')).toBe(false)
+    expect(shouldRunComponent('/component:my-component/')).toBe(false)
+  })
+
+  test('component ref predicate', () => {
+    expect(shouldRunComponentRef('ref:component:my-component')).toBe(true)
+    expect(shouldRunComponentRef('ref:component:my-*')).toBe(true)
+    expect(shouldRunComponentRef('component:my-component')).toBe(false)
+    expect(shouldRunComponentRef('/ref:component my-component/')).toBe(false)
+  })
+
+  test('workflow predicate', () => {
+    expect(shouldRunWorkflow('workflow:my-workflow')).toBe(true)
+    expect(shouldRunWorkflow('workflow:my-*')).toBe(true)
+    expect(shouldRunWorkflow('ref:workflow:my-workflow')).toBe(false)
+    expect(shouldRunWorkflow('/workflow:my-workflow/')).toBe(false)
+  })
+
+  test('workflow ref predicate', () => {
+    expect(shouldRunWorkflowRef('ref:workflow:my-workflow')).toBe(true)
+    expect(shouldRunWorkflowRef('ref:workflow:my-*')).toBe(true)
+    expect(shouldRunWorkflowRef('/ref:workflow my-workflow/')).toBe(false)
+  })
+
+  test('formula predicate', () => {
+    expect(shouldRunFormula('formula:my-formula')).toBe(true)
+    expect(shouldRunFormula('formula:my-*')).toBe(true)
+    expect(shouldRunFormula('ref:formula:my-formula')).toBe(false)
+    expect(shouldRunFormula('/formula:my-formula/')).toBe(false)
+  })
+
+  test('formula ref predicate', () => {
+    expect(shouldRunFormulaRef('ref:formula:my-formula')).toBe(true)
+    expect(shouldRunFormulaRef('ref:formula:my-*')).toBe(true)
+    expect(shouldRunFormulaRef('/ref:formula my-formula/')).toBe(false)
+  })
+})
+
+describe('Component and Component Reference Search', () => {
+  const files: ProjectFiles = {
+    formulas: {},
+    components: {
+      'my-component': {
+        name: 'my-component',
+        nodes: {},
+        formulas: {},
+        apis: {},
+        attributes: {},
+        variables: {},
+        route: { path: [], query: {} },
+        workflows: {},
+      },
+      IconLink: {
+        name: 'IconLink',
+        nodes: {},
+        formulas: {},
+        apis: {},
+        attributes: {},
+        variables: {},
+        route: { path: [], query: {} },
+        workflows: {},
+      },
+      ElementIcon: {
+        name: 'ElementIcon',
+        nodes: {},
+        formulas: {},
+        apis: {},
+        attributes: {},
+        variables: {},
+        route: { path: [], query: {} },
+        workflows: {},
+      },
+      'other-component': {
+        name: 'other-component',
+        nodes: {
+          inst: {
+            type: 'component',
+            name: 'my-component',
+            attrs: {},
+            children: [],
+          },
+          parentDiv: {
+            type: 'element',
+            tag: 'div',
+            attrs: {},
+            children: ['typoLabel'],
+          },
+          typoLabel: {
+            type: 'component',
+            name: 'ui-typography',
+            attrs: {},
+            children: ['nestedInst'],
+          },
+          nestedInst: {
+            type: 'component',
+            name: 'my-component',
+            attrs: {},
+            children: [],
+          },
+        },
+        formulas: {},
+        apis: {},
+        attributes: {},
+        variables: {},
+        route: { path: [], query: {} },
+        workflows: {},
+      },
+    },
+  }
+
+  test('find component by name exactly', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createComponentSearchRule({ query: 'component:my-component' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual(['components', 'my-component'])
+    expect(results[0].details?.context).toEqual({
+      before: 'components > ',
+      matched: 'my-component',
+      after: '',
+    })
+  })
+
+  test('find component with wildcard', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createComponentSearchRule({ query: 'component:my-*' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual(['components', 'my-component'])
+  })
+
+  test('extract wildcard before and after contexts', () => {
+    // 1. "component:Icon*" finds "IconLink" -> "Link" should be in the after context
+    const resultsSuffix = Array.from(
+      searchProject({
+        files,
+        rules: [createComponentSearchRule({ query: 'component:Icon*' })],
+      }),
+    )
+    // Suffix wildcard: IconLink matches. ElementIcon does not match because it doesn't start with Icon.
+    expect(resultsSuffix).toHaveLength(1)
+    expect(resultsSuffix[0].path).toEqual(['components', 'IconLink'])
+    expect(resultsSuffix[0].details?.context).toEqual({
+      before: 'components > ',
+      matched: 'Icon',
+      after: 'Link',
+    })
+
+    // 2. "component:*Icon*" finds "ElementIcon" -> "Element" should be part of the before
+    const resultsBoth = Array.from(
+      searchProject({
+        files,
+        rules: [createComponentSearchRule({ query: 'component:*Icon*' })],
+      }),
+    )
+    expect(resultsBoth).toHaveLength(2)
+    const elementIconResult = resultsBoth.find(
+      (r) => r.path[1] === 'ElementIcon',
+    )
+    expect(elementIconResult).toBeDefined()
+    expect(elementIconResult?.details?.context).toEqual({
+      before: 'components > Element',
+      matched: 'Icon',
+      after: '',
+    })
+
+    const iconLinkResult = resultsBoth.find((r) => r.path[1] === 'IconLink')
+    expect(iconLinkResult).toBeDefined()
+    expect(iconLinkResult?.details?.context).toEqual({
+      before: 'components > ',
+      matched: 'Icon',
+      after: 'Link',
+    })
+  })
+
+  test('find component references exactly', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createComponentRefSearchRule({ query: 'ref:component:my-component' }),
+        ],
+      }),
+    )
+    expect(results).toHaveLength(2)
+
+    // First result: inst (no ancestors)
+    const res1 = results.find((r) => r.path[3] === 'inst')
+    expect(res1).toBeDefined()
+    expect(res1?.path).toEqual([
+      'components',
+      'other-component',
+      'nodes',
+      'inst',
+    ])
+    expect(res1?.details?.context).toEqual({
+      before: '',
+      matched: 'my-component',
+      after: '',
+    })
+
+    // Second result: nestedInst (with ancestors: parentDiv -> typoLabel)
+    const res2 = results.find((r) => r.path[3] === 'nestedInst')
+    expect(res2).toBeDefined()
+    expect(res2?.path).toEqual([
+      'components',
+      'other-component',
+      'nodes',
+      'nestedInst',
+    ])
+    expect(res2?.details?.context).toEqual({
+      before: 'div > ui-typography > ',
+      matched: 'my-component',
+      after: '',
+    })
+  })
+})
+
+describe('Workflow and Workflow Reference Search', () => {
+  const files: ProjectFiles = {
+    formulas: {},
+    components: {
+      'my-component': {
+        name: 'my-component',
+        nodes: {},
+        formulas: {},
+        apis: {},
+        attributes: {},
+        variables: {},
+        route: { path: [], query: {} },
+        workflows: {
+          'save-user': {
+            name: 'save-user',
+            actions: [
+              {
+                id: 'trig',
+                type: 'TriggerWorkflow',
+                workflow: 'fetch-data',
+              },
+            ],
+          },
+          'fetch-data': {
+            name: 'fetch-data',
+            actions: [],
+          },
+        },
+        contexts: {
+          'some-context': {
+            formulas: [],
+            workflows: ['special-wf'],
+          },
+        },
+      },
+    },
+  }
+
+  test('find workflow by name', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createWorkflowSearchRule({ query: 'workflow:save-user' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'my-component',
+      'workflows',
+      'save-user',
+    ])
+  })
+
+  test('find workflow with wildcard', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [createWorkflowSearchRule({ query: 'workflow:*-user' })],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'my-component',
+      'workflows',
+      'save-user',
+    ])
+  })
+
+  test('find workflow references', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createWorkflowRefSearchRule({ query: 'ref:workflow:fetch-data' }),
+        ],
+      }),
+    )
+    // One match inside actions of save-user
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'my-component',
+      'workflows',
+      'save-user',
+      'actions',
+      '0',
+    ])
+    expect(results[0].details?.context).toEqual({
+      before: 'workflows > save-user > ',
+      matched: 'fetch-data',
+      after: '',
+    })
+  })
+
+  test('find workflow references inside context definitions', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createWorkflowRefSearchRule({ query: 'ref:workflow:special-wf' }),
+        ],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'my-component',
+      'contexts',
+      'some-context',
+    ])
+    expect(results[0].details?.context).toEqual({
+      before: 'contexts > some-context > ',
+      matched: 'special-wf',
+      after: '',
+    })
+  })
+})
+
+describe('Formula and Formula Reference Search', () => {
+  const files: ProjectFiles = {
+    formulas: {
+      'global-formula': {
+        name: 'global-formula',
+        formula: {
+          type: 'function',
+          name: 'some-func',
+          arguments: [],
+        },
+      },
+    },
+    components: {
+      'my-component': {
+        name: 'my-component',
+        nodes: {
+          divNode: {
+            type: 'element',
+            tag: 'div',
+            attrs: {
+              title: {
+                type: 'apply',
+                name: 'local-formula',
+                arguments: [],
+              },
+              subtitle: {
+                type: 'function',
+                name: 'global-formula',
+                arguments: [],
+              },
+              contexted: {
+                type: 'path',
+                path: ['Contexts', 'context-comp', 'shared-formula'],
+              },
+            },
+            children: [],
+          },
+        },
+        formulas: {
+          'local-formula': {
+            name: 'local-formula',
+            formula: {
+              type: 'value',
+              value: 123,
+            },
+          },
+        },
+        apis: {},
+        attributes: {},
+        variables: {},
+        route: { path: [], query: {} },
+        workflows: {},
+        contexts: {
+          'context-comp': {
+            formulas: ['shared-formula'],
+            workflows: [],
+          },
+        },
+      },
+    },
+  }
+
+  test('find local and global formulas', () => {
+    const resultsLocal = Array.from(
+      searchProject({
+        files,
+        rules: [createFormulaSearchRule({ query: 'formula:local-formula' })],
+      }),
+    )
+    expect(resultsLocal).toHaveLength(1)
+    expect(resultsLocal[0].path).toEqual([
+      'components',
+      'my-component',
+      'formulas',
+      'local-formula',
+    ])
+    expect(resultsLocal[0].details?.context).toEqual({
+      before: 'formulas > ',
+      matched: 'local-formula',
+      after: '',
+    })
+
+    const resultsGlobal = Array.from(
+      searchProject({
+        files,
+        rules: [createFormulaSearchRule({ query: 'formula:global-formula' })],
+      }),
+    )
+    expect(resultsGlobal).toHaveLength(1)
+    expect(resultsGlobal[0].path).toEqual(['formulas', 'global-formula'])
+    expect(resultsGlobal[0].details?.context).toEqual({
+      before: 'formulas > ',
+      matched: 'global-formula',
+      after: '',
+    })
+  })
+
+  test('find formula references (local apply)', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createFormulaRefSearchRule({ query: 'ref:formula:local-formula' }),
+        ],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'my-component',
+      'nodes',
+      'divNode',
+      'attrs',
+      'title',
+    ])
+    expect(results[0].details?.context).toEqual({
+      before: 'div > title > ',
+      matched: 'local-formula',
+      after: '',
+    })
+  })
+
+  test('find formula references (global function)', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createFormulaRefSearchRule({ query: 'ref:formula:global-formula' }),
+        ],
+      }),
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toEqual([
+      'components',
+      'my-component',
+      'nodes',
+      'divNode',
+      'attrs',
+      'subtitle',
+    ])
+    expect(results[0].details?.context).toEqual({
+      before: 'div > subtitle > ',
+      matched: 'global-formula',
+      after: '',
+    })
+  })
+
+  test('find formula references (context path)', () => {
+    const results = Array.from(
+      searchProject({
+        files,
+        rules: [
+          createFormulaRefSearchRule({ query: 'ref:formula:shared-formula' }),
+        ],
+      }),
+    )
+    // Matches the path formula on the contexted attribute, AND the component-context registration node!
+    expect(results).toHaveLength(2)
+    const paths = results.map((r) => r.path)
+    expect(paths).toContainEqual([
+      'components',
+      'my-component',
+      'nodes',
+      'divNode',
+      'attrs',
+      'contexted',
+    ])
+    expect(paths).toContainEqual([
+      'components',
+      'my-component',
+      'contexts',
+      'context-comp',
+    ])
+
+    const resWithNodes = results.find((r) => r.path[2] === 'nodes')
+    expect(resWithNodes?.details?.context).toEqual({
+      before: 'div > contexted > ',
+      matched: 'shared-formula',
+      after: '',
+    })
+
+    const resWithContexts = results.find((r) => r.path[2] === 'contexts')
+    expect(resWithContexts?.details?.context).toEqual({
+      before: 'contexts > context-comp > ',
+      matched: 'shared-formula',
+      after: '',
+    })
+  })
+})

--- a/packages/search/src/rules/search/searchRegistry.ts
+++ b/packages/search/src/rules/search/searchRegistry.ts
@@ -1,0 +1,47 @@
+import type { SearchRule } from '../../types'
+import * as componentRefSearchRule from './componentRefSearchRule'
+import * as componentSearchRule from './componentSearchRule'
+import * as elementSearchRule from './elementSearchRule'
+import * as formulaRefSearchRule from './formulaRefSearchRule'
+import * as formulaSearchRule from './formulaSearchRule'
+import * as workflowRefSearchRule from './workflowRefSearchRule'
+import * as workflowSearchRule from './workflowSearchRule'
+
+export interface QuerySearchRule {
+  shouldRun: (query: string) => boolean
+  create: (query: string) => SearchRule
+}
+
+export const querySearchRules: QuerySearchRule[] = [
+  {
+    shouldRun: componentSearchRule.shouldRun,
+    create: (query) => componentSearchRule.createComponentSearchRule({ query }),
+  },
+  {
+    shouldRun: componentRefSearchRule.shouldRun,
+    create: (query) =>
+      componentRefSearchRule.createComponentRefSearchRule({ query }),
+  },
+  {
+    shouldRun: workflowSearchRule.shouldRun,
+    create: (query) => workflowSearchRule.createWorkflowSearchRule({ query }),
+  },
+  {
+    shouldRun: workflowRefSearchRule.shouldRun,
+    create: (query) =>
+      workflowRefSearchRule.createWorkflowRefSearchRule({ query }),
+  },
+  {
+    shouldRun: formulaSearchRule.shouldRun,
+    create: (query) => formulaSearchRule.createFormulaSearchRule({ query }),
+  },
+  {
+    shouldRun: formulaRefSearchRule.shouldRun,
+    create: (query) =>
+      formulaRefSearchRule.createFormulaRefSearchRule({ query }),
+  },
+  {
+    shouldRun: elementSearchRule.shouldRun,
+    create: (query) => elementSearchRule.createElementSearchRule({ query }),
+  },
+]

--- a/packages/search/src/rules/search/workflowRefSearchRule.ts
+++ b/packages/search/src/rules/search/workflowRefSearchRule.ts
@@ -1,0 +1,72 @@
+import type { SearchRule } from '../../types'
+import { matchAndSplitWildcard } from '../../util/matchWildcard'
+
+const WORKFLOW_REF_REGEX = /^ref:workflow:\s*(.+)$/i
+
+export function shouldRun(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.startsWith('/') && trimmed.endsWith('/') && trimmed.length > 2) {
+    return false
+  }
+  return WORKFLOW_REF_REGEX.test(trimmed)
+}
+
+export function createWorkflowRefSearchRule({
+  query,
+}: {
+  query: string
+}): SearchRule {
+  const match = query.trim().match(WORKFLOW_REF_REGEX)
+  const pattern = match ? match[1] : ''
+
+  return {
+    visit: (report, { path, value, nodeType }) => {
+      if (nodeType === 'action-model') {
+        if (value.type === 'TriggerWorkflow' && value.workflow) {
+          const split = matchAndSplitWildcard(value.workflow, pattern)
+          if (split) {
+            const workflowName = path[3] as string
+            const beforeContext = workflowName
+              ? `workflows > ${workflowName} > `
+              : 'workflows > '
+            report({
+              path,
+              details: {
+                nodeType: 'action-model',
+                context: {
+                  before: beforeContext + split.before,
+                  matched: split.matched,
+                  after: split.after,
+                },
+              },
+            })
+          }
+        }
+      } else if (nodeType === 'component-context') {
+        if (Array.isArray(value.workflows)) {
+          for (const w of value.workflows) {
+            const split = matchAndSplitWildcard(w, pattern)
+            if (split) {
+              const contextName = path[3] as string
+              const beforeContext = contextName
+                ? `contexts > ${contextName} > `
+                : 'contexts > '
+              report({
+                path,
+                details: {
+                  nodeType: 'component-context',
+                  context: {
+                    before: beforeContext + split.before,
+                    matched: split.matched,
+                    after: split.after,
+                  },
+                },
+              })
+              break // inside find context, reporting once of the container is standard
+            }
+          }
+        }
+      }
+    },
+  }
+}

--- a/packages/search/src/rules/search/workflowSearchRule.ts
+++ b/packages/search/src/rules/search/workflowSearchRule.ts
@@ -1,0 +1,43 @@
+import type { SearchRule } from '../../types'
+import { matchAndSplitWildcard } from '../../util/matchWildcard'
+
+const WORKFLOW_REGEX = /^workflow:\s*(.+)$/i
+
+export function shouldRun(query: string): boolean {
+  const trimmed = query.trim()
+  if (trimmed.startsWith('/') && trimmed.endsWith('/') && trimmed.length > 2) {
+    return false
+  }
+  return WORKFLOW_REGEX.test(trimmed)
+}
+
+export function createWorkflowSearchRule({
+  query,
+}: {
+  query: string
+}): SearchRule {
+  const match = query.trim().match(WORKFLOW_REGEX)
+  const pattern = match ? match[1] : ''
+
+  return {
+    visit: (report, { path, value, nodeType }) => {
+      if (nodeType !== 'component-workflow') {
+        return
+      }
+
+      const workflowName = value.name ?? (path[path.length - 1] as string)
+      if (workflowName) {
+        const split = matchAndSplitWildcard(workflowName, pattern)
+        if (split) {
+          report({
+            path,
+            details: {
+              nodeType: 'component-workflow',
+              context: split,
+            },
+          })
+        }
+      }
+    },
+  }
+}

--- a/packages/search/src/util/matchWildcard.test.ts
+++ b/packages/search/src/util/matchWildcard.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'bun:test'
+import { matchAndSplitWildcard, matchWildcard } from './matchWildcard'
+
+describe('matchWildcard', () => {
+  test('it should match exact strings case-insensitively', () => {
+    expect(matchWildcard('my-component', 'my-component')).toBe(true)
+    expect(matchWildcard('My-Component', 'my-component')).toBe(true)
+    expect(matchWildcard('my-component', 'My-Component')).toBe(true)
+    expect(matchWildcard('other-component', 'my-component')).toBe(false)
+  })
+
+  test('it should match wildcards at the end', () => {
+    expect(matchWildcard('my-component', 'my-*')).toBe(true)
+    expect(matchWildcard('my-cool-widget', 'my-*')).toBe(true)
+    expect(matchWildcard('my-', 'my-*')).toBe(true)
+    expect(matchWildcard('other-my-component', 'my-*')).toBe(false)
+  })
+
+  test('it should match wildcards at the beginning', () => {
+    expect(matchWildcard('my-component', '*-component')).toBe(true)
+    expect(matchWildcard('cool-component', '*-component')).toBe(true)
+    expect(matchWildcard('-component', '*-component')).toBe(true)
+    expect(matchWildcard('my-component-other', '*-component')).toBe(false)
+  })
+
+  test('it should match wildcards in the middle', () => {
+    expect(matchWildcard('my-cool-component', 'my-*-component')).toBe(true)
+    expect(matchWildcard('my-awesome-widget-component', 'my-*-component')).toBe(
+      true,
+    )
+    expect(matchWildcard('my--component', 'my-*-component')).toBe(true)
+    expect(matchWildcard('my-component', 'my-*-component')).toBe(false)
+  })
+
+  test('it should escape regex special characters', () => {
+    expect(matchWildcard('my.component', 'my.component')).toBe(true)
+    expect(matchWildcard('my-component', 'my.component')).toBe(false)
+    expect(matchWildcard('my[component]', 'my[component]')).toBe(true)
+  })
+})
+
+describe('matchAndSplitWildcard', () => {
+  test('ends with wildcard', () => {
+    expect(matchAndSplitWildcard('IconLink', 'Icon*')).toEqual({
+      before: '',
+      matched: 'Icon',
+      after: 'Link',
+    })
+  })
+
+  test('starts and ends with wildcard', () => {
+    expect(matchAndSplitWildcard('ElementIcon', '*Icon*')).toEqual({
+      before: 'Element',
+      matched: 'Icon',
+      after: '',
+    })
+
+    expect(matchAndSplitWildcard('ElementIconLink', '*Icon*')).toEqual({
+      before: 'Element',
+      matched: 'Icon',
+      after: 'Link',
+    })
+  })
+
+  test('starts with wildcard only', () => {
+    expect(matchAndSplitWildcard('ElementIcon', '*Icon')).toEqual({
+      before: 'Element',
+      matched: 'Icon',
+      after: '',
+    })
+  })
+
+  test('no wildcard exactly match', () => {
+    expect(matchAndSplitWildcard('Icon', 'Icon')).toEqual({
+      before: '',
+      matched: 'Icon',
+      after: '',
+    })
+  })
+
+  test('no match returns null', () => {
+    expect(matchAndSplitWildcard('ElementIcon', 'Button*')).toBeNull()
+  })
+})

--- a/packages/search/src/util/matchWildcard.ts
+++ b/packages/search/src/util/matchWildcard.ts
@@ -1,0 +1,97 @@
+/**
+ * Matches a string against a wildcard pattern (case-insensitive).
+ * Standard wildcard `*` matches any character sequence.
+ */
+export function matchWildcard(str: string, pattern: string): boolean {
+  const regexStr =
+    '^' +
+    pattern.replace(/[-\/\\^$*+?.()|[\]{}]/g, (ch) =>
+      ch === '*' ? '.*' : '\\' + ch,
+    ) +
+    '$'
+  const rx = new RegExp(regexStr, 'i')
+  return rx.test(str)
+}
+
+export interface SplitResult {
+  before: string
+  matched: string
+  after: string
+}
+
+/**
+ * Matches a string against a wildcard pattern (case-insensitive) and splits
+ * the string into before, matched, and after contexts based on wildcard positions.
+ */
+export function matchAndSplitWildcard(
+  str: string,
+  pattern: string,
+): SplitResult | null {
+  const trimmedPattern = pattern.trim()
+
+  if (trimmedPattern === '') {
+    if (str === '') {
+      return { before: '', matched: '', after: '' }
+    }
+    return null
+  }
+
+  // If pattern is only wildcards (e.g. *, **, etc)
+  if (/^\*+$/.test(trimmedPattern)) {
+    return { before: '', matched: str, after: '' }
+  }
+
+  // Detect leading and trailing wildcards
+  const hasLeading = trimmedPattern.startsWith('*')
+  const hasTrailing = trimmedPattern.endsWith('*')
+
+  // Core pattern: strip leading and trailing stars
+  let core = trimmedPattern
+  if (hasLeading) {
+    core = core.slice(1)
+  }
+  if (hasTrailing) {
+    core = core.slice(0, -1)
+  }
+
+  // Escape regex special characters in core, but map '*' to '.*'
+  const coreRegexStr = core.replace(/[-\/\\^$*+?.()|[\]{}]/g, (ch) =>
+    ch === '*' ? '.*' : '\\' + ch,
+  )
+
+  // Build the full regexp with captures
+  // capture 1 (if leading): anything before the core pattern starts (non-greedy)
+  // capture 2: the core pattern itself
+  // capture 3 (if trailing): anything after the core pattern ends (greedy)
+  const prefixPart = hasLeading ? '^(.*?)' : '^'
+  const suffixPart = hasTrailing ? '(.*)$' : '$'
+  const fullRegex = new RegExp(
+    `${prefixPart}(${coreRegexStr})${suffixPart}`,
+    'i',
+  )
+
+  const match = str.match(fullRegex)
+  if (!match) {
+    return null
+  }
+
+  let before = ''
+  let matched = ''
+  let after = ''
+
+  if (hasLeading && hasTrailing) {
+    before = match[1]
+    matched = match[2]
+    after = match[3]
+  } else if (hasLeading) {
+    before = match[1]
+    matched = match[2]
+  } else if (hasTrailing) {
+    matched = match[1]
+    after = match[2]
+  } else {
+    matched = match[1]
+  }
+
+  return { before, matched, after }
+}

--- a/packages/search/src/util/searchContext.test.ts
+++ b/packages/search/src/util/searchContext.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'bun:test'
+import { getFormulaPathContext, getNodeAncestorsContext } from './searchContext'
+
+describe('searchContext', () => {
+  describe('getNodeAncestorsContext', () => {
+    test('should return an empty array if nodes or targetNodeId is falsy', () => {
+      expect(getNodeAncestorsContext(undefined, 'node-1')).toEqual([])
+      expect(getNodeAncestorsContext({}, '')).toEqual([])
+    })
+
+    test('should return empty array for root node with no parent', () => {
+      const nodes = {
+        root: {
+          type: 'element',
+          tag: 'div',
+          children: [],
+        },
+      }
+      expect(getNodeAncestorsContext(nodes, 'root')).toEqual([])
+    })
+
+    test('should return array of ancestors for single level nesting', () => {
+      const nodes = {
+        parent: {
+          type: 'element',
+          tag: 'div',
+          children: ['child'],
+        },
+        child: {
+          type: 'element',
+          tag: 'span',
+          children: [],
+        },
+      }
+      expect(getNodeAncestorsContext(nodes, 'child')).toEqual([
+        { id: 'parent', tag: 'div' },
+      ])
+    })
+
+    test('should return multiple ancestors with proper order (topmost first)', () => {
+      const nodes = {
+        gparent: {
+          type: 'element',
+          tag: 'section',
+          children: ['parent'],
+        },
+        parent: {
+          type: 'component',
+          name: 'ui-card',
+          children: ['child'],
+        },
+        child: {
+          type: 'element',
+          tag: 'button',
+          children: [],
+        },
+      }
+      expect(getNodeAncestorsContext(nodes, 'child')).toEqual([
+        { id: 'gparent', tag: 'section' },
+        { id: 'parent', tag: 'ui-card' },
+      ])
+    })
+
+    test('should fallback to name parameter for component or nextId if tag/name is missing', () => {
+      const nodes = {
+        parentComponent: {
+          type: 'component',
+          name: 'custom-element',
+          children: ['child'],
+        },
+        fallbackParent: {
+          type: 'unknown',
+          children: ['child2'],
+        },
+        child: {
+          tag: 'div',
+          children: [],
+        },
+        child2: {
+          tag: 'span',
+          children: [],
+        },
+      }
+      expect(getNodeAncestorsContext(nodes, 'child')).toEqual([
+        { id: 'parentComponent', tag: 'custom-element' },
+      ])
+      expect(getNodeAncestorsContext(nodes, 'child2')).toEqual([
+        { id: 'fallbackParent', tag: 'fallbackParent' },
+      ])
+    })
+
+    test('should stop when limit is exceeded or there is a loop', () => {
+      const nodes = {
+        nodeA: {
+          type: 'element',
+          tag: 'div',
+          children: ['nodeB'],
+        },
+        nodeB: {
+          type: 'element',
+          tag: 'span',
+          children: ['nodeA'],
+        },
+      }
+      // Infinite loop nodeA -> child nodeB -> child nodeA. Limit will kick in and terminate.
+      const ancestors = getNodeAncestorsContext(nodes, 'nodeA')
+      expect(ancestors.length).toBeLessThan(102)
+      expect(ancestors[0].tag).toBeDefined()
+    })
+  })
+
+  describe('getFormulaPathContext', () => {
+    const files = {
+      components: {
+        'comp-1': {
+          nodes: {
+            root: {
+              type: 'element',
+              tag: 'div',
+              children: ['nested'],
+            },
+            nested: {
+              type: 'element',
+              tag: 'span',
+              children: [],
+            },
+          },
+        },
+      },
+    }
+
+    test('should return empty string for unhandled paths', () => {
+      expect(getFormulaPathContext(['random', 'path'], files)).toBe('')
+    })
+
+    test('should compute formula context for nodes under a components basic path', () => {
+      const path = ['components', 'comp-1', 'nodes', 'nested']
+      expect(getFormulaPathContext(path, files)).toBe('div > span > ')
+    })
+
+    test('should compute formula context for nested node attributes', () => {
+      const path = ['components', 'comp-1', 'nodes', 'nested', 'attrs', 'title']
+      expect(getFormulaPathContext(path, files)).toBe('div > span > title > ')
+    })
+
+    test('should compute formula context for nested node styles', () => {
+      const path = ['components', 'comp-1', 'nodes', 'nested', 'style', 'color']
+      expect(getFormulaPathContext(path, files)).toBe(
+        'div > span > style > color > ',
+      )
+    })
+
+    test('should compute formula context for nested node variants', () => {
+      const path = [
+        'components',
+        'comp-1',
+        'nodes',
+        'nested',
+        'variants',
+        0,
+        'style',
+        'margin',
+      ]
+      expect(getFormulaPathContext(path, files)).toBe(
+        'div > span > variant > margin > ',
+      )
+    })
+
+    test('should compute formula context for formulas in component', () => {
+      const path = ['components', 'comp-1', 'formulas', 'my-math']
+      expect(getFormulaPathContext(path, files)).toBe('formulas > my-math > ')
+    })
+
+    test('should compute formula context for workflows in component', () => {
+      const path = ['components', 'comp-1', 'workflows', 'my-wf']
+      expect(getFormulaPathContext(path, files)).toBe('workflows > my-wf > ')
+    })
+
+    test('should compute formula context for contexts in component', () => {
+      const path = ['components', 'comp-1', 'contexts', 'my-context']
+      expect(getFormulaPathContext(path, files)).toBe(
+        'contexts > my-context > ',
+      )
+    })
+
+    test('should compute formula context for variables in component', () => {
+      const path = ['components', 'comp-1', 'variables', 'my-var']
+      expect(getFormulaPathContext(path, files)).toBe('variables > my-var > ')
+    })
+
+    test('should compute formula context for apis in component', () => {
+      const path = ['components', 'comp-1', 'apis', 'my-api']
+      expect(getFormulaPathContext(path, files)).toBe('apis > my-api > ')
+    })
+
+    test('should compute formula context for global formulas', () => {
+      const path = ['formulas', 'global-calc']
+      expect(getFormulaPathContext(path, files)).toBe(
+        'formulas > global-calc > ',
+      )
+    })
+  })
+})

--- a/packages/search/src/util/searchContext.ts
+++ b/packages/search/src/util/searchContext.ts
@@ -1,0 +1,115 @@
+import type { NodeModel } from '@nordcraft/core/dist/component/component.types'
+import type { Nullable } from '@nordcraft/core/dist/types'
+
+/**
+ * Traverses upwards to build an ancestor array
+ * for a node inside a component's flat node map.
+ */
+export function getNodeAncestorsContext(
+  nodes: Nullable<Partial<Record<string, NodeModel | null>>>,
+  targetNodeId: string,
+): NodeModel[] {
+  if (!nodes || !targetNodeId) {
+    return []
+  }
+  const ancestors: NodeModel[] = []
+  let currentId = targetNodeId
+  let limit = 100
+  while (currentId && limit-- > 0) {
+    const parentId = currentId
+    const parentEntry = Object.entries(nodes as any).find(
+      ([_, n]) =>
+        n &&
+        Array.isArray((n as any).children) &&
+        (n as any).children.includes(parentId),
+    )
+    if (parentEntry) {
+      const [nextId, parentNode] = parentEntry as [string, any]
+      ancestors.unshift(parentNode)
+      currentId = nextId
+    } else {
+      break
+    }
+  }
+  return ancestors
+}
+
+/**
+ * Builds context for formulas or generic locations based on the node path.
+ */
+export function getFormulaPathContext(
+  path: (string | number)[],
+  files: any,
+): string {
+  // If the path is under a component
+  if (path[0] === 'components' && typeof path[1] === 'string') {
+    const componentName = path[1]
+    const componentObj = files?.components?.[componentName]
+    const nodes = componentObj?.nodes
+
+    // Under nodes (elements/subcomponents)
+    if (path[2] === 'nodes' && typeof path[3] === 'string') {
+      const nodeId = path[3]
+      const ancestors = getNodeAncestorsContext(nodes, nodeId)
+      const mappedAncestors = ancestors
+        .map((a) =>
+          a.type === 'element'
+            ? a.tag
+            : a.type === 'component'
+              ? a.name
+              : '<unknown>',
+        )
+        .join(' > ')
+      const ancestorsStr = mappedAncestors ? `${mappedAncestors} > ` : ''
+      const node = nodes?.[nodeId]
+      const nodeName = node
+        ? node.type === 'element'
+          ? node.tag
+          : node.name
+        : nodeId
+
+      if (path[4] === 'attrs' && typeof path[5] === 'string') {
+        return `${ancestorsStr}${nodeName} > ${path[5]} > `
+      }
+      if (path[4] === 'style' && typeof path[5] === 'string') {
+        return `${ancestorsStr}${nodeName} > style > ${path[5]} > `
+      }
+      if (path[4] === 'variants' && typeof path[7] === 'string') {
+        return `${ancestorsStr}${nodeName} > variant > ${path[7]} > `
+      }
+      return `${ancestorsStr}${nodeName} > `
+    }
+
+    // Under formulas
+    if (path[2] === 'formulas' && typeof path[3] === 'string') {
+      return `formulas > ${path[3]} > `
+    }
+
+    // Under workflows
+    if (path[2] === 'workflows' && typeof path[3] === 'string') {
+      return `workflows > ${path[3]} > `
+    }
+
+    // Under contexts
+    if (path[2] === 'contexts' && typeof path[3] === 'string') {
+      return `contexts > ${path[3]} > `
+    }
+
+    // Under variables
+    if (path[2] === 'variables' && typeof path[3] === 'string') {
+      return `variables > ${path[3]} > `
+    }
+
+    // Under apis
+    if (path[2] === 'apis' && typeof path[3] === 'string') {
+      return `apis > ${path[3]} > `
+    }
+  }
+
+  // If path is root formulas
+  if (path[0] === 'formulas' && typeof path[1] === 'string') {
+    return `formulas > ${path[1]} > `
+  }
+
+  return ''
+}


### PR DESCRIPTION
Our search-worker already supports free-text search using regex in all file and nodes types. This PR introduces the ability to more precisely search for certain types, like:

`component:my-component` to find an exact component
`ref:component:my-component` to find all references to a component
`component:ui-*` to find all components starting with "ui-"
`node:img[src="*toddle*"]` find all img nodes with a src attribute containing "toddle"

Many node types are still missing, but this server as a POC draft that we can work on. The entire search-feature is still feature-flagged, so it is safe to release changes in batches instead of in one go.